### PR TITLE
BLUEBUTTON-1218 Migration DNS Zone

### DIFF
--- a/ops/terraform/env/prod-sbx/migration/backend.tf
+++ b/ops/terraform/env/prod-sbx/migration/backend.tf
@@ -1,0 +1,10 @@
+terraform {
+  backend "s3" {
+    bucket         = "bfd-tf-state"
+    key            = "prod-sbx/migration/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "bfd-tf-table"
+    encrypt        = "1"
+    kms_key_id     = "alias/bfd-tf-state"
+  }
+}

--- a/ops/terraform/env/prod-sbx/migration/main.tf
+++ b/ops/terraform/env/prod-sbx/migration/main.tf
@@ -11,8 +11,8 @@ module "migration" {
   source = "../../../modules/migration"
 
   env_config = {
-    env               = "test"
-    tags              = {application="bfd", business="oeda", stack="test", Environment="test"}
+    env               = "prod-sbx"
+    tags              = {application="bfd", business="oeda", stack="prod-sbx", Environment="prod-sbx"}
   }  
 
   bb      = 0

--- a/ops/terraform/env/prod/migration/backend.tf
+++ b/ops/terraform/env/prod/migration/backend.tf
@@ -1,0 +1,10 @@
+terraform {
+  backend "s3" {
+    bucket         = "bfd-tf-state"
+    key            = "prod/migration/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "bfd-tf-table"
+    encrypt        = "1"
+    kms_key_id     = "alias/bfd-tf-state"
+  }
+}

--- a/ops/terraform/env/prod/migration/main.tf
+++ b/ops/terraform/env/prod/migration/main.tf
@@ -11,8 +11,8 @@ module "migration" {
   source = "../../../modules/migration"
 
   env_config = {
-    env               = "test"
-    tags              = {application="bfd", business="oeda", stack="test", Environment="test"}
+    env               = "prod"
+    tags              = {application="bfd", business="oeda", stack="prod", Environment="prod"}
   }  
 
   bb      = 0

--- a/ops/terraform/env/test/migration/backend.tf
+++ b/ops/terraform/env/test/migration/backend.tf
@@ -1,0 +1,10 @@
+terraform {
+  backend "s3" {
+    bucket         = "bfd-tf-state"
+    key            = "test/migration/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "bfd-tf-table"
+    encrypt        = "1"
+    kms_key_id     = "alias/bfd-tf-state"
+  }
+}

--- a/ops/terraform/env/test/migration/main.tf
+++ b/ops/terraform/env/test/migration/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = "~> 0.12"
+}
+
+provider "aws" {
+  version = "~> 2.25"
+  region = "us-east-1"
+}
+
+module "migration" {
+  source = "../../../modules/migration"
+
+  env_config = {
+    env               = "test"
+    tags              = {application="bfd", business="oeda", stack="test", Environment="test"}
+  }  
+
+  bb      = 0
+  bcda    = 0
+  dpc     = 0
+  mct     = 0
+}

--- a/ops/terraform/modules/migration/main.tf
+++ b/ops/terraform/modules/migration/main.tf
@@ -1,0 +1,102 @@
+#
+# Create the DNS records for migration between HealthApt and CCS
+#
+# This records will be public, but they will contain private IPs
+#
+locals {
+  env           = var.env_config.env
+  env_config    = {env=local.env, tags=var.env_config.tags, vpc_id=data.aws_vpc.main.id}
+  parent        = "bfdcloud.net"
+  name          = "${local.env}.${local.parent}"
+
+  # Health Apt ELB information
+  health_apt    = { 
+    prod        = {dns="internal-pdcw10lb01-1951212262.us-east-1.elb.amazonaws.com", zone_id="Z35SXDOTRQ7X7K"},
+    prod-sbx    = {dns="internal-dpcwelb01-2074070868.us-east-1.elb.amazonaws.com", zone_id="Z35SXDOTRQ7X7K"},
+    test        = {dns="internal-tsbb10lb01-758855236.us-east-1.elb.amazonaws.com", zone_id="Z35SXDOTRQ7X7K"}
+  }
+}
+
+# VPC
+#
+data "aws_vpc" "main" {
+  filter {
+    name = "tag:Name"
+    values = ["bfd-${local.env}-vpc"]
+  }
+}
+
+# FHIR ELB
+#
+data "aws_lb" "fhir" {
+  name = "bfd-${local.env}-fhir"
+}
+
+# Parent zone
+#
+data "aws_route53_zone" "parent" {
+  name = local.parent
+}
+
+# DNS zone and records
+#
+module "main" {
+  source      = "../resources/dns"
+  name        = local.env
+  parent      = {name=data.aws_route53_zone.parent.name, zone_id=data.aws_route53_zone.parent.zone_id}
+  public      = true
+  env_config  = local.env_config
+
+  # The apex record just goes the FHIR server
+  apex_record = {
+    alias         = data.aws_lb.fhir.dns_name 
+    zone_id       = data.aws_lb.fhir.zone_id
+    health_check  = false
+  }
+
+  # The health-apt record goes to the health apt service
+  a_records   = [{
+    name          = "health-apt"
+    alias         = local.health_apt[local.env].dns
+    zone_id       = local.health_apt[local.env].zone_id
+    health_check  = false
+  }]
+
+  # Create one pair of records per partner
+  weighted_pairs = [
+    { 
+      name        = "bb", 
+      weight      = var.bb
+      a_record    = local.name
+      a_set       = "ccs"
+      b_record    = "health-apt.${local.name}"
+      b_set       = "health-apt"
+    },
+    { 
+      name        = "bcda", 
+      weight      = var.bcda
+      a_record    = local.name
+      a_set       = "ccs"
+      b_record    = "health-apt.${local.name}"
+      b_set       = "health-apt"
+    },
+    { 
+      name        = "dpc", 
+      weight      = var.dpc
+      a_record    = local.name
+      a_set       = "ccs"
+      b_record    = "health-apt.${local.name}"
+      b_set       = "health-apt"
+    },
+    { 
+      name        = "mct", 
+      weight      = var.mct
+      a_record    = local.name
+      a_set       = "ccs"
+      b_record    = "health-apt.${local.name}"
+      b_set       = "health-apt"
+    },
+  ]
+}
+
+

--- a/ops/terraform/modules/migration/variables.tf
+++ b/ops/terraform/modules/migration/variables.tf
@@ -1,0 +1,26 @@
+variable "env_config" {
+  description = "All high-level info for the whole vpc"
+  type        = object({env=string, tags=map(string)})
+}
+
+variable "bb" {
+  description = "Blue Button API percentage (0-100) served by the CCS environment"
+  type        = number
+}
+
+variable "bcda" {
+  description = "BCDA percentage (0-100) served by the CCS environment"
+  type        = number
+}
+
+variable "dpc" {
+  description = "DPC percentage (0-100) served by the CCS environment"
+  type        = number
+}
+
+variable "mct" {
+  description = "MCT percentage (0-100) served by the CCS environment"
+  type        = number
+}
+
+

--- a/ops/terraform/modules/resources/dns/main.tf
+++ b/ops/terraform/modules/resources/dns/main.tf
@@ -1,9 +1,89 @@
+# Create a zone, public or private
+# 
 resource "aws_route53_zone" "main" {
-  vpc_id  = "${var.vpc_id}"
-  name    = "bfd-${var.env}.local"
-  comment = "BFD private hosted zone (${var.env})"
-
-  tags {
-    Environment = "${var.env}"
+  name          = var.public ? var.parent != null ? "${var.name}.${var.parent.name}" : var.name : "bfd-${var.env_config.env}.local"
+  comment       = var.public ? "BFD public zone for ${var.env_config.env}." : "BFD private zone for ${var.env_config.env}."
+  tags          = var.env_config.tags
+  force_destroy = true
+  
+  # VPC is only valid for private zones
+  dynamic "vpc" {
+    for_each  = var.public ? [] : ["dummy"]
+    content {
+      vpc_id  = var.public ? null : var.env_config.vpc_id
+    }
   }
+}
+
+# Create a NS record that points to the main zone in the parent zone
+#
+resource "aws_route53_record" "parent" {
+  count     = var.parent != null ? 1 : 0
+  zone_id   = var.parent.zone_id 
+  name      = var.name
+  type      = "NS"
+  ttl       = 300
+  records   = aws_route53_zone.main.name_servers[*]
+}
+
+# Create an apex record for the zone
+#
+resource "aws_route53_record" "apex" {
+  count     = var.apex_record != null ? 1 : 0
+  zone_id   = aws_route53_zone.main.zone_id
+  name      = ""
+  type      = "A"
+
+  alias {
+    name                   = var.apex_record.alias
+    zone_id                = var.apex_record.zone_id
+    evaluate_target_health = var.apex_record.health_check
+  }
+}
+
+# Create A records for the zone
+#
+resource "aws_route53_record" "a" {
+  count     = length(var.a_records)
+  zone_id   = aws_route53_zone.main.zone_id
+  name      = var.a_records[count.index].name
+  type      = "A"
+
+  alias {
+    name                   = var.a_records[count.index].alias
+    zone_id                = var.a_records[count.index].zone_id
+    evaluate_target_health = var.a_records[count.index].health_check
+  }
+}
+
+# Create weighted CNAME record pairs with 0-100 for weights. 
+#
+resource "aws_route53_record" "cname_a" {
+  count     = length(var.weighted_pairs)
+  zone_id   = aws_route53_zone.main.zone_id
+  name      = var.weighted_pairs[count.index].name
+  type      = "CNAME"
+  ttl       = 60 # Alias records have a 60 second TTL so doing less than that is wasteful
+
+  weighted_routing_policy {
+    weight  = min(100, var.weighted_pairs[count.index].weight)
+  }
+
+  set_identifier  = var.weighted_pairs[count.index].a_set
+  records         = [var.weighted_pairs[count.index].a_record]
+}
+
+resource "aws_route53_record" "cname_b" {
+  count     = length(var.weighted_pairs)
+  zone_id   = aws_route53_zone.main.zone_id
+  name      = var.weighted_pairs[count.index].name
+  type      = "CNAME"
+  ttl       = 60  # Alias records have a 60 second TTL so doing less than that is wasteful
+
+  weighted_routing_policy {
+    weight  = max(0, 100 - var.weighted_pairs[count.index].weight)
+  }
+
+  set_identifier  = var.weighted_pairs[count.index].b_set
+  records         = [var.weighted_pairs[count.index].b_record]
 }

--- a/ops/terraform/modules/resources/dns/main.tf
+++ b/ops/terraform/modules/resources/dns/main.tf
@@ -26,7 +26,7 @@ resource "aws_route53_record" "parent" {
   records   = aws_route53_zone.main.name_servers[*]
 }
 
-# Create an apex record for the zone
+# Create an A apex record for the zone
 #
 resource "aws_route53_record" "apex" {
   count     = var.apex_record != null ? 1 : 0
@@ -41,7 +41,7 @@ resource "aws_route53_record" "apex" {
   }
 }
 
-# Create A records for the zone
+# Create A-records for the zone
 #
 resource "aws_route53_record" "a" {
   count     = length(var.a_records)
@@ -55,4 +55,3 @@ resource "aws_route53_record" "a" {
     evaluate_target_health = true
   }
 }
-

--- a/ops/terraform/modules/resources/dns/outputs.tf
+++ b/ops/terraform/modules/resources/dns/outputs.tf
@@ -1,3 +1,3 @@
-output "id" {
+output "zone_id" {
   value = aws_route53_zone.main.zone_id
 }

--- a/ops/terraform/modules/resources/dns/outputs.tf
+++ b/ops/terraform/modules/resources/dns/outputs.tf
@@ -1,0 +1,3 @@
+output "id" {
+  value = aws_route53_zone.main.zone_id
+}

--- a/ops/terraform/modules/resources/dns/variables.tf
+++ b/ops/terraform/modules/resources/dns/variables.tf
@@ -1,2 +1,41 @@
-variable "vpc_id" {}
-variable "env" {}
+variable "env_config" {
+  description = "All high-level info for the whole vpc"
+  type        = object({env=string, tags=map(string), vpc_id=string})
+}
+
+variable "name" {
+  description = "Domain name for the zone. Only needed for public domains"
+  type        = string
+  default     = null
+}
+
+variable "parent" {
+  description = "Parent zone. Create a NAPTR record to this zone in the parent zone"
+  type        = object({name=string, zone_id=string})
+  default     = null
+}
+
+variable "public" {
+  description = "If true, declare the zone as a public zone"
+  type        = bool
+  default     = false
+}
+
+variable "apex_record" {
+  description = "Create an APEX record for an AWS resource"
+  type        = object({alias=string, zone_id=string, health_check=bool})
+  default     = null
+}
+
+variable "a_records" {
+  description = "A list of A records that AWS resources"
+  type        = list(object({name=string, alias=string, zone_id=string, health_check=bool}))
+  default     = []
+}
+
+
+variable "weighted_pairs" {
+  description = "Create a pair of weighted CNAME records. Weights should be 0-100"
+  type        = list(object({name=string, weight=number, a_record=string, a_set=string, b_record=string, b_set=string}))
+  default     = []
+}

--- a/ops/terraform/modules/resources/dns/variables.tf
+++ b/ops/terraform/modules/resources/dns/variables.tf
@@ -23,19 +23,12 @@ variable "public" {
 
 variable "apex_record" {
   description = "Create an APEX record for an AWS resource"
-  type        = object({alias=string, zone_id=string, health_check=bool})
+  type        = object({alias=string, zone_id=string})
   default     = null
 }
 
 variable "a_records" {
   description = "A list of A records that AWS resources"
-  type        = list(object({name=string, alias=string, zone_id=string, health_check=bool}))
-  default     = []
-}
-
-
-variable "weighted_pairs" {
-  description = "Create a pair of weighted CNAME records. Weights should be 0-100"
-  type        = list(object({name=string, weight=number, a_record=string, a_set=string, b_record=string, b_set=string}))
+  type        = list(object({name=string, alias=string, zone_id=string}))
   default     = []
 }

--- a/ops/terraform/modules/resources/dns_pairs/main.tf
+++ b/ops/terraform/modules/resources/dns_pairs/main.tf
@@ -1,0 +1,37 @@
+# Create weighted CNAME record pairs with 0-100 for weights. 
+#
+resource "aws_route53_record" "record_a" {
+  for_each  = var.weights
+  zone_id   = var.zone_id
+  name      = each.key
+  type      = "A"
+
+  alias {
+    name                    = var.a_alias
+    zone_id                 = var.a_zone_id
+    evaluate_target_health  = true
+  }
+
+  set_identifier            = var.a_set
+  weighted_routing_policy {
+    weight                  = min(100, each.value)
+  }
+}
+
+resource "aws_route53_record" "record_b" {
+  for_each  = var.weights
+  zone_id   = var.zone_id
+  name      = each.key
+  type      = "A"
+
+  alias {
+    name                    = var.b_alias
+    zone_id                 = var.b_zone_id
+    evaluate_target_health  = true
+  }
+
+  set_identifier            = var.b_set
+  weighted_routing_policy {
+    weight                  = max(0, 100 - each.value)
+  }
+}

--- a/ops/terraform/modules/resources/dns_pairs/main.tf
+++ b/ops/terraform/modules/resources/dns_pairs/main.tf
@@ -1,4 +1,4 @@
-# Create weighted CNAME record pairs with 0-100 for weights. 
+# Create weighted A-record pairs with 0-100 for weights. 
 #
 resource "aws_route53_record" "record_a" {
   for_each  = var.weights

--- a/ops/terraform/modules/resources/dns_pairs/variables.tf
+++ b/ops/terraform/modules/resources/dns_pairs/variables.tf
@@ -1,0 +1,37 @@
+variable "env_config" {
+  description = "All high-level info for the whole vpc"
+  type        = object({env=string, tags=map(string), vpc_id=string})
+}
+
+variable "zone_id" {
+  type        = string
+}
+
+variable "a_alias" {
+  type        = string
+}
+
+variable "a_zone_id" {
+  type        = string
+}
+
+variable "a_set" {
+  type        = string
+}
+
+variable "b_alias" {
+  type        = string
+}
+
+variable "b_zone_id" {
+  type        = string
+}
+
+variable "b_set" {
+  type        = string
+}
+
+variable "weights" {
+  description = "For each name, create a pair with a weight."
+  type        = map(number)
+}

--- a/ops/terraform/modules/stateful/main.tf
+++ b/ops/terraform/modules/stateful/main.tf
@@ -6,7 +6,7 @@
 
 locals {
   azs = ["us-east-1a", "us-east-1b", "us-east-1c"]
-  env_config = {env=var.env_config.env, tags=var.env_config.tags, vpc_id=data.aws_vpc.main.id, zone_id=aws_route53_zone.local_zone.id }
+  env_config = {env=var.env_config.env, tags=var.env_config.tags, vpc_id=data.aws_vpc.main.id, zone_id=module.local_zone.id }
   
   db_sgs = [
     aws_security_group.db.id,
@@ -96,11 +96,10 @@ data "aws_security_group" "management" {
 #
 # Build a VPC private local zone for CNAME records
 #
-resource "aws_route53_zone" "local_zone" {
-  name    = "bfd-${var.env_config.env}.local"
-  vpc {
-    vpc_id = data.aws_vpc.main.id
-  }
+module "local_zone" {
+  source        = "../resources/dns"
+  env_config    = {env=var.env_config.env, tags=var.env_config.tags, vpc_id=data.aws_vpc.main.id}
+  public        = false
 }
 
 # CloudWatch SNS Topic

--- a/ops/terraform/modules/stateful/main.tf
+++ b/ops/terraform/modules/stateful/main.tf
@@ -6,7 +6,7 @@
 
 locals {
   azs = ["us-east-1a", "us-east-1b", "us-east-1c"]
-  env_config = {env=var.env_config.env, tags=var.env_config.tags, vpc_id=data.aws_vpc.main.id, zone_id=module.local_zone.id }
+  env_config = {env=var.env_config.env, tags=var.env_config.tags, vpc_id=data.aws_vpc.main.id, zone_id=module.local_zone.zone_id }
   
   db_sgs = [
     aws_security_group.db.id,


### PR DESCRIPTION
**Why**

To gradually migrate partners between the HealthApt and CCS environments. The plan is contained in https://confluence.cms.gov/display/BB/Traffic+routing+between+HealthApt+and+CCS.

**What Changed**
- A new env/migration folder deploys the migration DNS zone per environment. The main.tf contains the weights.  
- A new migration module drives the weight policy
- The DNS resource has a bunch more features. 
- See https://gist.github.com/RickHawesUSDS/9669dc8683b23ff40861badd44ce80f3 for the Terraform plan

**Decisions Made**
- One zone per environment with the apex record resolving to the CCS environment
- One record per partner to allow complete flexibility per partner
- Use the Route53 alias feature to allow for health checks 
- Registered bfdcloud.net domain to allow us to start. Started the process to get bfd.cmscloud.gov.

**Work to Do**
BLUEBUTTON-1247 Create an equivalent to hhsdevcloud.us.
