### PR TITLE
Remove RDS storage autoscaling, implement RDS import mode, tweak test/prod RDS params for import

### DIFF
--- a/ops/terraform/env/prod-sbx/stateful/main.tf
+++ b/ops/terraform/env/prod-sbx/stateful/main.tf
@@ -16,6 +16,11 @@ module "stateful" {
     allocated_storage = 2000
   }
 
+  db_import_mode = {
+    enabled = true
+    maintenance_work_mem = "1048576"
+  }
+
   env_config = {
     env               = "prod-sbx"
     tags              = {application="bfd", business="oeda", stack="prod-sbx", Environment="prod-sbx"}

--- a/ops/terraform/env/prod-sbx/stateful/main.tf
+++ b/ops/terraform/env/prod-sbx/stateful/main.tf
@@ -10,7 +10,6 @@ provider "aws" {
 module "stateful" {
   source = "../../../modules/stateful"
 
-  # Medium DB
   db_config = { 
     instance_class    = "db.m5.2xlarge"
     iops              = 4000

--- a/ops/terraform/env/prod/stateful/main.tf
+++ b/ops/terraform/env/prod/stateful/main.tf
@@ -10,11 +10,10 @@ provider "aws" {
 module "stateful" {
   source = "../../../modules/stateful"
 
-  # Large DB
   db_config = { 
     instance_class    = "db.r5.24xlarge"
-    iops              = 5000
-    allocated_storage = 10000
+    iops              = 32000
+    allocated_storage = 16000
   }
 
   env_config = {

--- a/ops/terraform/env/prod/stateful/main.tf
+++ b/ops/terraform/env/prod/stateful/main.tf
@@ -12,7 +12,7 @@ module "stateful" {
 
   db_config = { 
     instance_class    = "db.r5.24xlarge"
-    iops              = 32000
+    iops              = 16000
     allocated_storage = 16000
   }
 

--- a/ops/terraform/env/prod/stateful/main.tf
+++ b/ops/terraform/env/prod/stateful/main.tf
@@ -16,6 +16,11 @@ module "stateful" {
     allocated_storage = 16000
   }
 
+  db_import_mode = {
+    enabled = true
+    maintenance_work_mem = "4194304"
+  }
+
   env_config = {
     env               = "prod"
     tags              = {application="bfd", business="oeda", stack="prod", Environment="prod"}

--- a/ops/terraform/env/test/stateful/main.tf
+++ b/ops/terraform/env/test/stateful/main.tf
@@ -16,6 +16,11 @@ module "stateful" {
     allocated_storage = 8000
   }
 
+  db_import_mode = {
+    enabled = true
+    maintenance_work_mem = "2097152"
+  }
+
   env_config = {
     env               = "test"
     tags              = {application="bfd", business="oeda", stack="test", Environment="test"}

--- a/ops/terraform/env/test/stateful/main.tf
+++ b/ops/terraform/env/test/stateful/main.tf
@@ -10,11 +10,10 @@ provider "aws" {
 module "stateful" {
   source = "../../../modules/stateful"
 
-  # Smallish DB
   db_config = { 
-    instance_class    = "db.m4.2xlarge"
-    iops              = 1000
-    allocated_storage = 1000
+    instance_class    = "db.m5.4xlarge"
+    iops              = 16000
+    allocated_storage = 8000
   }
 
   env_config = {

--- a/ops/terraform/env/test/stateful/main.tf
+++ b/ops/terraform/env/test/stateful/main.tf
@@ -11,14 +11,14 @@ module "stateful" {
   source = "../../../modules/stateful"
 
   db_config = { 
-    instance_class    = "db.m5.4xlarge"
+    instance_class    = "db.r5.24xlarge"
     iops              = 16000
-    allocated_storage = 8000
+    allocated_storage = 12000
   }
 
   db_import_mode = {
     enabled = true
-    maintenance_work_mem = "2097152"
+    maintenance_work_mem = "4194304"
   }
 
   env_config = {

--- a/ops/terraform/modules/resources/rds/main.tf
+++ b/ops/terraform/modules/resources/rds/main.tf
@@ -24,8 +24,7 @@ data "aws_iam_role" "rds_monitoring" {
 #   - deletition protection in prod environments
 #
 resource "aws_db_instance" "db" {
-  max_allocated_storage  = local.is_master ? var.db_config.allocated_storage : null
-  allocated_storage      = local.is_master ? 100 : null
+  allocated_storage      = var.db_config.allocated_storage
   storage_type           = "io1" 
   iops                   = var.db_config.iops
   instance_class         = var.db_config.instance_class

--- a/ops/terraform/modules/resources/rds/main.tf
+++ b/ops/terraform/modules/resources/rds/main.tf
@@ -54,6 +54,9 @@ resource "aws_db_instance" "db" {
   performance_insights_enabled    = false                     # Not supported in postgres 9.6
   final_snapshot_identifier       = local.deletion_protection ? "${local.name}-final" : null
   enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"] # Could add 'listener' and "audit"
+  # depends on the state of var.db_import_mode.enabled in the parent module
+  parameter_group_name = var.parameter_group_name
+  apply_immediately    = var.apply_immediately
 
   lifecycle {
     ignore_changes = ["password"]

--- a/ops/terraform/modules/resources/rds/variables.tf
+++ b/ops/terraform/modules/resources/rds/variables.tf
@@ -33,3 +33,11 @@ variable "replicate_source_db" {
 variable "kms_key_id" {
   type        = string
 }
+
+variable "apply_immediately" {
+  type        = bool
+}
+
+variable "parameter_group_name" {
+  type        = string
+}

--- a/ops/terraform/modules/stateful/main.tf
+++ b/ops/terraform/modules/stateful/main.tf
@@ -183,7 +183,7 @@ resource "aws_db_parameter_group" "import_mode" {
   }
 
   parameter {
-    name  = "checkpoint_segments"
+    name  = "max_wal_size"
     value = "256"
   }
 
@@ -194,7 +194,7 @@ resource "aws_db_parameter_group" "import_mode" {
 
   parameter {
     name  = "synchronous_commit"
-    value = "0"
+    value = "off"
   }
 
   parameter {

--- a/ops/terraform/modules/stateful/variables.tf
+++ b/ops/terraform/modules/stateful/variables.tf
@@ -3,6 +3,11 @@ variable "db_config" {
   type              = object({instance_class = string, allocated_storage=number, iops = number})
 }
 
+variable "db_import_mode" {
+  description       = "Enable or disable parameters that optimize bulk data imports"
+  type              = object({enabled = bool, maintenance_work_mem = string})
+}
+
 variable "env_config" {
   description       = "All high-level info for the whole vpc"
   type              = object({env=string, tags=map(string)})


### PR DESCRIPTION
This PR does 3 things:  
* Removes RDS storage autoscaling completely by removing the `max_allocated_storage` parameter in favor of directly setting `allocated_storage`.  We have a large existing dataset and to import it properly storage needs to be allocated up front.  
* Implements an RDS import mode on master nodes.  This is a feature that when enabled allows for immediate application of RDS parameters, and sets several RDS parameters tuned for import per this guide: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/PostgreSQL.Procedural.Importing.html#PostgreSQL.Procedural.Importing.Copy  
* I have also tweaked RDS instance size, storage size, and IOPS parameters based feedback, though I think these are still subject to change (definitely post-import).  

Let me know if you think this could be structured better, or if any of the parameters seem off.