### PR TITLE
Fix RDS import mode issues

### DIFF
--- a/ops/terraform/modules/stateful/main.tf
+++ b/ops/terraform/modules/stateful/main.tf
@@ -185,6 +185,7 @@ resource "aws_db_parameter_group" "import_mode" {
   parameter {
     name  = "max_wal_size"
     value = "256"
+    apply_method = "pending-reboot"
   }
 
   parameter {
@@ -200,6 +201,7 @@ resource "aws_db_parameter_group" "import_mode" {
   parameter {
     name  = "wal_buffers"
     value = "8192"
+    apply_method = "pending-reboot"
   }
 
   parameter {

--- a/ops/terraform/modules/stateful/main.tf
+++ b/ops/terraform/modules/stateful/main.tf
@@ -225,7 +225,7 @@ module "master" {
 
   vpc_security_group_ids = local.master_db_sgs
 
-  apply_immediately    = var.db_import_mode.enabled ? true : false
+  apply_immediately    = var.db_import_mode.enabled
   parameter_group_name = var.db_import_mode.enabled ? aws_db_parameter_group.import_mode.name : null
 }
 
@@ -245,7 +245,7 @@ module "replica1" {
 
   vpc_security_group_ids = local.db_sgs
 
-  apply_immediately    = var.db_import_mode.enabled ? true : false
+  apply_immediately    = var.db_import_mode.enabled
   parameter_group_name = null
 }
 
@@ -261,7 +261,7 @@ module "replica2" {
 
   vpc_security_group_ids = local.db_sgs
 
-  apply_immediately    = var.db_import_mode.enabled ? true : false
+  apply_immediately    = var.db_import_mode.enabled
   parameter_group_name = null
 }
 
@@ -277,7 +277,7 @@ module "replica3" {
 
   vpc_security_group_ids = local.db_sgs
 
-  apply_immediately    = var.db_import_mode.enabled ? true : false
+  apply_immediately    = var.db_import_mode.enabled
   parameter_group_name = null
 }
 

--- a/ops/terraform/modules/stateful/main.tf
+++ b/ops/terraform/modules/stateful/main.tf
@@ -245,7 +245,7 @@ module "replica1" {
 
   vpc_security_group_ids = local.db_sgs
 
-  apply_immediately    = false
+  apply_immediately    = var.db_import_mode.enabled ? true : false
   parameter_group_name = null
 }
 
@@ -261,7 +261,7 @@ module "replica2" {
 
   vpc_security_group_ids = local.db_sgs
 
-  apply_immediately    = false
+  apply_immediately    = var.db_import_mode.enabled ? true : false
   parameter_group_name = null
 }
 
@@ -277,7 +277,7 @@ module "replica3" {
 
   vpc_security_group_ids = local.db_sgs
 
-  apply_immediately    = false
+  apply_immediately    = var.db_import_mode.enabled ? true : false
   parameter_group_name = null
 }
 


### PR DESCRIPTION
Quick fix for two things observed:  
* Two parameters required `pending-reboot` rather than `immediate` apply method  
* It makes more sense if the read replicas are in lock-step with master during import mode so changes like IOPS and storage size can be propagated immediately  

I have already applied this in PROD-SBX to get going.