### PR TITLE
BLUEBUTTON-1086: Fix dumb typo in deploy config script

### DIFF
--- a/ops/ansible/roles/bfd-server/files/bluebutton-appserver-config.sh
+++ b/ops/ansible/roles/bfd-server/files/bluebutton-appserver-config.sh
@@ -219,7 +219,7 @@ end-if
 if (outcome == success) of /system-property=bfdServer.logs.dir:read-resource
 	/system-property=bfdServer.logs.dir:remove
 end-if
-if (outcome == success) of /system-property=bbfdServer.db.url:read-resource
+if (outcome == success) of /system-property=bfdServer.db.url:read-resource
 	/system-property=bfdServer.db.url:remove
 end-if
 if (outcome == success) of /system-property=bfdServer.db.username:read-resource


### PR DESCRIPTION
Currently breaking all of our deploys:

```
WFLYCTL0212: Duplicate resource [(\"system-property\" => \"bfdServer.db.url\")]
```

Didn't catch this in the PR that created it, because it only goes boom the _second_ time you run the script as-is.

https://jira.cms.gov/browse/BLUEBUTTON-1086