### PR TITLE
Change the root volume size to 100GB

### DIFF
--- a/ops/terraform/modules/resources/asg/main.tf
+++ b/ops/terraform/modules/resources/asg/main.tf
@@ -21,6 +21,19 @@ data "aws_subnet" "app_subnets" {
   }
 }
 
+# KMS 
+#
+# The customer master key is created outside of this script
+#
+data "aws_kms_key" "master_key" {
+  key_id = "alias/bfd-${var.env_config.env}-cmk"
+}
+
+
+##
+# Create Resources
+##
+
 #
 # Security groups
 #
@@ -98,6 +111,15 @@ resource "aws_launch_configuration" "main" {
     env   = var.env_config.env
     port  = var.lb_config.port
   })
+
+  root_block_device {
+    volume_type               = "gp2"
+    volume_size               = var.launch_config.volume_size
+    delete_on_termination     = true
+    encrypted                 = true
+    # not yet supported
+    # kms_key_id                = data.aws_kms_key.master_key.key_id
+  }
 
   lifecycle {
     create_before_destroy = true

--- a/ops/terraform/modules/resources/asg/variables.tf
+++ b/ops/terraform/modules/resources/asg/variables.tf
@@ -34,7 +34,7 @@ variable "mgmt_config" {
 }
 
 variable "launch_config" {
-  type        = object({instance_type=string, ami_id=string, key_name=string, profile=string, user_data_tpl=string})
+  type        = object({instance_type=string, volume_size=number, ami_id=string, key_name=string, profile=string, user_data_tpl=string})
 }
 
 

--- a/ops/terraform/modules/resources/ec2/variables.tf
+++ b/ops/terraform/modules/resources/ec2/variables.tf
@@ -22,7 +22,7 @@ variable "mgmt_config" {
 }
 
 variable "launch_config" {
-  type        = object({instance_type=string, ami_id=string, key_name=string, profile=string, user_data_tpl=string})
+  type        = object({instance_type=string, volume_size=number, ami_id=string, key_name=string, profile=string, user_data_tpl=string})
 }
 
 

--- a/ops/terraform/modules/stateless/main.tf
+++ b/ops/terraform/modules/stateless/main.tf
@@ -173,6 +173,7 @@ module "fhir_asg" {
   # TODO: Dummy values to get started
   launch_config   = {
     instance_type = "m5.large" 
+    volume_size   = 100 # GB
     ami_id        = "ami-0b898040803850657" 
     key_name      = "bfd-rick-test" 
     profile       = module.fhir_iam.profile
@@ -205,6 +206,7 @@ module "etl_instance" {
   # TODO: Dummy values to get started
   launch_config   = {
     instance_type = "m5.large" 
+    volume_size   = 100 # GB
     ami_id        = "ami-0b898040803850657" 
     key_name      = "bfd-rick-test" 
     profile       = module.etl_iam.profile


### PR DESCRIPTION
**Why**
Add more space on the root volumes for logs and other things. 

**What Changed**
Variable passed in as part of launch_config in resources. 100GB set in stateless/main.tf. 

**Choices Made**
The volume is encrypted with the default iops. 

**Terraform State**
This change will cause replacement of all instances. Example TF Plan is here: https://gist.github.com/RickHawesUSDS/b4e26c172889af24676da8f1a765f24b. The plan has not been applied to any environment. 