### PR TITLE
BLUEBUTTON-1163 Instance Snapshots

### DIFF
--- a/ops/terraform/env/global/dlm/backend.tf
+++ b/ops/terraform/env/global/dlm/backend.tf
@@ -1,0 +1,11 @@
+terraform {
+  backend "s3" {
+    bucket         = "bfd-tf-state"
+    key            = "global/dlm/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "bfd-tf-table"
+    encrypt        = "1"
+    kms_key_id     = "alias/bfd-tf-state"
+  }
+}
+

--- a/ops/terraform/env/global/dlm/main.tf
+++ b/ops/terraform/env/global/dlm/main.tf
@@ -1,0 +1,18 @@
+##
+# Setup a global DLM policy that takes snapshots of EBS volumes
+##
+
+terraform {
+  required_version = "~> 0.12"
+}
+
+provider "aws" {
+  version   = "~> 2.28"
+  region    = "us-east-1"
+}
+
+module "dlm" {
+  source    = "../../../modules/resources/dlm"
+  retain    = 21       # days
+  time      = "23:30"   
+}

--- a/ops/terraform/modules/resources/asg/main.tf
+++ b/ops/terraform/modules/resources/asg/main.tf
@@ -131,8 +131,9 @@ resource "aws_launch_template" "main" {
   }
   
   user_data = base64encode(templatefile("${path.module}/../templates/${var.launch_config.user_data_tpl}", {
-    env     = var.env_config.env
-    port    = var.lb_config.port
+    env       = var.env_config.env
+    port      = var.lb_config.port
+    accountId = var.launch_config.account_id
   }))
 
   tag_specifications {

--- a/ops/terraform/modules/resources/asg/main.tf
+++ b/ops/terraform/modules/resources/asg/main.tf
@@ -118,7 +118,7 @@ resource "aws_launch_template" "main" {
   }
   
   block_device_mappings {    
-    device_name = "/dev/xvda"
+    device_name = "/dev/sda1"
     ebs {
       volume_type               = "gp2"
       volume_size               = var.launch_config.volume_size
@@ -129,45 +129,6 @@ resource "aws_launch_template" "main" {
       */
     }
   }
-
-  user_data                     = templatefile("${path.module}/../templates/${var.launch_config.user_data_tpl}", {
-    env   = var.env_config.env
-    port  = var.lb_config.port
-  })
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-
-##
-# Launch configuration
-##
-resource "aws_launch_configuration" "main" {
-  # Generate a new config on every revision
-  name_prefix                 = "bfd-${var.env_config.env}-${var.role}-"
-  security_groups             = concat([aws_security_group.base.id], aws_security_group.app[*].id)
-  key_name                    = var.launch_config.key_name
-  image_id                    = var.launch_config.ami_id
-  instance_type               = var.launch_config.instance_type
-  associate_public_ip_address = false
-  iam_instance_profile        = var.launch_config.profile
-  placement_tenancy           = local.is_prod ? "dedicated" : "default"
-
-  user_data                   = templatefile("${path.module}/../templates/${var.launch_config.user_data_tpl}", {
-    env   = var.env_config.env
-    port  = var.lb_config.port
-    accountId = var.launch_config.account_id
-  })
-
-  root_block_device {
-    volume_type               = "gp2"
-    volume_size               = var.launch_config.volume_size
-    delete_on_termination     = true
-    encrypted                 = true
-    # not yet supported
-    # kms_key_id                = data.aws_kms_key.master_key.key_id
   
   user_data = base64encode(templatefile("${path.module}/../templates/${var.launch_config.user_data_tpl}", {
     env     = var.env_config.env

--- a/ops/terraform/modules/resources/dlm/main.tf
+++ b/ops/terraform/modules/resources/dlm/main.tf
@@ -56,7 +56,7 @@ EOF
 # DLM policy and schedule
 #
 resource "aws_dlm_lifecycle_policy" "main" {
-  description        = "example DLM lifecycle policy"
+  description        = "EBS volume snapshot and retention policy for BFD"
   execution_role_arn = aws_iam_role.dlm_lifecycle_role.arn
   state              = "ENABLED"
 
@@ -67,9 +67,9 @@ resource "aws_dlm_lifecycle_policy" "main" {
       name = "Daily snapshots of EC2 volumes which are marked for snapshots"
 
       create_rule {
-        interval      = var.interval
+        interval      = 24
         interval_unit = "HOURS"
-        times         = ["23:45"]
+        times         = [var.time]
       }
 
       retain_rule {

--- a/ops/terraform/modules/resources/dlm/main.tf
+++ b/ops/terraform/modules/resources/dlm/main.tf
@@ -56,7 +56,7 @@ EOF
 # DLM policy and schedule
 #
 resource "aws_dlm_lifecycle_policy" "main" {
-  description        = "EBS volume snapshot and retention policy for BFD"
+  description        = "BFDs snapshot policy"
   execution_role_arn = aws_iam_role.dlm_lifecycle_role.arn
   state              = "ENABLED"
 

--- a/ops/terraform/modules/resources/dlm/main.tf
+++ b/ops/terraform/modules/resources/dlm/main.tf
@@ -1,0 +1,90 @@
+##
+# Create a Data Lifecycle Manager (DLM) schedule that snapshots EBS volumes that have the "snapshot=true" tag 
+##
+
+# IAM Roles and Policy for the DLM policy
+#
+resource "aws_iam_role" "dlm_lifecycle_role" {
+  name = "dlm-lifecycle-role"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "dlm.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "dlm_lifecycle" {
+  name = "dlm-lifecycle-policy"
+  role = aws_iam_role.dlm_lifecycle_role.id
+
+  policy = <<EOF
+{
+   "Version": "2012-10-17",
+   "Statement": [
+      {
+         "Effect": "Allow",
+         "Action": [
+            "ec2:CreateSnapshot",
+            "ec2:DeleteSnapshot",
+            "ec2:DescribeVolumes",
+            "ec2:DescribeSnapshots"
+         ],
+         "Resource": "*"
+      },
+      {
+         "Effect": "Allow",
+         "Action": [
+            "ec2:CreateTags"
+         ],
+         "Resource": "arn:aws:ec2:*::snapshot/*"
+      }
+   ]
+}
+EOF
+}
+
+# DLM policy and schedule
+#
+resource "aws_dlm_lifecycle_policy" "main" {
+  description        = "example DLM lifecycle policy"
+  execution_role_arn = aws_iam_role.dlm_lifecycle_role.arn
+  state              = "ENABLED"
+
+  policy_details {
+    resource_types = ["VOLUME"]
+
+    schedule {
+      name = "Daily snapshots of EC2 volumes which are marked for snapshots"
+
+      create_rule {
+        interval      = var.interval
+        interval_unit = "HOURS"
+        times         = ["23:45"]
+      }
+
+      retain_rule {
+        count = var.retain
+      }
+
+      tags_to_add = {
+        SnapshotCreator = "DLM"
+      }
+
+      copy_tags = true
+    }
+
+    target_tags = {
+      snapshot = "true"
+    }
+  }
+}

--- a/ops/terraform/modules/resources/dlm/variables.tf
+++ b/ops/terraform/modules/resources/dlm/variables.tf
@@ -3,7 +3,8 @@ variable "retain" {
   type        = number
 }
 
-variable "interval" {
-  description = "Snapshot interval in hours"
-  type        = number
+variable "time" {
+  description = "Snapshot start time"
+  type        = string
+  default     = "23:45" 
 }

--- a/ops/terraform/modules/resources/dlm/variables.tf
+++ b/ops/terraform/modules/resources/dlm/variables.tf
@@ -1,0 +1,9 @@
+variable "retain" {
+  description = "Number of days to retain the snapshots"
+  type        = number
+}
+
+variable "interval" {
+  description = "Snapshot interval in hours"
+  type        = number
+}

--- a/ops/terraform/modules/resources/ec2/main.tf
+++ b/ops/terraform/modules/resources/ec2/main.tf
@@ -86,6 +86,7 @@ resource "aws_instance" "main" {
   monitoring                  = true
   associate_public_ip_address = false
   tenancy                     = local.is_prod ? "dedicated" : "default"
+  ebs_optimized               = true
 
   vpc_security_group_ids      = [aws_security_group.base.id]
   subnet_id                   = data.aws_subnet.main.id

--- a/ops/terraform/modules/resources/ec2/main.tf
+++ b/ops/terraform/modules/resources/ec2/main.tf
@@ -82,6 +82,7 @@ resource "aws_instance" "main" {
 
   availability_zone           = var.az
   tags                        = merge({Name="bfd-${var.env_config.env}-${var.role}"}, local.tags)
+  volume_tags                 = merge({Name="bfd-${var.env_config.env}-${var.role}", snapshot="true"}, local.tags)
   monitoring                  = true
   associate_public_ip_address = false
   tenancy                     = local.is_prod ? "dedicated" : "default"
@@ -92,7 +93,7 @@ resource "aws_instance" "main" {
   root_block_device {
     volume_type               = "gp2"
     volume_size               = var.launch_config.volume_size
-    delete_on_termination     = true
+    delete_on_termination     = false
     encrypted                 = true
     kms_key_id                = data.aws_kms_key.master_key.key_id
   }


### PR DESCRIPTION
**Why**
For security audits and other security purposes, retain daily snapshots of BFD's instance volumes. 

**What Changed**
- A new global data lifecycle manager policy that takes snapshots of volumes and retains them for 21 days.
- Since DLM policy runs on tag matching, tag all ec2 instance volumes. 
- In order to tag volumes, switched from Launch Configurations to Launch Templates to specify the instances created by Autoscale Groups

The terraform plan is here:
https://gist.github.com/RickHawesUSDS/dad91f312d9ec5ae1b755c00466a6df1

**Choices Made**
- The use of DLM to do manage the snapshots. Could of done this with a Lambda function.
- Use Launch Templates to tag snapshots. Found articles that recommended using Lambdas to do this task.

**Whats Left**
This finishes BLUEBOTTON-1163. 