### PR TITLE
Allow FHIR and ETL roles to grab vault password from mgmt bucket

### DIFF
--- a/ops/terraform/modules/mgmt_stateful/main.tf
+++ b/ops/terraform/modules/mgmt_stateful/main.tf
@@ -94,6 +94,33 @@ module "admin" {
   acl                 = "log-delivery-write"
 }
 
+# IAM policy to allow read access to ansible vault password
+#
+resource "aws_iam_policy" "ansible_vault_pw_ro_s3" {
+  name        = "bfd-ansible-vault-pw-ro-s3"
+  description = "ansible vault pw read only S3 policy"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AnsibleVaultPwRO",
+      "Action": [
+        "kms:Decrypt",
+        "s3:GetObject"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "${data.aws_kms_key.master_key.arn}",
+        "${module.admin.arn}/ansible/vault.password"
+      ]
+    }
+  ]
+}
+EOF
+}
+
 # S3 bucket for Build Artifacts
 #
 module "artifacts" {

--- a/ops/terraform/modules/stateless/main.tf
+++ b/ops/terraform/modules/stateless/main.tf
@@ -97,6 +97,12 @@ data "aws_security_group" "remote" {
   }
 }
 
+# Find ansible vault pw read only policy by hardcoded ARN, no other options for this data source
+#
+data "aws_iam_policy" "ansible_vault_pw_ro_s3" {
+  arn           = "arn:aws:iam::577373831711:policy/bfd-ansible-vault-pw-ro-s3"
+}
+
 #
 # Start to build stuff
 #
@@ -111,12 +117,22 @@ module "fhir_iam" {
   name            = "fhir"
 }
 
+resource "aws_iam_role_policy_attachment" "fhir_iam_ansible_vault_pw_ro_s3" {
+  role            = module.fhir_iam.role
+  policy_arn      = data.aws_iam_policy.ansible_vault_pw_ro_s3.arn
+}
+
 module "etl_iam" {
   source = "../resources/iam"
 
   env_config      = local.env_config
   name            = "etl"
   s3_bucket_arns  = [data.aws_s3_bucket.etl.arn]
+}
+
+resource "aws_iam_role_policy_attachment" "etl_iam_ansible_vault_pw_ro_s3" {
+  role            = module.etl_iam.role
+  policy_arn      = data.aws_iam_policy.ansible_vault_pw_ro_s3.arn
 }
 
 


### PR DESCRIPTION
This creates an IAM policy which allows read access to the vault.password file, and attaches that policy to the FHIR and ETL roles.  

Unfortunately the IAM policy data source in terraform is not very useful and only allows lookup via the ARN itself: https://www.terraform.io/docs/providers/aws/d/iam_policy.html