### PR TITLE
User data needs account id, fix to pass it down to proper scope

### DIFF
--- a/ops/terraform/modules/resources/asg/main.tf
+++ b/ops/terraform/modules/resources/asg/main.tf
@@ -110,6 +110,7 @@ resource "aws_launch_configuration" "main" {
   user_data                   = templatefile("${path.module}/../templates/${var.launch_config.user_data_tpl}", {
     env   = var.env_config.env
     port  = var.lb_config.port
+    accountId = var.launch_config.account_id
   })
 
   root_block_device {

--- a/ops/terraform/modules/resources/asg/variables.tf
+++ b/ops/terraform/modules/resources/asg/variables.tf
@@ -34,7 +34,7 @@ variable "mgmt_config" {
 }
 
 variable "launch_config" {
-  type        = object({instance_type=string, volume_size=number, ami_id=string, key_name=string, profile=string, user_data_tpl=string})
+  type        = object({instance_type=string, volume_size=number, ami_id=string, key_name=string, profile=string, user_data_tpl=string, account_id=string})
 }
 
 

--- a/ops/terraform/modules/stateless/main.tf
+++ b/ops/terraform/modules/stateless/main.tf
@@ -196,6 +196,7 @@ module "fhir_asg" {
 
     profile       = module.fhir_iam.profile
     user_data_tpl = "fhir_server.tpl"       # See templates directory for choices
+    account_id    = data.aws_caller_identity.current.account_id
   }
 
   db_config       = {


### PR DESCRIPTION
Fix for the following build error:
```
Error: Invalid function argument

  on ../../../modules/resources/asg/main.tf line 110, in resource "aws_launch_configuration" "main":
 110:   user_data                   = templatefile("${path.module}/../templates/${var.launch_config.user_data_tpl}", {
 111: 
 112: 
 113: 
    |----------------
    | var.env_config.env is "test"
    | var.lb_config.port is 7743

Invalid value for "vars" parameter: vars map does not contain key "accountId",
referenced at
../../../modules/resources/asg/../templates/fhir_server.tpl:9,33-42.
```