### PR TITLE
Fix missing data_server_version that causes war deploy to fail

### DIFF
--- a/ops/terraform/modules/resources/templates/fhir_server.tpl
+++ b/ops/terraform/modules/resources/templates/fhir_server.tpl
@@ -13,7 +13,8 @@ aws s3 cp s3://bfd-mgmt-admin-${accountId}/ansible/vault.password .
 cat <<EOF >> extra_vars.json
 {
     "env":"${env}",
-    "data_server_container_name":"wildfly-8.1.0.Final"
+    "data_server_container_name":"wildfly-8.1.0.Final",
+    "data_server_version":"1.0.0-SNAPSHOT"
 }
 EOF
 


### PR DESCRIPTION
With logging enabled it became apparent that the `data_server_version` var was missing.
```
TASK [bfd-server : Deploy WAR (with Authentication)] *******************************************************
Friday 13 September 2019  17:03:29 -0400 (0:00:00.049)       0:00:02.049 ******
fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'data_server_version' is undefined\n\nThe error appears to be in '/beneficiary-fhir-data/ops/ansible/roles/bfd-server/tasks/war_deploy.yml': line 21, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Deploy WAR (with Authentication)\n  ^ here\n"}
```
This is currently hardcoded for pipeline, hardcoding for the time being for data-server.