### PR TITLE
BLUEBUTTON-850: Resolve non-unique bucket name test errors

### DIFF
--- a/apps/bfd-pipeline/bfd-pipeline-app/src/test/java/gov/cms/bfd/pipeline/app/S3ToDatabaseLoadAppIT.java
+++ b/apps/bfd-pipeline/bfd-pipeline-app/src/test/java/gov/cms/bfd/pipeline/app/S3ToDatabaseLoadAppIT.java
@@ -22,7 +22,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.codec.binary.Hex;
 import org.awaitility.Awaitility;
@@ -126,7 +125,7 @@ public final class S3ToDatabaseLoadAppIT {
     Process appProcess = null;
     try {
       // Create the (empty) bucket to run against.
-      bucket = s3Client.createBucket(String.format("bb-test-%d", new Random().nextInt(1000)));
+      bucket = DataSetTestUtilities.createTestBucket(s3Client);
 
       // Start the app.
       ProcessBuilder appRunBuilder = createAppProcessBuilder(bucket);
@@ -177,7 +176,7 @@ public final class S3ToDatabaseLoadAppIT {
        * Create the (empty) bucket to run against, and populate it with a
        * data set.
        */
-      bucket = s3Client.createBucket(String.format("bb-test-%d", new Random().nextInt(1000)));
+      bucket = DataSetTestUtilities.createTestBucket(s3Client);
       DataSetManifest manifest =
           new DataSetManifest(
               Instant.now(),

--- a/apps/bfd-pipeline/bfd-pipeline-rif-extract/src/main/java/gov/cms/bfd/pipeline/rif/extract/s3/DataSetTestUtilities.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rif-extract/src/main/java/gov/cms/bfd/pipeline/rif/extract/s3/DataSetTestUtilities.java
@@ -2,11 +2,13 @@ package gov.cms.bfd.pipeline.rif.extract.s3;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.Bucket;
+import com.amazonaws.services.s3.model.HeadBucketRequest;
 import com.amazonaws.services.s3.model.ListObjectsV2Request;
 import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.amazonaws.waiters.WaiterParameters;
 import gov.cms.bfd.pipeline.rif.extract.exceptions.ChecksumException;
 import gov.cms.bfd.pipeline.rif.extract.s3.DataSetManifest.DataSetManifestEntry;
 import gov.cms.bfd.pipeline.rif.extract.s3.task.ManifestEntryDownloadTask;
@@ -45,11 +47,13 @@ public class DataSetTestUtilities {
 
     Bucket bucket = s3Client.createBucket(bucketName);
     /*
-     * Note: S3's API is eventually consistent, so any calls to use this new bucket will
-     * intermittently fail for a brief period of time. The only solution to this is to retry all of
-     * those calls (because it's intermittent, we can't just check once here to see if the bucket is
-     * available).
+     * Note: S3's API is eventually consistent, so we want to wait for this new bucket to be
+     * available everywhere.
      */
+    s3Client
+        .waiters()
+        .bucketExists()
+        .run(new WaiterParameters<HeadBucketRequest>(new HeadBucketRequest(bucketName)));
 
     return bucket;
   }

--- a/apps/bfd-pipeline/bfd-pipeline-rif-extract/src/main/java/gov/cms/bfd/pipeline/rif/extract/s3/DataSetTestUtilities.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rif-extract/src/main/java/gov/cms/bfd/pipeline/rif/extract/s3/DataSetTestUtilities.java
@@ -41,7 +41,7 @@ public class DataSetTestUtilities {
     username.replaceAll("@", "-");
     username.replaceAll("\\\\", "-");
     int randomId = new Random().nextInt(100000);
-    String bucketName = String.format("bfd-test-%s-%d", username, randomId);
+    String bucketName = String.format("bb-test-%s-%d", username, randomId);
 
     Bucket bucket = s3Client.createBucket(bucketName);
     /*

--- a/apps/bfd-pipeline/bfd-pipeline-rif-extract/src/test/java/gov/cms/bfd/pipeline/rif/extract/s3/DataSetMonitorIT.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rif-extract/src/test/java/gov/cms/bfd/pipeline/rif/extract/s3/DataSetMonitorIT.java
@@ -9,7 +9,6 @@ import gov.cms.bfd.pipeline.rif.extract.ExtractionOptions;
 import gov.cms.bfd.pipeline.rif.extract.s3.DataSetManifest.DataSetManifestEntry;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Random;
 import org.awaitility.Awaitility;
 import org.awaitility.Duration;
 import org.junit.Assert;
@@ -51,13 +50,12 @@ public final class DataSetMonitorIT {
    */
   @Test
   public void emptyBucketTest() {
-    ExtractionOptions options =
-        new ExtractionOptions(String.format("bb-test-%d", new Random().nextInt(1000)));
-    AmazonS3 s3Client = S3Utilities.createS3Client(options);
+    AmazonS3 s3Client = S3Utilities.createS3Client(new ExtractionOptions("foo"));
     Bucket bucket = null;
     try {
       // Create the (empty) bucket to run against.
-      bucket = s3Client.createBucket(options.getS3BucketName());
+      bucket = DataSetTestUtilities.createTestBucket(s3Client);
+      ExtractionOptions options = new ExtractionOptions(bucket.getName());
       LOGGER.info(
           "Bucket created: '{}:{}'",
           s3Client.getS3AccountOwner().getDisplayName(),
@@ -89,16 +87,15 @@ public final class DataSetMonitorIT {
    */
   @Test
   public void multipleDataSetsTest() throws InterruptedException {
-    ExtractionOptions options =
-        new ExtractionOptions(String.format("bb-test-%d", new Random().nextInt(1000)));
-    AmazonS3 s3Client = S3Utilities.createS3Client(options);
+    AmazonS3 s3Client = S3Utilities.createS3Client(new ExtractionOptions("foo"));
     Bucket bucket = null;
     try {
       /*
        * Create the (empty) bucket to run against, and populate it with
        * two data sets.
        */
-      bucket = s3Client.createBucket(options.getS3BucketName());
+      bucket = DataSetTestUtilities.createTestBucket(s3Client);
+      ExtractionOptions options = new ExtractionOptions(bucket.getName());
       LOGGER.info(
           "Bucket created: '{}:{}'",
           s3Client.getS3AccountOwner().getDisplayName(),

--- a/apps/bfd-pipeline/bfd-pipeline-rif-extract/src/test/java/gov/cms/bfd/pipeline/rif/extract/s3/task/ManifestEntryDownloadTaskIT.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rif-extract/src/test/java/gov/cms/bfd/pipeline/rif/extract/s3/task/ManifestEntryDownloadTaskIT.java
@@ -23,7 +23,6 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
-import java.util.Random;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -45,12 +44,11 @@ public final class ManifestEntryDownloadTaskIT {
   @SuppressWarnings("deprecation")
   @Test
   public void testMD5ChkSum() throws Exception {
-    ExtractionOptions options =
-        new ExtractionOptions(String.format("bb-test-%d", new Random().nextInt(1000)));
-    AmazonS3 s3Client = S3Utilities.createS3Client(options);
+    AmazonS3 s3Client = S3Utilities.createS3Client(new ExtractionOptions("foo"));
     Bucket bucket = null;
     try {
-      bucket = s3Client.createBucket(options.getS3BucketName());
+      bucket = DataSetTestUtilities.createTestBucket(s3Client);
+      ExtractionOptions options = new ExtractionOptions(bucket.getName());
       LOGGER.info(
           "Bucket created: '{}:{}'",
           s3Client.getS3AccountOwner().getDisplayName(),


### PR DESCRIPTION
It's _almost_ the same as before, except now the "get a random bucket name" code is centralized, and improved:

1. Added a couple decimal places to the random number.
2. Added usernames to the generated strings, so that one person failing to clean up their mess shouldn't impact someone else.

There are still several other things that can cause intermittent test failures, but this was definitely the biggest offender.

https://jira.cms.gov/browse/BLUEBUTTON-850