### PR TITLE
BLUEBUTTON-1278: Update LB and SG's to use app port 7443 instead of 7743

### DIFF
--- a/ops/terraform/modules/stateless/main.tf
+++ b/ops/terraform/modules/stateless/main.tf
@@ -6,7 +6,7 @@
 locals {
   azs             = ["us-east-1a", "us-east-1b", "us-east-1c"]
   env_config      = {env=var.env_config.env, tags=var.env_config.tags, vpc_id=data.aws_vpc.main.id, zone_id=data.aws_route53_zone.local_zone.id, azs=local.azs}
-  port            = 7743
+  port            = 7443
   cw_period       = 60    # Seconds
   cw_eval_periods = 3
 }


### PR DESCRIPTION
We have a mismatch in our configuration. Instances are deployed and being bound to port 7443 but our LB and SG's are configured for 7743.  

This resolves BLUEBUTTON-1278