### PR TITLE
BLUEBUTTON-1135: Increase user level file descriptor limits

### DIFF
--- a/apps/bfd-pipeline/bfd-pipeline-benchmarks/src/test/ansible/roles/server_fhir/tasks/install.yml
+++ b/apps/bfd-pipeline/bfd-pipeline-benchmarks/src/test/ansible/roles/server_fhir/tasks/install.yml
@@ -123,3 +123,12 @@
 - name: Run 'server-config-healthapt.sh' to Configure FHIR Server
   command: "/usr/local/bluebutton-server-app/bluebutton-server-app-server-config-healthapt.sh --serverhome /usr/local/bluebutton-server-app/wildfly-8.1.0.Final --httpsport {{ fhir_port }} --keystore /usr/local/bluebutton-server-app/wildfly-8.1.0.Final/standalone/configuration/server-keystore.jks --truststore /usr/local/bluebutton-server-app/wildfly-8.1.0.Final/standalone/configuration/server-truststore.jks --war /usr/local/bluebutton-server-app/bfd-server-war.war --dburl jdbc:postgresql://{{ hostvars['rds']['endpoint'] }}:{{ hostvars['rds']['port'] }}/fhirdb --dbusername {{ postgres_master_username }} --dbpassword {{ postgres_master_password }} --dbconnectionsmax {{ fhir_db_connections }}"
   become: true
+  
+- name: Increase user level soft/hard FD limits
+  blockinfile:
+    path: /etc/security/limits.conf
+    insertbefore: '# End of file'
+    block: |
+      {{ data_server_user }} soft  nofile  999999
+      {{ data_server_user }} hard  nofile  999999
+  become: true


### PR DESCRIPTION
Ansible tasks to increase the user level file descriptor limits (both
hard and soft) to resolve the "too many open files" errors.