### PR TITLE
BLUEBUTTON-1112: Fix Jenkinsfile default for deploy_env in CCS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@ properties([
 		booleanParam(name: 'deploy_management', description: 'Whether to deploy/redeploy the management environment, which includes Jenkins. May cause the job to end early, if Jenkins is restarted.', defaultValue: false),
 		booleanParam(name: 'deploy_prod_skip_confirm', defaultValue: false, description: 'Whether to prompt for confirmation before deploying to most prod-like envs.'),
 		booleanParam(name: 'deploy_hhsdevcloud', description: 'Whether to deploy to the hhsdevcloud/"old sandbox" environment.', defaultValue: false),
-		booleanParam(name: 'build_platinum', description: 'Whether to build/update the "platinum" base AMI.', defaultValue: true)
+		booleanParam(name: 'build_platinum', description: 'Whether to build/update the "platinum" base AMI.', defaultValue: false)
 		//booleanParam(name: 'deploy_to_lss', description: 'Whether to run the Ansible plays for LSS systems (e.g. Jenkins itself).', defaultValue: false),
 		//booleanParam(name: 'deploy_to_prod', description: 'Whether to run the Ansible plays for PROD systems (without prompting first, which is the default behavior).', defaultValue: false)
 	]),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,6 +66,12 @@ stage('Prepare') {
 		// Grab the commit that triggered the build.
 		checkout scm
 
+		// Fix defaults for CCS environment.
+		if (env.JENKINS_URL.contains('cmscloud')) {
+			params.deploy_env = 'ccs'
+			params.build_platinum = true
+		}
+
 		// Load the child Jenkinsfiles.
 		scriptForApps = load('apps/build.groovy')
 		if (params.deploy_env == 'healthapt') {


### PR DESCRIPTION
The ultimate end goal is that auto-builds in the CCS environment "just work" as expected. As opposed to right now, where you have to manually kick off a hand-configured job to really test things.

Was hoping this'd be more of a one-line change, but it turns out that Jenkins' `params` object is read-only, so have to (kinda' sorta') shadow the variable, instead of updating it.

Note: There was another default-Jenkins-builds-don't-work-in-the-CCS issue, which was resolved in #45 (and has been merged in here now that that's accepted).