### PR TITLE
Remove import mode from TEST and PROD-SBX

### DIFF
--- a/ops/terraform/env/prod-sbx/stateful/main.tf
+++ b/ops/terraform/env/prod-sbx/stateful/main.tf
@@ -17,7 +17,7 @@ module "stateful" {
   }
 
   db_import_mode = {
-    enabled = true
+    enabled = false
     maintenance_work_mem = "1048576"
   }
 

--- a/ops/terraform/env/test/stateful/main.tf
+++ b/ops/terraform/env/test/stateful/main.tf
@@ -17,7 +17,7 @@ module "stateful" {
   }
 
   db_import_mode = {
-    enabled = true
+    enabled = false
     maintenance_work_mem = "4194304"
   }
 

--- a/ops/terraform/modules/stateful/main.tf
+++ b/ops/terraform/modules/stateful/main.tf
@@ -171,6 +171,12 @@ resource "aws_db_subnet_group" "db" {
 
 # Parameter Group
 #
+resource "aws_db_parameter_group" "default_mode" {
+  name        = "bfd-${local.env_config.env}-default-mode-parameter-group"
+  family      = "postgres9.6"
+  description = "Sets parameters for standard operation"
+}
+
 resource "aws_db_parameter_group" "import_mode" {
   name        = "bfd-${local.env_config.env}-import-mode-parameter-group"
   family      = "postgres9.6"
@@ -225,7 +231,7 @@ module "master" {
   vpc_security_group_ids = local.master_db_sgs
 
   apply_immediately    = var.db_import_mode.enabled
-  parameter_group_name = var.db_import_mode.enabled ? aws_db_parameter_group.import_mode.name : "default.postgres9.6"
+  parameter_group_name = var.db_import_mode.enabled ? aws_db_parameter_group.import_mode.name : aws_db_parameter_group.default_mode.name
 }
 
 # Replicas Database 
@@ -245,7 +251,7 @@ module "replica1" {
   vpc_security_group_ids = local.db_sgs
 
   apply_immediately    = var.db_import_mode.enabled
-  parameter_group_name = "default.postgres9.6"
+  parameter_group_name = aws_db_parameter_group.default_mode.name
 }
 
 module "replica2" {
@@ -261,7 +267,7 @@ module "replica2" {
   vpc_security_group_ids = local.db_sgs
 
   apply_immediately    = var.db_import_mode.enabled
-  parameter_group_name = "default.postgres9.6"
+  parameter_group_name = aws_db_parameter_group.default_mode.name
 }
 
 module "replica3" {
@@ -277,7 +283,7 @@ module "replica3" {
   vpc_security_group_ids = local.db_sgs
 
   apply_immediately    = var.db_import_mode.enabled
-  parameter_group_name = "default.postgres9.6"
+  parameter_group_name = aws_db_parameter_group.default_mode.name
 }
 
 # Cloud Watch alarms for each RDS instance

--- a/ops/terraform/modules/stateful/main.tf
+++ b/ops/terraform/modules/stateful/main.tf
@@ -225,7 +225,7 @@ module "master" {
   vpc_security_group_ids = local.master_db_sgs
 
   apply_immediately    = var.db_import_mode.enabled
-  parameter_group_name = var.db_import_mode.enabled ? aws_db_parameter_group.import_mode.name : null
+  parameter_group_name = var.db_import_mode.enabled ? aws_db_parameter_group.import_mode.name : "default.postgres9.6"
 }
 
 # Replicas Database 
@@ -245,7 +245,7 @@ module "replica1" {
   vpc_security_group_ids = local.db_sgs
 
   apply_immediately    = var.db_import_mode.enabled
-  parameter_group_name = null
+  parameter_group_name = "default.postgres9.6"
 }
 
 module "replica2" {
@@ -261,7 +261,7 @@ module "replica2" {
   vpc_security_group_ids = local.db_sgs
 
   apply_immediately    = var.db_import_mode.enabled
-  parameter_group_name = null
+  parameter_group_name = "default.postgres9.6"
 }
 
 module "replica3" {
@@ -277,7 +277,7 @@ module "replica3" {
   vpc_security_group_ids = local.db_sgs
 
   apply_immediately    = var.db_import_mode.enabled
-  parameter_group_name = null
+  parameter_group_name = "default.postgres9.6"
 }
 
 # Cloud Watch alarms for each RDS instance


### PR DESCRIPTION
When the RDS instances were built there was no parameter group specified, so a default group was assigned.  After RDS instances were assigned the import parameter group, setting them back to null did not trigger a change, we need to be explicit to set them back to defaults.  We could also create our own parameter group to pave the way for setting custom values as we need them.