### PR TITLE
BLUEBUTTON-1157: Correcting prod and prod-sbx to load the correct client certs.

### DIFF
--- a/ops/ansible/playbooks-ccs/vars/prod-sbx/group_vars/all/env_specific.yml
+++ b/ops/ansible/playbooks-ccs/vars/prod-sbx/group_vars/all/env_specific.yml
@@ -1,5 +1,5 @@
 ---
-
+  
 # Version of the ETL Jar to deploy 
 data_pipeline_version: '0.1.0-SNAPSHOT'
 
@@ -7,24 +7,21 @@ data_pipeline_version: '0.1.0-SNAPSHOT'
 s3_bucket_deployment: 'bfd-mgmt-artifacts-577373831711'
 
 # Name of ETL Staging Bucket 
-s3_bucket_etl_staging: 'bfd-prod-sbx-etl-577373831711'
-
-# The abbreviated name for this environment, per the naming conventions used by HealthAPT.
-# env_name: 'ts'
+s3_bucket_etl_staging: 'bfd-prod-etl-577373831711'
 
 # The abbreviated name for this environment, per https://confluence.cms.gov/display/ODI/AWS+Naming+and+Tagging+Conventions.
 env_name_std: 'prod-sbx'
 
-# This system is an m4.2xlarge (8 vCPUs, 32 GB RAM).
-data_pipeline_ec2_instance_type_mem_mib: "{{ 32 * 1024 }}"
-data_pipeline_ec2_instance_type_vcpu: 8
+# This system is an m5.xlarge (4 vCPUs, 16 GB RAM).
+data_pipeline_ec2_instance_type_mem_mib: "{{ 16 * 1024 }}"
+data_pipeline_ec2_instance_type_vcpu: 4
 
-# There is no ongoing data refresh here: if we're loading data in test, it should be an initial
+# There is no ongoing data refresh here: if we're loading data in the developer preview environment, it should be an initial
 # load.
 data_pipeline_idempotency_required: false
 
-# These systems are m4.large (2 vCPUs, 8 GB RAM).
-data_server_ec2_instance_type_mem_mib: "{{ 8 * 1024 }}"
+# These systems are m5.xlarge (4 vCPUs, 16 GB RAM).
+data_server_ec2_instance_type_mem_mib: "{{ 16 * 1024 }}"
 
 # The path (in this project) to the test keypair that will be copied to the Data Servers for local-only testing.
 # Note: This file is encrypted with Ansible Vault and will be automagically encrypted during the copy.
@@ -32,11 +29,23 @@ data_server_ssl_client_certificate_test: 'files/client_data_server_local_test_en
 
 # These are the SSL keypairs authorized to query this environment's Data Servers.
 data_server_ssl_client_certificates:
-  - alias: client_local_test_env_test
-    certificate: "{{ lookup('file', 'files/client_data_server_local_test_env_test_certificate.pem') }}"
+  - alias: client_local_test_env_dpr
+    certificate: "{{ lookup('file', 'files/client_data_server_local_test_env_dpr_certificate.pem') }}"
   - alias: client_bluebutton_frontend_dev
     certificate: "{{ lookup('file', 'files/client_data_server_bluebutton_frontend_dev_certificate.pem') }}"
   - alias: client_bluebutton_frontend_test
     certificate: "{{ lookup('file', 'files/client_data_server_bluebutton_frontend_test_certificate.pem') }}"
+  - alias: client_bluebutton_frontend_sbx
+    certificate: "{{ lookup('file', 'files/client_data_server_bluebutton_frontend_sbx_certificate.pem') }}"
+  - alias: client_bcda_dev
+    certificate: "{{ lookup('file', 'files/client_data_server_bcda_dev_certificate.pem') }}"
+  - alias: client_bcda_test
+    certificate: "{{ lookup('file', 'files/client_data_server_bcda_test_certificate.pem') }}"
+  - alias: client_bcda_sbx
+    certificate: "{{ lookup('file', 'files/client_data_server_bcda_sbx_certificate.pem') }}"
+  - alias: client_mct_test
+    certificate: "{{ lookup('file', 'files/client_data_server_mct_test_certificate.pem') }}"
+  - alias: client_mct_imp
+    certificate: "{{ lookup('file', 'files/client_data_server_mct_imp_certificate.pem') }}"
   - alias: client_performance_tester
     certificate: "{{ lookup('file', 'files/client_data_server_performance_tester_certificate.pem') }}"

--- a/ops/ansible/playbooks-ccs/vars/prod-sbx/group_vars/all/env_specific.yml
+++ b/ops/ansible/playbooks-ccs/vars/prod-sbx/group_vars/all/env_specific.yml
@@ -7,7 +7,7 @@ data_pipeline_version: '0.1.0-SNAPSHOT'
 s3_bucket_deployment: 'bfd-mgmt-artifacts-577373831711'
 
 # Name of ETL Staging Bucket 
-s3_bucket_etl_staging: 'bfd-prod-etl-577373831711'
+s3_bucket_etl_staging: 'bfd-prod-sbx-etl-577373831711'
 
 # The abbreviated name for this environment, per https://confluence.cms.gov/display/ODI/AWS+Naming+and+Tagging+Conventions.
 env_name_std: 'prod-sbx'

--- a/ops/ansible/playbooks-ccs/vars/prod/group_vars/all/env_specific.yml
+++ b/ops/ansible/playbooks-ccs/vars/prod/group_vars/all/env_specific.yml
@@ -9,9 +9,6 @@ s3_bucket_deployment: 'bfd-mgmt-artifacts-577373831711'
 # Name of ETL Staging Bucket 
 s3_bucket_etl_staging: 'bfd-prod-etl-577373831711'
 
-# The abbreviated name for this environment, per the naming conventions used by HealthAPT.
-env_name: 'pd'
-
 # The abbreviated name for this environment, per https://confluence.cms.gov/display/ODI/AWS+Naming+and+Tagging+Conventions.
 env_name_std: 'prod'
 


### PR DESCRIPTION
# Why
We need the correct client certs installed for each environment. I goofed and a copy/paste issue is causing us to deploy certs configured for the TEST environment to all our environments. 

# What

Updated variable data_server_ssl_client_certificates for both prod-sbx and prod to reflect the correct client certs. 