### PR TITLE
BLUEBUTTON-1257: Fix Ansible

### DIFF
--- a/ops/ansible/playbooks-ccs/build_bfd-server.yml
+++ b/ops/ansible/playbooks-ccs/build_bfd-server.yml
@@ -18,15 +18,6 @@
       include_vars:
         dir: vars/{{ env }}
       tags: [pre-ami, post-ami]
-
-    # Before the bfd-server role copy the keystore file 
-    - name: Copy the appserver keystore  
-      copy:
-        # Note: this JKS file is encrypted via the Ansible Vault 
-        src: "{{ data_server_appserver_keystore }}"
-        dest: '/jboss/bluebutton-appserver-keystore.jks'
-      tags:
-        - pre-ami
       
     - name: Apply Blue Button Data Server Role
       import_role:
@@ -51,6 +42,16 @@
         data_server_db_username: "{{ vault_data_server_db_username }}"
         data_server_db_password: "{{ vault_data_server_db_password }}"
         data_server_db_connections_max: 400
+
+    # Overwrite bfd-server role copy of the keystore file 
+    - name: Copy the appserver keystore  
+      copy:
+        # Note: this JKS file is encrypted via the Ansible Vault 
+        src: "{{ data_server_appserver_keystore }}"
+        dest: '/jboss/bluebutton-appserver-keystore.jks'
+        force: yes # overwrite the existing keystore
+      tags:
+        - pre-ami
         
     - name: Copy Local Test SSL Keypair
       copy:


### PR DESCRIPTION
**Why**
My last PR had a bug that wasn't caught. This PR fixes our build-server.yml ansible playbook. 

**What Changed**
The copy keystore task had to order to after the /jboss directory was created. 

**Verification Done**
Built the AMI and deployed to test env. Smoke test run.  