### PR TITLE
BLUEBUTTON-1157: Make deployed commit available to user_data script

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -146,7 +146,9 @@ stage('Deploy to TEST') {
 	milestone(label: 'stage_deploy_test_start')
 
 	node {
-		scriptForDeploys.deploy('test', amiIds, appBuildResults)
+		gitBranchName = env.BRANCH_NAME
+		gitCommitId = env.GIT_COMMIT
+		scriptForDeploys.deploy('test', gitBranchName, gitCommitId, amiIds, appBuildResults)
 	}
 
 }

--- a/ops/deploy-ccs.groovy
+++ b/ops/deploy-ccs.groovy
@@ -186,7 +186,7 @@ def buildAppAmis(String environmentId, AmiIds amiIds, AppBuildResults appBuildRe
  * @param appBuildResults (not used in the CCS environment; this stuff is all baked into the AMIs there, instead)
  * @throws RuntimeException An exception will be bubbled up if the deploy tooling returns a non-zero exit code.
  */
-def deploy(String environmentId, AmiIds amiIds, AppBuildResults appBuildResults) {
+def deploy(String environmentId, String gitBranchName, String gitCommitId, AmiIds amiIds, AppBuildResults appBuildResults) {
 	def env = normalizeEnvironmentId(environmentId)
 		dir("${workspace}/ops/terraform/env/${env}/stateless") {
 
@@ -201,12 +201,14 @@ def deploy(String environmentId, AmiIds amiIds, AppBuildResults appBuildResults)
 		-var='fhir_ami=${amiIds.bfdServerAmiId}' \
 		-var='etl_ami=${amiIds.bfdPipelineAmiId}' \
 		-var='ssh_key_name=bfd-${env}' \
+		-var='git_branch_name=${gitBranchName}' \
+		-var='git_commit_id=${gitCommitId}' \
 		-no-color -out=tfplan"
 		
 		// Apply Terraform plan
 		sh "/usr/bin/terraform apply \
 		-no-color -input=false tfplan"
-	}
+		}
 }
 
 

--- a/ops/terraform/env/test/stateless/main.tf
+++ b/ops/terraform/env/test/stateless/main.tf
@@ -18,4 +18,6 @@ module "stateless" {
   fhir_ami            = var.fhir_ami
   etl_ami             = var.etl_ami
   ssh_key_name        = var.ssh_key_name
+  git_branch_name     = var.git_branch_name
+  git_commit_id       = var.git_commit_id
 }

--- a/ops/terraform/env/test/stateless/variables.tf
+++ b/ops/terraform/env/test/stateless/variables.tf
@@ -12,3 +12,13 @@ variable "ssh_key_name" {
   description       = "SSH Key"
   type              = string
 }
+
+variable "git_branch_name" {
+  description       = "git branch of beneficiary-fhir-data"
+  type              = string
+}
+
+variable "git_commit_id" {
+  description       = "git commit of beneficiary-fhir-data"
+  type              = string
+}

--- a/ops/terraform/modules/resources/asg/main.tf
+++ b/ops/terraform/modules/resources/asg/main.tf
@@ -131,9 +131,11 @@ resource "aws_launch_template" "main" {
   }
   
   user_data = base64encode(templatefile("${path.module}/../templates/${var.launch_config.user_data_tpl}", {
-    env       = var.env_config.env
-    port      = var.lb_config.port
-    accountId = var.launch_config.account_id
+    env           = var.env_config.env
+    port          = var.lb_config.port
+    accountId     = var.launch_config.account_id
+    gitBranchName = var.launch_config.git_branch
+    gitCommitId   = var.launch_config.git_branch
   }))
 
   tag_specifications {

--- a/ops/terraform/modules/resources/asg/variables.tf
+++ b/ops/terraform/modules/resources/asg/variables.tf
@@ -34,7 +34,7 @@ variable "mgmt_config" {
 }
 
 variable "launch_config" {
-  type        = object({instance_type=string, volume_size=number, ami_id=string, key_name=string, profile=string, user_data_tpl=string, account_id=string})
+  type        = object({instance_type=string, volume_size=number, ami_id=string, key_name=string, profile=string, user_data_tpl=string, account_id=string, git_branch=string, git_commit=string})
 }
 
 

--- a/ops/terraform/modules/resources/ec2/main.tf
+++ b/ops/terraform/modules/resources/ec2/main.tf
@@ -102,5 +102,7 @@ resource "aws_instance" "main" {
   user_data                   = templatefile("${path.module}/../templates/${var.launch_config.user_data_tpl}", {
     env    = var.env_config.env,
     accountId = data.aws_caller_identity.current.account_id
+    gitBranchName = var.launch_config.git_branch
+    gitCommitId = var.launch_config.git_commit
   })
 }

--- a/ops/terraform/modules/resources/ec2/variables.tf
+++ b/ops/terraform/modules/resources/ec2/variables.tf
@@ -22,7 +22,7 @@ variable "mgmt_config" {
 }
 
 variable "launch_config" {
-  type        = object({instance_type=string, volume_size=number, ami_id=string, key_name=string, profile=string, user_data_tpl=string})
+  type        = object({instance_type=string, volume_size=number, ami_id=string, key_name=string, profile=string, user_data_tpl=string, git_branch=string, git_commit=string})
 }
 
 

--- a/ops/terraform/modules/resources/templates/fhir_server.tpl
+++ b/ops/terraform/modules/resources/templates/fhir_server.tpl
@@ -3,8 +3,11 @@ set -e
 
 exec > >(tee -a /var/log/user_data.log 2>&1)
 
-git clone https://github.com/CMSgov/beneficiary-fhir-data.git
+git clone https://github.com/CMSgov/beneficiary-fhir-data.git --branch ${gitBranchName} --single-branch
+
 cd beneficiary-fhir-data/ops/ansible/playbooks-ccs/
+
+git checkout ${gitCommitId}
 
 aws s3 cp s3://bfd-mgmt-admin-${accountId}/ansible/vault.password .
 

--- a/ops/terraform/modules/resources/templates/pipeline_server.tpl
+++ b/ops/terraform/modules/resources/templates/pipeline_server.tpl
@@ -3,8 +3,11 @@ set -e
 
 exec > >(tee -a /var/log/user_data.log 2>&1)
 
-git clone https://github.com/CMSgov/beneficiary-fhir-data.git
+git clone https://github.com/CMSgov/beneficiary-fhir-data.git --branch ${gitBranchName} --single-branch
+
 cd beneficiary-fhir-data/ops/ansible/playbooks-ccs/
+
+git checkout ${gitCommitId}
 
 aws s3 cp s3://bfd-mgmt-admin-${accountId}/ansible/vault.password .
 

--- a/ops/terraform/modules/stateless/main.tf
+++ b/ops/terraform/modules/stateless/main.tf
@@ -189,14 +189,16 @@ module "fhir_asg" {
   # TODO: Dummy values to get started
   launch_config   = {
 
-    instance_type = "m5.2xlarge" 
-    volume_size   = 100 # GB
-    ami_id        = var.fhir_ami 
-    key_name      = var.ssh_key_name 
+    instance_type   = "m5.2xlarge" 
+    volume_size     = 100 # GB
+    ami_id          = var.fhir_ami 
+    key_name        = var.ssh_key_name 
 
-    profile       = module.fhir_iam.profile
-    user_data_tpl = "fhir_server.tpl"       # See templates directory for choices
-    account_id    = data.aws_caller_identity.current.account_id
+    profile         = module.fhir_iam.profile
+    user_data_tpl   = "fhir_server.tpl"       # See templates directory for choices
+    account_id      = data.aws_caller_identity.current.account_id
+    git_branch      = var.git_branch_name
+    git_commit      = var.git_commit_id
   }
 
   db_config       = {
@@ -232,6 +234,8 @@ module "etl_instance" {
     key_name      = var.ssh_key_name 
     profile       = module.etl_iam.profile
     user_data_tpl = "pipeline_server.tpl"
+    git_branch    = var.git_branch_name
+    git_commit    = var.git_commit_id
   }
 
   mgmt_config     = {

--- a/ops/terraform/modules/stateless/variables.tf
+++ b/ops/terraform/modules/stateless/variables.tf
@@ -17,3 +17,13 @@ variable "ssh_key_name" {
   description       = "SSH Key"
   type              = string
 }
+
+variable "git_branch_name" {
+  description       = "git branch of beneficiary-fhir-data"
+  type              = string
+}
+
+variable "git_commit_id" {
+  description       = "git commit of beneficiary-fhir-data"
+  type              = string
+}


### PR DESCRIPTION
# What

This PR supplies the specific git branch and git commit used during the build pipeline and makes it available to terraform to pass along to user_data 

# Why

... so that during post bake of the AMI this commit is checked out to finalize the deployment thus keeping all stages of the pipeline in sync with a specific branch / commit. 

# Testing

Built and Deployed this PR to TEST with successful results. Jumped on instance to confirm the branch was cloned and commit was checked out and used to complete the user_data script. 

# Improves

BLUEBUTTON-1157