### PR TITLE
BLUEBUTTON-1257: Migrate BB and BCDA prod-sbx traffic 

### DIFF
--- a/ops/terraform/env/prod-sbx/migration/main.tf
+++ b/ops/terraform/env/prod-sbx/migration/main.tf
@@ -18,5 +18,5 @@ module "migration" {
   bb      = 100
   bcda    = 100
   dpc     = 100
-  mct     = 0
+  mct     = 100
 }

--- a/ops/terraform/env/prod-sbx/migration/main.tf
+++ b/ops/terraform/env/prod-sbx/migration/main.tf
@@ -15,8 +15,8 @@ module "migration" {
     tags              = {application="bfd", business="oeda", stack="prod-sbx", Environment="prod-sbx"}
   }  
 
-  bb      = 0
-  bcda    = 0
-  dpc     = 0
+  bb      = 100
+  bcda    = 100
+  dpc     = 100
   mct     = 0
 }

--- a/ops/terraform/env/test/migration/main.tf
+++ b/ops/terraform/env/test/migration/main.tf
@@ -18,5 +18,5 @@ module "migration" {
   bb      = 100
   bcda    = 100
   dpc     = 100
-  mct     = 0
+  mct     = 100
 }

--- a/ops/terraform/env/test/migration/main.tf
+++ b/ops/terraform/env/test/migration/main.tf
@@ -15,8 +15,8 @@ module "migration" {
     tags              = {application="bfd", business="oeda", stack="test", Environment="test"}
   }  
 
-  bb      = 0
-  bcda    = 0
-  dpc     = 0
+  bb      = 100
+  bcda    = 100
+  dpc     = 100
   mct     = 0
 }


### PR DESCRIPTION
**Why**
As the first step of the migration to the CCS environment, move prod-sbx traffic from health-apt to the CCS environment.

**What**
Altered the weighting records for the prod-sbx.bfdcloud.net and test.bfdcloud.net domains to point to the CCS environment. Already applied to test and prod-sbx. 
