### PR TITLE
Startup smoke testing for data server

### DIFF
--- a/ops/ansible/playbooks-ccs/vars/test/group_vars/all/env_specific.yml
+++ b/ops/ansible/playbooks-ccs/vars/test/group_vars/all/env_specific.yml
@@ -44,3 +44,6 @@ data_server_ssl_client_certificates:
     certificate: "{{ lookup('file', 'files/client_data_server_bluebutton_frontend_test_certificate.pem') }}"
   - alias: client_performance_tester
     certificate: "{{ lookup('file', 'files/client_data_server_performance_tester_certificate.pem') }}"
+
+# Feature toggle for startup wrapper script that performs smoke testing on boot
+data_server_startup_wrapper: true

--- a/ops/ansible/roles/bfd-server/tasks/appserver_install.yml
+++ b/ops/ansible/roles/bfd-server/tasks/appserver_install.yml
@@ -20,6 +20,18 @@
   tags: 
     - pre-ami
 
+- name: Create App Server Startup Wrapper Script
+  template:
+    src: bluebutton-appserver-start.sh.j2
+    dest: "{{ data_server_dir }}/bluebutton-appserver-start.sh"
+    owner: "{{ data_server_user }}"
+    group: "{{ data_server_user }}"
+    mode: u=rwx,g=rwx,o=rx
+  become: true
+  when: data_server_startup_wrapper
+  tags:
+    - pre-ami
+
 - name: Create App Server Service Definition
   template:
     src: bluebutton-appserver.service.j2

--- a/ops/ansible/roles/bfd-server/templates/bluebutton-appserver-start.sh.j2
+++ b/ops/ansible/roles/bfd-server/templates/bluebutton-appserver-start.sh.j2
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+STARTUP_TIMEOUT=30
+REQ_TIMEOUT=15
+REQ_BACKOFF_TIMEOUT=10
+
+check_endpoint() {
+  curl --max-time $REQ_TIMEOUT --silent --insecure --cert-type pem --cert /jboss/bluebutton-backend-test-data-server-client-test-keypair.pem "$1" | grep "$2"
+}
+
+stop_service_if_failing() {
+  echo "$(date): Waiting $STARTUP_TIMEOUT seconds for initial startup"
+  sleep $STARTUP_TIMEOUT
+
+  for I in 1 2 3; do
+    echo "$(date): Checking metadata endpoint"
+    CHECK_METADATA=$(check_endpoint 'https://localhost:7443/v1/fhir/metadata?_format=application%2Fjson%2Bfhir' 'status')
+    CHECK_METADATA_EXIT=$?
+
+    echo "$(date): Checking database endpoint"
+    CHECK_DATABASE=$(check_endpoint 'https://localhost:7443/v1/fhir/Coverage?beneficiary=-201&_format=application%2Fjson%2Bfhir' 'id')
+    CHECK_DATABASE_EXIT=$?
+
+    if [[ $CHECK_METADATA_EXIT == 0 ]] && [[ $CHECK_DATABASE_EXIT == 0 ]]; then
+      echo "$(date): Server started properly"
+      return 0
+    elif [[ $I != 3 ]]; then
+      echo "$(date): Server failed to start properly, backing off"
+      sleep $REQ_BACKOFF_TIMEOUT
+    fi
+  done
+
+  echo "$(date): Server failed to start properly, shutting down"
+  JBOSS_PID=$(ps -ef | grep '\-Dbfd-server' | grep -v grep | awk '{print $2}')
+  JBOSS_PID_EXIT=$?
+
+  if [[ $JBOSS_PID_EXIT == 0 ]] && [[ kill -INT $JBOSS_PID ]]; then
+    echo "$(date): Server shut down gracefully"
+  else
+    echo "$(date): Error shutting down server gracefully"
+  fi
+  return 1
+}
+
+(stop_service_if_failing >>/jboss/bluebutton-appserver-start.log 2>&1) &
+/jboss/wildfly-8.1.0.Final/bin/standalone.sh

--- a/ops/ansible/roles/bfd-server/templates/bluebutton-appserver.service.j2
+++ b/ops/ansible/roles/bfd-server/templates/bluebutton-appserver.service.j2
@@ -5,7 +5,11 @@ After=network.target network-online.target
 
 [Service]
 WorkingDirectory={{ data_server_dir }}
+{% if data_server_startup_wrapper %}
+ExecStart={{ data_server_dir }}/bluebutton-appserver-start.sh
+{% else %}
 ExecStart={{ data_server_dir }}/{{ data_server_container_name }}/bin/standalone.sh
+{% endif %}
 User={{ data_server_user }}
 
 [Install]


### PR DESCRIPTION
Getting this out there for feedback.  The main issue right now is there are a few values that are hardcoded outside of the scope of the bfd-server role (local testing cert and wildfly version) so I can't think of a good way of grabbing them.