### PR TITLE
Tag AMI's, user_data commit checkout and disable prod builds. 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -137,7 +137,9 @@ if (deployEnvironment == 'ccs') {
 		milestone(label: 'stage_build_app_amis_test_start')
 
 		node {
-			amiIds = scriptForDeploys.buildAppAmis('test', amiIds, appBuildResults)
+			gitBranchName = env.BRANCH_NAME
+			gitCommitId = checkout(scm).GIT_COMMIT
+			amiIds = scriptForDeploys.buildAppAmis('test', gitBranchName, gitCommitId, amiIds, appBuildResults)
 		}
 	}
 }
@@ -147,7 +149,7 @@ stage('Deploy to TEST') {
 
 	node {
 		gitBranchName = env.BRANCH_NAME
-		gitCommitId = env.GIT_COMMIT
+		gitCommitId = scmVars.GIT_COMMIT
 		scriptForDeploys.deploy('test', gitBranchName, gitCommitId, amiIds, appBuildResults)
 	}
 
@@ -198,7 +200,9 @@ if (deployEnvironment == 'ccs') {
 			milestone(label: 'stage_build_app_amis_prod-sbx_start')
 
 			node {
-				amiIds = scriptForDeploys.buildAppAmis('prod-stg', amiIds, appBuildResults)
+				gitBranchName = env.BRANCH_NAME
+				gitCommitId = scmVars.GIT_COMMIT
+				amiIds = scriptForDeploys.buildAppAmis('prod-stg', gitBranchName, gitCommitId, amiIds, appBuildResults)
 			}
 		}
 	}
@@ -210,7 +214,9 @@ stage('Deploy to prod-stg') {
 			milestone(label: 'stage_deploy_prod_stg_start')
 
 			node {
-				scriptForDeploys.deploy('prod-stg', amiIds, appBuildResults)
+				gitBranchName = env.BRANCH_NAME
+				gitCommitId = scmVars.GIT_COMMIT
+				scriptForDeploys.deploy('prod-stg', gitBranchName, gitCommitId, amiIds, appBuildResults)
 			}
 		}
 	} else {
@@ -219,12 +225,14 @@ stage('Deploy to prod-stg') {
 }
 
 if (deployEnvironment == 'ccs') {
-	if (willDeployToProdEnvs) {
+	if (willDeployToProdEnvs && deployEnvironment != 'ccs') {
 		stage('Build App AMIs for PROD') {
 			milestone(label: 'stage_build_app_amis_prod_start')
 
 			node {
-				amiIds = scriptForDeploys.buildAppAmis('prod', amiIds, appBuildResults)
+				gitBranchName = env.BRANCH_NAME
+				gitCommitId = scmVars.GIT_COMMIT
+				amiIds = scriptForDeploys.buildAppAmis('prod', gitBranchName, gitCommitId, amiIds, appBuildResults)
 			}
 		}
 	}
@@ -236,7 +244,9 @@ stage('Deploy to prod') {
 			milestone(label: 'stage_deploy_prod_start')
 
 			node {
-				scriptForDeploys.deploy('prod', amiIds, appBuildResults)
+				gitBranchName = env.BRANCH_NAME
+				gitCommitId = scmVars.GIT_COMMIT
+				scriptForDeploys.deploy('prod', gitBranchName, gitCommitId, amiIds, appBuildResults)
 			}
 		}
 	} else {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -225,8 +225,9 @@ stage('Deploy to prod-stg') {
 }
 
 if (deployEnvironment == 'ccs') {
-	if (willDeployToProdEnvs && deployEnvironment != 'ccs') {
-		stage('Build App AMIs for PROD') {
+	stage('Build App AMIs for PROD') {
+		if (willDeployToProdEnvs && deployEnvironment != 'ccs') {
+			// Note: CCS prod deploys are disabled for the moment, and so this block is unreachable.
 			milestone(label: 'stage_build_app_amis_prod_start')
 
 			node {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -149,7 +149,7 @@ stage('Deploy to TEST') {
 
 	node {
 		gitBranchName = env.BRANCH_NAME
-		gitCommitId = scmVars.GIT_COMMIT
+		gitCommitId = checkout(scm).GIT_COMMIT
 		scriptForDeploys.deploy('test', gitBranchName, gitCommitId, amiIds, appBuildResults)
 	}
 
@@ -201,7 +201,7 @@ if (deployEnvironment == 'ccs') {
 
 			node {
 				gitBranchName = env.BRANCH_NAME
-				gitCommitId = scmVars.GIT_COMMIT
+				gitCommitId = checkout(scm).GIT_COMMIT
 				amiIds = scriptForDeploys.buildAppAmis('prod-stg', gitBranchName, gitCommitId, amiIds, appBuildResults)
 			}
 		}
@@ -215,7 +215,7 @@ stage('Deploy to prod-stg') {
 
 			node {
 				gitBranchName = env.BRANCH_NAME
-				gitCommitId = scmVars.GIT_COMMIT
+				gitCommitId = checkout(scm).GIT_COMMIT
 				scriptForDeploys.deploy('prod-stg', gitBranchName, gitCommitId, amiIds, appBuildResults)
 			}
 		}
@@ -231,7 +231,7 @@ if (deployEnvironment == 'ccs') {
 
 			node {
 				gitBranchName = env.BRANCH_NAME
-				gitCommitId = scmVars.GIT_COMMIT
+				gitCommitId = checkout(scm).GIT_COMMIT
 				amiIds = scriptForDeploys.buildAppAmis('prod', gitBranchName, gitCommitId, amiIds, appBuildResults)
 			}
 		}
@@ -245,7 +245,7 @@ stage('Deploy to prod') {
 
 			node {
 				gitBranchName = env.BRANCH_NAME
-				gitCommitId = scmVars.GIT_COMMIT
+				gitCommitId = checkout(scm).GIT_COMMIT
 				scriptForDeploys.deploy('prod', gitBranchName, gitCommitId, amiIds, appBuildResults)
 			}
 		}

--- a/ops/deploy-ccs.groovy
+++ b/ops/deploy-ccs.groovy
@@ -130,10 +130,10 @@ def deployManagement(AmiIds amiIds) {
  * @return a new {@link AmiIds} instance detailing the shiny new AMIs that are now available for use
  * @throws RuntimeException An exception will be bubbled up if the AMI-builder tooling returns a non-zero exit code.
  */
-def buildAppAmis(String environmentId, AmiIds amiIds, AppBuildResults appBuildResults) {
+def buildAppAmis(String environmentId, String gitBranchName, String gitCommitId, AmiIds amiIds, AppBuildResults appBuildResults) {
 	dir('ops/ansible/playbooks-ccs'){
 		withCredentials([file(credentialsId: 'bluebutton-ansible-playbooks-data-ansible-vault-password', variable: 'vaultPasswordFile')]) {
-
+ 
 			// both packer builds expect additional variables in a file called `extra_vars.json` in the current directory
 		
 			def varsFile = new File("${workspace}/ops/ansible/playbooks-ccs/extra_vars.json")
@@ -157,6 +157,8 @@ def buildAppAmis(String environmentId, AmiIds amiIds, AppBuildResults appBuildRe
 				-var 'source_ami=${amiIds.platinumAmiId}' \
 				-var 'subnet_id=subnet-092c2a68bd18b34d1' \
 				-var 'env=${environmentId}' \
+				-var 'git_branch=${gitBranchName}' \
+				-var 'git_commit=${gitCommitId}' \
 				../../packer/build_bfd-pipeline.json"
 
 			// build the FHIR server
@@ -165,6 +167,8 @@ def buildAppAmis(String environmentId, AmiIds amiIds, AppBuildResults appBuildRe
 				-var 'source_ami=${amiIds.platinumAmiId}' \
 				-var 'subnet_id=subnet-092c2a68bd18b34d1' \
 				-var 'env=${environmentId}' \
+				-var 'git_branch=${gitBranchName}' \
+				-var 'git_commit=${gitCommitId}' \
 				../../packer/build_bfd-server.json"
 
 			return new AmiIds(

--- a/ops/packer/build_bfd-pipeline.json
+++ b/ops/packer/build_bfd-pipeline.json
@@ -18,14 +18,18 @@
           "tag:Name": "bfd-mgmt-vpn-private"
         }
       },
-      "ami_name": "bfd-etl-{{isotime \"20060102030405\"}}",
+      "ami_name": "bfd-etl-{{user `env`}}-{{isotime \"20060102030405\"}}",
       "ssh_pty": true,
       "tags": {
-        "Name": "bfd-etl-{{isotime \"20060102030405\"}}",
-        "Application": "bfd-etl"
+        "Name": "bb-{{user `env`}}-{{isotime \"20060102030405\"}}",
+        "Application": "BFD",
+        "Environment": "{{user `env`}}",
+        "Function": "ETL APP SERVER",
+        "Layer": "APP",
+        "Branch": "{{user `git_branch`}}",
+        "Commit": "{{user `git_commit`}}"
       }
-    }
-  ],
+  }],
   "provisioners": [{
       "type": "ansible",
       "playbook_file": "./build_bfd-pipeline.yml",

--- a/ops/packer/build_bfd-server.json
+++ b/ops/packer/build_bfd-server.json
@@ -19,14 +19,18 @@
           "tag:Name": "bfd-mgmt-vpn-private"
         }
       },
-      "ami_name": "bfd-fhir-{{isotime \"20060102030405\"}}",
+      "ami_name": "bfd-fhir-{{user `env`}}-{{isotime \"20060102030405\"}}",
       "ssh_pty": true,
       "tags": {
-        "Name": "bfd-fhir-{{isotime \"20060102030405\"}}",
-        "Application": "bfd-fhir"
+        "Name": "bfd-fhir-{{user `env`}}-{{isotime \"20060102030405\"}}",
+        "Application": "BFD",
+        "Environment": "{{user `env`}}",
+        "Function": "FHIR APP SERVER",
+        "Layer": "APP",
+        "Branch": "{{user `git_branch`}}",
+        "Commit": "{{user `git_commit`}}"
       }
-    }
-  ],
+  }],
   "provisioners": [{
       "type": "ansible",
       "playbook_file": "./build_bfd-server.yml",


### PR DESCRIPTION
# What & Why

This PR address one main feature, a bug fix and a deployment modifications so that we can tag our AMIs to give insights into its contents, provide the git commit to our user_data script so that we post-ami config with the same code as we built with, and to disable prod AMI building until we're cleared for prod launch, respectively. 

# Resolves

BLUEBUTTON-1312 - Feature - Tag AMI's
BLUEBUTTON-1157 - Bug - Build and Deploy (user_data script)
BLUEBUTTON-1314 - Feature - Disable PROD AMI Builds. 



