### PR TITLE
Fix to always pull last AMI ID from packer manifest

### DIFF
--- a/ops/deploy-ccs.groovy
+++ b/ops/deploy-ccs.groovy
@@ -221,7 +221,7 @@ def extractAmiIdFromPackerManifest(File manifest) {
 		def manifestJson = new JsonSlurper().parseText(manifest.text)
 
 		// artifactId will be of the form $region:$amiId
-		return manifestJson.builds[0].artifact_id.split(":")[1]
+		return manifestJson.builds[manifestJson.builds.size() - 1].artifact_id.split(":")[1]
 	}
 }
 


### PR DESCRIPTION
I think this bug occurred because there was an assumption that packer would overwrite the old manifest on every run.  However packer is "intelligent" in that it actually appends to an existing manifest if detected.  This ensures that if the manifest has multiple entires, we always pull the last addition.

Tested in Jenkins script console.