### PR TITLE
BLUEBUTTON-1298: Fixed errors from Jenkinsfile syntax and JBoss service

### DIFF
--- a/ops/ansible/roles/bfd-server/handlers/enable_appserver.yml
+++ b/ops/ansible/roles/bfd-server/handlers/enable_appserver.yml
@@ -4,6 +4,10 @@
 # Reloads the system's service definitions.
 ##
 
+- name: Reload Service Daemons
+  command: /usr/bin/systemctl daemon-reload
+  become: true
+
 - name: Enable App Server Service
   command: /usr/bin/systemctl --system enable "{{ data_server_appserver_service }}"
   become: true

--- a/ops/ansible/roles/bfd-server/tasks/appserver_config.yml
+++ b/ops/ansible/roles/bfd-server/tasks/appserver_config.yml
@@ -1,5 +1,21 @@
 ---
 
+# Duplicating this task from the `appserver_install.yml` file is a temporary hack to support
+# switching between JBoss and Jetty, while the switch to Jetty is still in development.
+- name: Create App Server Service Definition
+  template:
+    src: bluebutton-appserver.service.j2
+    dest: "/etc/systemd/system/{{ data_server_appserver_service }}.service"
+    owner: root
+    group: root
+    mode: u=rw,g=r,o=r
+  become: true
+  notify:
+    - 'Enable App Server Service'
+    - 'Restart App Server Service'
+  tags: 
+    - pre-ami
+
 - name: Create App Server 'standalone.conf' File
   template:
     src: standalone.conf.j2

--- a/ops/ansible/roles/bfd-server/tasks/appserver_config.yml
+++ b/ops/ansible/roles/bfd-server/tasks/appserver_config.yml
@@ -15,6 +15,11 @@
     - 'Restart App Server Service'
   tags: 
     - pre-ami
+- name: Reload Service Daemons
+  command: /usr/bin/systemctl daemon-reload
+  become: true
+  tags: 
+    - pre-ami
 
 - name: Create App Server 'standalone.conf' File
   template:

--- a/ops/deploy-ccs.groovy
+++ b/ops/deploy-ccs.groovy
@@ -186,6 +186,8 @@ def buildAppAmis(String environmentId, String gitBranchName, String gitCommitId,
  * Deploys to the specified environment.
  *
  * @param envId the ID of the environment to deploy to
+ * @param gitBranchName the name of the Git branch this build is for
+ * @param gitCommitId the hash/ID of the Git commit that this build is for
  * @param amiIds an {@link AmiIds} instance detailing the IDs of the AMIs that should be used
  * @param appBuildResults (not used in the CCS environment; this stuff is all baked into the AMIs there, instead)
  * @throws RuntimeException An exception will be bubbled up if the deploy tooling returns a non-zero exit code.

--- a/ops/deploy-healthapt.groovy
+++ b/ops/deploy-healthapt.groovy
@@ -37,11 +37,13 @@ def deployManagement(AmiIds amiIds) {
  * Deploys to the specified environment.
  *
  * @param envId the ID of the environment to deploy to
+ * @param gitBranchName the name of the Git branch this build is for
+ * @param gitCommitId the hash/ID of the Git commit that this build is for
  * @param amiIds an {@link AmiIds} instance detailing the IDs of the AMIs that should be used
  * @param appBuildResults the {@link AppBuildResults} containing the paths to the app binaries that were built
  * @throws RuntimeException An exception will be bubbled up if the deploy tooling returns a non-zero exit code.
  */
-def deploy(String envId, AmiIds amiIds, AppBuildResults appBuildResults) {
+def deploy(String envId, String gitBranchName, String gitCommitId, AmiIds amiIds, AppBuildResults appBuildResults) {
 
 	// Ensure the Ansible image is ready to go.
 	insideAnsibleContainer {


### PR DESCRIPTION
For the `Jenkinsfile` errors: params were added to `deploy(...)` environment, but not the other. Led to weird errors.

For the JBoss service errors: the service definition was getting swapped for Jetty's when that branch was deployed, but not swapped back when other branches were deployed. (The fixes here are hacky and non-idempotent, but temporary, so I don't care.)

https://jira.cms.gov/browse/BLUEBUTTON-1298