### PR TITLE
BLUEBUTTON-1308: Create user, policy, and attachment for external ETL access

### DIFF
--- a/ops/terraform/modules/stateful/main.tf
+++ b/ops/terraform/modules/stateful/main.tf
@@ -450,8 +450,7 @@ resource "aws_iam_policy" "etl_rw_s3" {
       "Sid": "ETLRWBucketActions",
       "Action": [
         "s3:GetObject",
-        "s3:PutObject",
-        "s3:DeleteObject"
+        "s3:PutObject"
       ],
       "Effect": "Allow",
       "Resource": ["${module.etl.arn}/*"]

--- a/ops/terraform/modules/stateful/main.tf
+++ b/ops/terraform/modules/stateful/main.tf
@@ -424,7 +424,13 @@ module "etl" {
   log_bucket          = module.admin.id
 }
 
-# IAM policy to allow read-write access to ETL bucket
+# IAM policy, user, and attachment to allow external read-write
+# access to ETL bucket
+#
+# NOTE: We only need this for production, however it is ok to
+# provision these resources for all environments since the mechanism
+# by which we control access is through a manually provisioned
+# access key
 #
 resource "aws_iam_policy" "etl_rw_s3" {
   name        = "bfd-${local.env_config.env}-etl-rw-s3"
@@ -460,8 +466,6 @@ resource "aws_iam_policy" "etl_rw_s3" {
 EOF
 }
 
-# IAM user to allow external access to ETL bucket
-#
 resource "aws_iam_user" "etl" {
   name       = "bfd-${local.env_config.env}-etl"
 }


### PR DESCRIPTION
This leaves access key management outside of terraform since we currently don't manage any keys there.