### PR TITLE
BLUEBUTTON-1329: Move to classic ELB

### DIFF
--- a/ops/terraform/modules/migration/main.tf
+++ b/ops/terraform/modules/migration/main.tf
@@ -28,7 +28,7 @@ data "aws_vpc" "main" {
 
 # FHIR ELB
 #
-data "aws_lb" "fhir" {
+data "aws_elb" "fhir" {
   name = "bfd-${local.env}-fhir"
 }
 
@@ -49,8 +49,8 @@ module "main" {
 
   # The apex record just goes the FHIR server
   apex_record = {
-    alias         = data.aws_lb.fhir.dns_name 
-    zone_id       = data.aws_lb.fhir.zone_id
+    alias         = data.aws_elb.fhir.dns_name 
+    zone_id       = data.aws_elb.fhir.zone_id
   }
 
   # The health-apt record goes to the health apt service
@@ -69,8 +69,8 @@ module "weighted_pairs" {
   zone_id         = module.main.zone_id
 
   a_set           = "ccs"
-  a_alias         = data.aws_lb.fhir.dns_name 
-  a_zone_id       = data.aws_lb.fhir.zone_id
+  a_alias         = data.aws_elb.fhir.dns_name 
+  a_zone_id       = data.aws_elb.fhir.zone_id
 
   b_set           = "health-apt"
   b_alias         = local.health_apt[local.env].dns

--- a/ops/terraform/modules/resources/asg/main.tf
+++ b/ops/terraform/modules/resources/asg/main.tf
@@ -169,7 +169,7 @@ resource "aws_autoscaling_group" "main" {
   health_check_grace_period = 300
   health_check_type         = var.lb_config == null ? "EC2" : "ELB" # Failures of ELB healthchecks are asg failures
   vpc_zone_identifier       = data.aws_subnet.app_subnets[*].id
-  target_group_arns         = var.lb_config == null ? [] : [var.lb_config.tg_arn]
+  load_balancers            = var.lb_config == null ? [] : [var.lb_config.name]
 
   launch_template {
     name                    = aws_launch_template.main.name

--- a/ops/terraform/modules/resources/asg/variables.tf
+++ b/ops/terraform/modules/resources/asg/variables.tf
@@ -25,7 +25,7 @@ variable "db_config" {
 
 variable "lb_config" {
   description = "Load balancer information"
-  type        = object({name=string, tg_arn=string, port=number})
+  type        = object({name=string, port=number})
   default     = null
 }
 

--- a/ops/terraform/modules/resources/lb/main.tf
+++ b/ops/terraform/modules/resources/lb/main.tf
@@ -11,7 +11,7 @@ locals {
 # Find context
 ##
 
-# Account 
+# Accounts 
 #
 data "aws_caller_identity" "current" {}
 data "aws_elb_service_account" "main" {}
@@ -85,7 +85,7 @@ resource "aws_security_group" "lb" {
   name            = "bfd-${var.env_config.env}-${var.role}-lb"
   description     = "Allow access to the ${var.role} load-balancer"
   vpc_id          = var.env_config.vpc_id
-  tags            = merge({Name="bfd-${var.env_config.env}-${var.role}-base"}, local.tags)
+  tags            = merge({Name="bfd-${var.env_config.env}-${var.role}-lb"}, local.tags)
 
   ingress {
     from_port     = var.ingress.port

--- a/ops/terraform/modules/resources/lb/outputs.tf
+++ b/ops/terraform/modules/resources/lb/outputs.tf
@@ -1,11 +1,7 @@
 output "name" {
-  value = aws_lb.main.name
-}
-
-output "target_group" {
-  value = aws_lb_target_group.main.name
+  value = aws_elb.main.name
 }
 
 output "lb_config" {
-  value = {name=aws_lb.main.name, tg_arn=aws_lb_target_group.main.arn, port=var.egress_port}
+  value = {name=aws_elb.main.name, port=var.egress.port}
 }

--- a/ops/terraform/modules/resources/lb/variables.tf
+++ b/ops/terraform/modules/resources/lb/variables.tf
@@ -8,11 +8,6 @@ variable "role" {
   type        = string
 }
 
-variable "load_balancer_type" {
-  type        = string
-  default     = "application"
-}
-
 variable "layer" {
   description = "app or data"
   type        = string 
@@ -22,11 +17,12 @@ variable "log_bucket" {
   type        = string
 }
 
-variable "ingress_port" {
-  type        = number
+variable "ingress" {
+  description = "Ingress port and cidr blocks"
+  type        = object({description=string, port=number, cidr_blocks=list(string)})
 }
 
-variable "egress_port" {
-  type        = number
+variable "egress" {
+  description = "Egress port and cidr blocks"
+  type        = object({description=string, port=number, cidr_blocks=list(string)})
 }
-

--- a/ops/terraform/modules/stateful/main.tf
+++ b/ops/terraform/modules/stateful/main.tf
@@ -414,6 +414,15 @@ module "admin" {
   acl                 = "log-delivery-write"
 }
 
+# S3 Admin bucket for logs and other adminstrative 
+#
+module "elb" { 
+  source              = "../resources/s3"
+  role                = "elb"
+  env_config          = local.env_config
+  kms_key_id          = data.aws_kms_key.master_key.arn
+}
+
 # S3 bucket for ETL files
 #
 module "etl" {

--- a/ops/terraform/modules/stateless/main.tf
+++ b/ops/terraform/modules/stateless/main.tf
@@ -4,11 +4,31 @@
 #
 
 locals {
-  azs             = ["us-east-1a", "us-east-1b", "us-east-1c"]
-  env_config      = {env=var.env_config.env, tags=var.env_config.tags, vpc_id=data.aws_vpc.main.id, zone_id=data.aws_route53_zone.local_zone.id, azs=local.azs}
-  port            = 7443
-  cw_period       = 60    # Seconds
-  cw_eval_periods = 3
+  azs               = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  env_config        = {env=var.env_config.env, tags=var.env_config.tags, vpc_id=data.aws_vpc.main.id, zone_id=data.aws_route53_zone.local_zone.id, azs=local.azs}
+  port              = 7443
+  cw_period         = 60    # Seconds
+  cw_eval_periods   = 3
+
+  # Add new peerings here
+  vpc_peerings_by_env = {
+    test            = [
+      "bfd-test-vpc-to-bluebutton-dev", "bfd-test-vpc-to-bluebutton-test"
+    ],
+    prod            = [
+      "bfd-prod-vpc-to-mct-prod-vpc", "bfd-prod-vpc-to-mct-prod-dr-vpc", 
+      "bfd-prod-vpc-to-dpc-prod-vpc", 
+      "bfd-prod-vpc-to-dpc-prod-vpc", 
+      "bfd-prod-vpc-to-bcda-prod-vpc"
+    ],
+    prod-sbx        = [
+      "bfd-prod-sbx-to-bcda-dev", "bfd-prod-sbx-to-bcda-test", "bfd-prod-sbx-to-bcda-sbx", "bfd-prod-sbx-to-bcda-opensbx",
+      "bfd-prod-sbx-vpc-to-bluebutton-dev", "bfd-prod-sbx-vpc-to-bluebutton-impl", "bfd-prod-sbx-vpc-to-bluebutton-test",
+      "bfd-prod-sbx-vpc-to-dpc-prod-sbx-vpc", "bfd-prod-sbx-vpc-to-dpc-test-vpc",
+      "bfd-prod-sbx-vpc-to-mct-imp-vpc", "bfd-prod-sbx-vpc-to-mct-test-vpc"
+    ]
+  }
+  vpc_peerings      = local.vpc_peerings_by_env[var.env_config.env]
 }
 
 # Find resources defined outside this script 
@@ -18,16 +38,30 @@ locals {
 #
 data "aws_vpc" "main" {
   filter {
-    name = "tag:Name"
-    values = ["bfd-${var.env_config.env}-vpc"]
+    name    = "tag:Name"
+    values  = ["bfd-${var.env_config.env}-vpc"]
   }
+}
+
+data "aws_vpc" "mgmt" {
+  filter {
+    name    = "tag:Name"
+    values  = ["bfd-mgmt-vpc"]
+  }
+}
+
+# VPC peerings
+#
+data "aws_vpc_peering_connection" "peers" {
+  count     = length(local.vpc_peerings)
+  tags      = {Name=local.vpc_peerings[count.index]}
 }
 
 # DNS
 #
 data "aws_route53_zone" "local_zone" {
-  name         = "bfd-${var.env_config.env}.local"
-  private_zone = true
+  name          = "bfd-${var.env_config.env}.local"
+  private_zone  = true
 }
 
 # S3 Buckets
@@ -135,19 +169,27 @@ resource "aws_iam_role_policy_attachment" "etl_iam_ansible_vault_pw_ro_s3" {
   policy_arn      = data.aws_iam_policy.ansible_vault_pw_ro_s3.arn
 }
 
-
 # NLB for the FHIR server (SSL terminated by the FHIR server)
 #
 module "fhir_lb" {
   source = "../resources/lb"
-  load_balancer_type = "network"
 
   env_config      = local.env_config
   role            = "fhir"
   layer           = "dmz"
   log_bucket      = data.aws_s3_bucket.admin.id
-  ingress_port    = 443
-  egress_port     = local.port
+
+  ingress = {
+    description   = "From VPC peerings and MGMT VPC"
+    port          = 443
+    cidr_blocks   = concat(data.aws_vpc_peering_connection.peers[*].peer_cidr_block, [data.aws_vpc.mgmt.cidr_block])
+  }
+
+  egress = {
+    description   = "To VPC instances"
+    port          = local.port
+    cidr_blocks   = [data.aws_vpc.main.cidr_block]
+  }    
 }
 
 module "lb_alarms" {
@@ -186,9 +228,7 @@ module "fhir_asg" {
     sns_topic_arn = ""
   }
 
-  # TODO: Dummy values to get started
   launch_config   = {
-
     instance_type   = "m5.2xlarge" 
     volume_size     = 100 # GB
     ami_id          = var.fhir_ami 
@@ -224,9 +264,7 @@ module "etl_instance" {
   layer           = "data"
   az              = "us-east-1b" # Same as the master db
 
-  # TODO: Dummy values to get started
   launch_config   = {
-
     instance_type = "m5.2xlarge"
     volume_size   = 100 # GB 
     ami_id        = var.etl_ami 


### PR DESCRIPTION
**Why**
To make the CCS environment better match the HealthApt environment, move to the classic ELB. 

**What Changed**
- Replaced the FHIR LB with a classic v1 ELB
- Created a Security Group for the new ELB
- Created a S3 Bucket for the new ELB's access logs
- The Launch Template references the new ELB instead of the old target group

**Testing Done**

**Terraform Plan**
Ignore the ETL change which was picked up accidentally. 

```
14:20:50 <bfd> ~/p/b/o/t/e/t/stateless> tf plan -var fhir_ami=ami-074f924de93c81314 -var etl_ami=ami-00a5226c314e71769 -var ssh_key_name=bfd-test -var git_branch_name=master -var git_commit_id=18846ecb9a81e9919d396d48931adefb62cb29ea
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

...
------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create
  ~ update in-place
  - destroy
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # module.stateless.module.etl_instance.aws_instance.main must be replaced
-/+ resource "aws_instance" "main" {
        ami                          = "ami-00a5226c314e71769"
      ~ arn                          = "arn:aws:ec2:us-east-1:577373831711:instance/i-04c7f25f1b07ee32a" -> (known after apply)
        associate_public_ip_address  = false
        availability_zone            = "us-east-1b"
      ~ cpu_core_count               = 4 -> (known after apply)
      ~ cpu_threads_per_core         = 2 -> (known after apply)
      - disable_api_termination      = false -> null
        ebs_optimized                = true
        get_password_data            = false
      + host_id                      = (known after apply)
        iam_instance_profile         = "bfd-test-etl-profile"
      ~ id                           = "i-04c7f25f1b07ee32a" -> (known after apply)
      ~ instance_state               = "running" -> (known after apply)
        instance_type                = "m5.2xlarge"
      ~ ipv6_address_count           = 0 -> (known after apply)
      ~ ipv6_addresses               = [] -> (known after apply)
        key_name                     = "bfd-test"
        monitoring                   = true
      + network_interface_id         = (known after apply)
      + password_data                = (known after apply)
      + placement_group              = (known after apply)
      ~ primary_network_interface_id = "eni-035d9b4be785ac937" -> (known after apply)
      ~ private_dns                  = "ip-10-235-21-56.ec2.internal" -> (known after apply)
      ~ private_ip                   = "10.235.21.56" -> (known after apply)
      + public_dns                   = (known after apply)
      + public_ip                    = (known after apply)
      ~ security_groups              = [] -> (known after apply)
        source_dest_check            = true
        subnet_id                    = "subnet-048c7b59678709fa4"
        tags                         = {
            "Environment" = "test"
            "Layer"       = "data"
            "Name"        = "bfd-test-etl"
            "application" = "bfd"
            "business"    = "oeda"
            "role"        = "etl"
            "stack"       = "test"
        }
        tenancy                      = "default"
      ~ user_data                    = "07fa826a50da41f93592ed531f9c3be0375da440" -> "b85f64b812a3f294ccb8720e9a049c6be5b2a8a5" # forces replacement
        volume_tags                  = {
            "Environment" = "test"
            "Layer"       = "data"
            "Name"        = "bfd-test-etl"
            "application" = "bfd"
            "business"    = "oeda"
            "role"        = "etl"
            "snapshot"    = "true"
            "stack"       = "test"
        }
        vpc_security_group_ids       = [
            "sg-08a5db0c457334064",
        ]

      + ebs_block_device {
          + delete_on_termination = (known after apply)
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + snapshot_id           = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = (known after apply)
          + volume_type           = (known after apply)
        }

      + ephemeral_block_device {
          + device_name  = (known after apply)
          + no_device    = (known after apply)
          + virtual_name = (known after apply)
        }

      + network_interface {
          + delete_on_termination = (known after apply)
          + device_index          = (known after apply)
          + network_interface_id  = (known after apply)
        }

      ~ root_block_device {
            delete_on_termination = true
            encrypted             = true
          ~ iops                  = 300 -> (known after apply)
          ~ kms_key_id            = "arn:aws:kms:us-east-1:577373831711:key/7dcca42a-da93-40b1-a4a8-2eb10050f449" -> "alias/bfd-test-cmk" # forces replacement
          ~ volume_id             = "vol-066977574cf6616f7" -> (known after apply)
            volume_size           = 100
            volume_type           = "gp2"
        }
    }

  # module.stateless.module.fhir_asg.aws_autoscaling_group.main will be updated in-place
  ~ resource "aws_autoscaling_group" "main" {
        arn                       = "arn:aws:autoscaling:us-east-1:577373831711:autoScalingGroup:ad88ad8c-a499-4f71-ae5c-d2cecbb91242:autoScalingGroupName/bfd-test-fhir-34"
        availability_zones        = [
            "us-east-1a",
            "us-east-1b",
            "us-east-1c",
        ]
        default_cooldown          = 300
        desired_capacity          = 3
        enabled_metrics           = [
            "GroupDesiredCapacity",
            "GroupInServiceInstances",
            "GroupMaxSize",
            "GroupMinSize",
            "GroupPendingInstances",
            "GroupStandbyInstances",
            "GroupTerminatingInstances",
            "GroupTotalInstances",
        ]
        force_delete              = false
        health_check_grace_period = 300
        health_check_type         = "ELB"
        id                        = "bfd-test-fhir-34"
      ~ load_balancers            = [
          + "bfd-test-fhir",
        ]
        max_size                  = 6
        metrics_granularity       = "1Minute"
        min_elb_capacity          = 3
        min_size                  = 3
        name                      = "bfd-test-fhir-34"
        protect_from_scale_in     = false
        service_linked_role_arn   = "arn:aws:iam::577373831711:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
        suspended_processes       = []
        target_group_arns         = [
            "arn:aws:elasticloadbalancing:us-east-1:577373831711:targetgroup/bfd-20190926164535094800000001/642eca7dca827243",
        ]
        termination_policies      = []
        vpc_zone_identifier       = [
            "subnet-0334c1f4eec7a52af",
            "subnet-059284636c71808eb",
            "subnet-0a6ee82462453afbb",
        ]
        wait_for_capacity_timeout = "10m"
        wait_for_elb_capacity     = 3

        launch_template {
            id      = "lt-08cf8a855a25fdbf7"
            name    = "bfd-test-fhir"
            version = "34"
        }

        tag {
            key                 = "Environment"
            propagate_at_launch = true
            value               = "test"
        }
        tag {
            key                 = "Layer"
            propagate_at_launch = true
            value               = "app"
        }
        tag {
            key                 = "Name"
            propagate_at_launch = true
            value               = "bfd-test-fhir"
        }
        tag {
            key                 = "application"
            propagate_at_launch = true
            value               = "bfd"
        }
        tag {
            key                 = "business"
            propagate_at_launch = true
            value               = "oeda"
        }
        tag {
            key                 = "role"
            propagate_at_launch = true
            value               = "fhir"
        }
        tag {
            key                 = "stack"
            propagate_at_launch = true
            value               = "test"
        }
    }

  # module.stateless.module.fhir_lb.aws_elb.main will be created
  + resource "aws_elb" "main" {
      + arn                         = (known after apply)
      + availability_zones          = (known after apply)
      + connection_draining         = false
      + connection_draining_timeout = 300
      + cross_zone_load_balancing   = false
      + dns_name                    = (known after apply)
      + id                          = (known after apply)
      + idle_timeout                = 60
      + instances                   = (known after apply)
      + internal                    = true
      + name                        = "bfd-test-fhir"
      + security_groups             = (known after apply)
      + source_security_group       = (known after apply)
      + source_security_group_id    = (known after apply)
      + subnets                     = [
          + "subnet-00818819eb42ebb9e",
          + "subnet-042007383f5705c9f",
          + "subnet-0febfd09bda69964f",
        ]
      + tags                        = {
          + "Environment" = "test"
          + "Layer"       = "dmz"
          + "application" = "bfd"
          + "business"    = "oeda"
          + "role"        = "fhir"
          + "stack"       = "test"
        }
      + zone_id                     = (known after apply)

      + access_logs {
          + bucket        = "bfd-test-elb-577373831711"
          + bucket_prefix = "fhir_elb_access_logs"
          + enabled       = false
          + interval      = 5
        }

      + health_check {
          + healthy_threshold   = 5
          + interval            = 10
          + target              = "TCP:7443"
          + timeout             = 5
          + unhealthy_threshold = 2
        }

      + listener {
          + instance_port     = 7443
          + instance_protocol = "TCP"
          + lb_port           = 443
          + lb_protocol       = "TCP"
        }
    }

  # module.stateless.module.fhir_lb.aws_lb.main will be destroyed
  - resource "aws_lb" "main" {
      - arn                              = "arn:aws:elasticloadbalancing:us-east-1:577373831711:loadbalancer/net/bfd-test-fhir/0393e66cc827c221" -> null
      - arn_suffix                       = "net/bfd-test-fhir/0393e66cc827c221" -> null
      - dns_name                         = "bfd-test-fhir-0393e66cc827c221.elb.us-east-1.amazonaws.com" -> null
      - enable_cross_zone_load_balancing = true -> null
      - enable_deletion_protection       = false -> null
      - id                               = "arn:aws:elasticloadbalancing:us-east-1:577373831711:loadbalancer/net/bfd-test-fhir/0393e66cc827c221" -> null
      - internal                         = true -> null
      - ip_address_type                  = "ipv4" -> null
      - load_balancer_type               = "network" -> null
      - name                             = "bfd-test-fhir" -> null
      - security_groups                  = [] -> null
      - subnets                          = [
          - "subnet-00818819eb42ebb9e",
          - "subnet-042007383f5705c9f",
          - "subnet-0febfd09bda69964f",
        ] -> null
      - tags                             = {
          - "Environment" = "test"
          - "Layer"       = "dmz"
          - "application" = "bfd"
          - "business"    = "oeda"
          - "role"        = "fhir"
          - "stack"       = "test"
        } -> null
      - vpc_id                           = "vpc-0d1667499d300a58b" -> null
      - zone_id                          = "Z26RNL4JYFTOTI" -> null

      - access_logs {
          - enabled = false -> null
        }

      - subnet_mapping {
          - subnet_id = "subnet-00818819eb42ebb9e" -> null
        }
      - subnet_mapping {
          - subnet_id = "subnet-042007383f5705c9f" -> null
        }
      - subnet_mapping {
          - subnet_id = "subnet-0febfd09bda69964f" -> null
        }
    }

  # module.stateless.module.fhir_lb.aws_lb_listener.main will be destroyed
  - resource "aws_lb_listener" "main" {
      - arn               = "arn:aws:elasticloadbalancing:us-east-1:577373831711:listener/net/bfd-test-fhir/0393e66cc827c221/6c6503adc7c72582" -> null
      - id                = "arn:aws:elasticloadbalancing:us-east-1:577373831711:listener/net/bfd-test-fhir/0393e66cc827c221/6c6503adc7c72582" -> null
      - load_balancer_arn = "arn:aws:elasticloadbalancing:us-east-1:577373831711:loadbalancer/net/bfd-test-fhir/0393e66cc827c221" -> null
      - port              = 443 -> null
      - protocol          = "TCP" -> null

      - default_action {
          - order            = 1 -> null
          - target_group_arn = "arn:aws:elasticloadbalancing:us-east-1:577373831711:targetgroup/bfd-20190926164535094800000001/642eca7dca827243" -> null
          - type             = "forward" -> null
        }
    }

  # module.stateless.module.fhir_lb.aws_lb_target_group.main will be destroyed
  - resource "aws_lb_target_group" "main" {
      - arn                                = "arn:aws:elasticloadbalancing:us-east-1:577373831711:targetgroup/bfd-20190926164535094800000001/642eca7dca827243" -> null
      - arn_suffix                         = "targetgroup/bfd-20190926164535094800000001/642eca7dca827243" -> null
      - deregistration_delay               = 300 -> null
      - id                                 = "arn:aws:elasticloadbalancing:us-east-1:577373831711:targetgroup/bfd-20190926164535094800000001/642eca7dca827243" -> null
      - lambda_multi_value_headers_enabled = false -> null
      - name                               = "bfd-20190926164535094800000001" -> null
      - name_prefix                        = "bfd-" -> null
      - port                               = 7443 -> null
      - protocol                           = "TCP" -> null
      - proxy_protocol_v2                  = false -> null
      - slow_start                         = 0 -> null
      - tags                               = {
          - "Environment" = "test"
          - "Layer"       = "dmz"
          - "application" = "bfd"
          - "business"    = "oeda"
          - "role"        = "fhir"
          - "stack"       = "test"
        } -> null
      - target_type                        = "instance" -> null
      - vpc_id                             = "vpc-0d1667499d300a58b" -> null

      - health_check {
          - enabled             = true -> null
          - healthy_threshold   = 5 -> null
          - interval            = 10 -> null
          - port                = "traffic-port" -> null
          - protocol            = "TCP" -> null
          - timeout             = 10 -> null
          - unhealthy_threshold = 5 -> null
        }
    }

  # module.stateless.module.fhir_lb.aws_s3_bucket_policy.logs will be created
  + resource "aws_s3_bucket_policy" "logs" {
      + bucket = "bfd-test-elb-577373831711"
      + id     = (known after apply)
      + policy = jsonencode(
            {
              + Id        = "LBAccessLogs"
              + Statement = [
                  + {
                      + Action    = "s3:PutObject"
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = [
                              + "arn:aws:iam::127311923021:root",
                            ]
                        }
                      + Resource  = "arn:aws:s3:::bfd-test-elb-577373831711/*"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
    }

  # module.stateless.module.fhir_lb.aws_security_group.lb will be created
  + resource "aws_security_group" "lb" {
      + arn                    = (known after apply)
      + description            = "Allow access to the fhir load-balancer"
      + egress                 = [
          + {
              + cidr_blocks      = [
                  + "10.235.16.0/21",
                ]
              + description      = "To VPC instances"
              + from_port        = 7443
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "tcp"
              + security_groups  = []
              + self             = false
              + to_port          = 7443
            },
        ]
      + id                     = (known after apply)
      + ingress                = [
          + {
              + cidr_blocks      = [
                  + "10.224.78.0/23",
                  + "10.224.90.0/23",
                  + "10.252.40.0/21",
                  + "10.235.16.0/21",
                ]
              + description      = "From VPC peerings, the MGMT VPC, and self"
              + from_port        = 443
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "tcp"
              + security_groups  = []
              + self             = false
              + to_port          = 443
            },
        ]
      + name                   = "bfd-test-fhir-lb"
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Environment" = "test"
          + "Layer"       = "dmz"
          + "Name"        = "bfd-test-fhir-lb"
          + "application" = "bfd"
          + "business"    = "oeda"
          + "role"        = "fhir"
          + "stack"       = "test"
        }
      + vpc_id                 = "vpc-0d1667499d300a58b"
    }

Plan: 4 to add, 1 to change, 4 to destroy.
```