### PR TITLE
BLUEBUTTON-1315: Encrypt AMIs

### DIFF
--- a/ops/packer/build_bfd-platinum.json
+++ b/ops/packer/build_bfd-platinum.json
@@ -23,7 +23,9 @@
       "tags": {
         "Name": "bfd-platinum-{{isotime \"20060102030405\"}}",
         "Application": "bfd-platinum"
-      }
+      },
+      "encrypt_boot": true,
+      "kms_key_id": "076b1eb1-2fe3-45d3-a8c8-dae8c26d4e8c"
     }
   ],
   "provisioners": [{

--- a/ops/terraform/modules/resources/asg/main.tf
+++ b/ops/terraform/modules/resources/asg/main.tf
@@ -123,10 +123,8 @@ resource "aws_launch_template" "main" {
       volume_type               = "gp2"
       volume_size               = var.launch_config.volume_size
       delete_on_termination     = true
-      /* Will be set by AMI's root block snapshot
       encrypted                 = true
       kms_key_id                = data.aws_kms_key.master_key.arn
-      */
     }
   }
   


### PR DESCRIPTION
This does two things:
- Encrypts the platinum AMI with the mgmt KMS key
- Ensures that at launch time, the root volume of an instance in an ASG is then encrypted with the per environment KMS key, rather than inheriting encryption from the mgmt key

Alternately we could apply the per environment KMS key at application AMI build, but this solution makes more sense (and is simpler) if we are planning to move to environment agnostic AMIs after implementing SSM.