### PR TITLE
BLUEBUTTON-1288: Allow SSH access from VPN to BFD Pipeline EC2 instances

### DIFF
--- a/ops/terraform/modules/resources/asg/main.tf
+++ b/ops/terraform/modules/resources/asg/main.tf
@@ -46,12 +46,7 @@ resource "aws_security_group" "base" {
   vpc_id        = var.env_config.vpc_id
   tags          = merge({Name="bfd-${var.env_config.env}-${var.role}-base"}, local.tags)
 
-  ingress {
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = ["10.0.0.0/8"]
-  }
+  # Note: If we want to allow Jenkins to SSH into boxes, that would go here.
 
   egress {
     from_port   = 0
@@ -74,8 +69,7 @@ resource "aws_security_group" "app" {
     from_port       = var.lb_config.port
     to_port         = var.lb_config.port
     protocol        = "tcp"
-    # TODO: Figure out what the real ingress rule should be
-    cidr_blocks     = ["10.0.0.0/8"]
+    security_groups = [var.lb_config.sg]
   } 
 }
 

--- a/ops/terraform/modules/resources/asg/variables.tf
+++ b/ops/terraform/modules/resources/asg/variables.tf
@@ -25,7 +25,7 @@ variable "db_config" {
 
 variable "lb_config" {
   description = "Load balancer information"
-  type        = object({name=string, port=number})
+  type        = object({name=string, port=number, sg=string})
   default     = null
 }
 

--- a/ops/terraform/modules/resources/ec2/main.tf
+++ b/ops/terraform/modules/resources/ec2/main.tf
@@ -49,19 +49,7 @@ resource "aws_security_group" "base" {
   vpc_id        = var.env_config.vpc_id
   tags          = merge({Name="bfd-${var.env_config.env}-${var.role}-base"}, local.tags)
 
-  ingress {
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = var.mgmt_config.ci_cidrs
-  }
-
-  ingress {
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    security_groups = [var.mgmt_config.remote_sg,var.mgmt_config.vpn_sg,var.mgmt_config.tool_sg]
-  }
+  # Note: If we want to allow Jenkins to SSH into boxes, that would go here.
 
   egress {
     from_port   = 0
@@ -88,7 +76,7 @@ resource "aws_instance" "main" {
   tenancy                     = local.is_prod ? "dedicated" : "default"
   ebs_optimized               = true
 
-  vpc_security_group_ids      = [aws_security_group.base.id]
+  vpc_security_group_ids      = [aws_security_group.base.id, var.mgmt_config.vpn_sg]
   subnet_id                   = data.aws_subnet.main.id
 
   root_block_device {

--- a/ops/terraform/modules/resources/lb/outputs.tf
+++ b/ops/terraform/modules/resources/lb/outputs.tf
@@ -3,5 +3,5 @@ output "name" {
 }
 
 output "lb_config" {
-  value = {name=aws_elb.main.name, port=var.egress.port}
+  value = {name=aws_elb.main.name, port=var.egress.port, sg=aws_security_group.lb.id}
 }

--- a/ops/terraform/modules/stateless/main.tf
+++ b/ops/terraform/modules/stateless/main.tf
@@ -117,7 +117,7 @@ data "aws_security_group" "vpn" {
   }
 }
 
-# Find the management group
+# Find the tools group
 #
 data "aws_security_group" "tools" {
   filter {
@@ -126,7 +126,7 @@ data "aws_security_group" "tools" {
   }
 }
 
-# Find the tools group 
+# Find the management group
 #
 data "aws_security_group" "remote" {
   filter {


### PR DESCRIPTION
Fixed the security group for the BFD Pipeline EC2 instance, as it was not configured in a way that allowed SSH access.

Also:
* Cleaned up the security groups for the ASG and BFD Pipeline systems in general, as they were a bit borked.
* Fixed a couple comments. 

Security implications:
1. Now attaching the `*-vpn-private` security groups to the BFD Server and BFD Pipeline EC2 instances.
    * These SGs are created as part of GDIT's CCS Cloud Formation templates and allow systems on the CCS VPN access to all ports of the EC2 systems.
    * That does seem a bit broad to me, but it's the supported mechanism, so I've raised the issue in general to our ISSO -- we should use these rather than maintaining our own CIDR lists, but they should also be a bit narrower (e.g. just port 22).

BLUEBUTTON-1288