### PR TITLE
BLUEBUTTON-1288: Fix BFD Pipeline app's DB access

### DIFF
--- a/ops/terraform/modules/resources/asg/main.tf
+++ b/ops/terraform/modules/resources/asg/main.tf
@@ -83,8 +83,8 @@ resource "aws_security_group_rule" "allow_db_access" {
   protocol                  = "tcp"
   description               = "Allows access to the ${var.db_config.role} db"
 
-  security_group_id         = var.db_config.db_sg         # The SG associated with each replica
-  source_security_group_id  = aws_security_group.base.id  # Every instance in the ASG
+  security_group_id         = var.db_config.db_sg           # The SG associated with each replica
+  source_security_group_id  = aws_security_group.app[0].id  # Every instance in the ASG
 }
 
 ##

--- a/ops/terraform/modules/resources/bfd_pipeline/main.tf
+++ b/ops/terraform/modules/resources/bfd_pipeline/main.tf
@@ -1,33 +1,3 @@
-# EC2 Instance to run the BFD Pipeline app.
-#
-module "ec2_instance" {
-  source = "../ec2"
-
-  env_config      = var.env_config
-  role            = "etl"
-  layer           = "data"
-  az              = "us-east-1b" # Same as the master db
-
-  launch_config   = {
-    instance_type = "m5.2xlarge"
-    volume_size   = 100 # GB
-    ami_id        = var.launch_config.ami_id
-
-    key_name      = var.launch_config.ssh_key_name
-    profile       = var.launch_config.profile
-    user_data_tpl = "pipeline_server.tpl"
-    git_branch    = var.launch_config.git_branch
-    git_commit    = var.launch_config.git_commit
-  }
-
-  mgmt_config     = {
-    vpn_sg        = var.mgmt_config.vpn_sg
-    tool_sg       = var.mgmt_config.tool_sg
-    remote_sg     = var.mgmt_config.remote_sg
-    ci_cidrs      = var.mgmt_config.ci_cidrs
-  }
-}
-
 # Security group for application-specific (i.e. non-management) traffic.
 #
 resource "aws_security_group" "app" {
@@ -57,4 +27,36 @@ resource "aws_security_group_rule" "allow_db_primary_access" {
 
   security_group_id         = var.db_config.db_sg         # The SG associated with the primary DB.
   source_security_group_id  = aws_security_group.app.id   # The EC2 instance for the BFD Pipeline app.
+}
+
+# EC2 Instance to run the BFD Pipeline app.
+#
+module "ec2_instance" {
+  source = "../ec2"
+
+  env_config      = var.env_config
+  role            = "etl"
+  layer           = "data"
+  az              = "us-east-1b" # Same as the master db
+
+  launch_config   = {
+    instance_type = "m5.2xlarge"
+    volume_size   = 100 # GB
+    ami_id        = var.launch_config.ami_id
+
+    key_name      = var.launch_config.ssh_key_name
+    profile       = var.launch_config.profile
+    user_data_tpl = "pipeline_server.tpl"
+    git_branch    = var.launch_config.git_branch
+    git_commit    = var.launch_config.git_commit
+  }
+
+  mgmt_config     = {
+    vpn_sg        = var.mgmt_config.vpn_sg
+    tool_sg       = var.mgmt_config.tool_sg
+    remote_sg     = var.mgmt_config.remote_sg
+    ci_cidrs      = var.mgmt_config.ci_cidrs
+  }
+
+  sg_ids          = [aws_security_group.app.id]
 }

--- a/ops/terraform/modules/resources/bfd_pipeline/main.tf
+++ b/ops/terraform/modules/resources/bfd_pipeline/main.tf
@@ -1,0 +1,60 @@
+# EC2 Instance to run the BFD Pipeline app.
+#
+module "ec2_instance" {
+  source = "../ec2"
+
+  env_config      = var.env_config
+  role            = "etl"
+  layer           = "data"
+  az              = "us-east-1b" # Same as the master db
+
+  launch_config   = {
+    instance_type = "m5.2xlarge"
+    volume_size   = 100 # GB
+    ami_id        = var.launch_config.ami_id
+
+    key_name      = var.launch_config.ssh_key_name
+    profile       = var.launch_config.profile
+    user_data_tpl = "pipeline_server.tpl"
+    git_branch    = var.launch_config.git_branch
+    git_commit    = var.launch_config.git_commit
+  }
+
+  mgmt_config     = {
+    vpn_sg        = var.mgmt_config.vpn_sg
+    tool_sg       = var.mgmt_config.tool_sg
+    remote_sg     = var.mgmt_config.remote_sg
+    ci_cidrs      = var.mgmt_config.ci_cidrs
+  }
+}
+
+# Security group for application-specific (i.e. non-management) traffic.
+#
+resource "aws_security_group" "app" {
+  name          = "bfd-${var.env_config.env}-etl-app"
+  description   = "Access specific to the BFD Pipeline application."
+  vpc_id        = var.env_config.vpc_id
+  tags          = merge({Name="bfd-${var.env_config.env}-etl-app"}, var.env_config.tags)
+
+  # Note: The application does not currently listen on any ports, so no ingress rules are needed.
+
+  egress {
+    from_port   = 0
+    protocol    = "-1"
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# App access to the database
+#
+resource "aws_security_group_rule" "allow_db_primary_access" {
+  type                      = "ingress"
+  from_port                 = 5432
+  to_port                   = 5432
+  protocol                  = "tcp"
+  description               = "Allows BFD Pipeline access to the primary DB."
+
+  security_group_id         = var.db_config.db_sg         # The SG associated with the primary DB.
+  source_security_group_id  = aws_security_group.app.id   # The EC2 instance for the BFD Pipeline app.
+}

--- a/ops/terraform/modules/resources/bfd_pipeline/variables.tf
+++ b/ops/terraform/modules/resources/bfd_pipeline/variables.tf
@@ -1,0 +1,22 @@
+variable "env_config" {
+  description = "All high-level info for the whole vpc"
+  type        = object({env=string, tags=map(string), vpc_id=string, zone_id=string, azs=list(string)})
+}
+
+variable "az" {
+  type        = string
+}
+
+variable "db_config" {
+  description = "Setup DB ingress rules if defined"
+  type        = object({db_sg=string})
+  default     = null
+}
+
+variable "mgmt_config" {
+  type        = object({vpn_sg=string, tool_sg=string, remote_sg=string, ci_cidrs=list(string)})
+}
+
+variable "launch_config" {
+  type        = object({ami_id=string, ssh_key_name=string, profile=string, git_branch=string, git_commit=string})
+}

--- a/ops/terraform/modules/resources/ec2/main.tf
+++ b/ops/terraform/modules/resources/ec2/main.tf
@@ -76,7 +76,7 @@ resource "aws_instance" "main" {
   tenancy                     = local.is_prod ? "dedicated" : "default"
   ebs_optimized               = true
 
-  vpc_security_group_ids      = [aws_security_group.base.id, var.mgmt_config.vpn_sg]
+  vpc_security_group_ids      = concat([aws_security_group.base.id, var.mgmt_config.vpn_sg], var.sg_ids)
   subnet_id                   = data.aws_subnet.main.id
 
   root_block_device {

--- a/ops/terraform/modules/resources/ec2/variables.tf
+++ b/ops/terraform/modules/resources/ec2/variables.tf
@@ -25,4 +25,8 @@ variable "launch_config" {
   type        = object({instance_type=string, volume_size=number, ami_id=string, key_name=string, profile=string, user_data_tpl=string, git_branch=string, git_commit=string})
 }
 
-
+variable "sg_ids" {
+  type        = list(string)
+  default     = []
+  description = "The IDs of the additional security groups that this EC2 instance should be added to."
+}


### PR DESCRIPTION
### Description
Needs access to the primary/write DB, which wasn't accounted for in the security groups.

Restructured things a bit to group the resources for the BFD Pipeline app all together, since there's now more than just what the `ec2` resource provides.

### Terraform Plan

```
$ cd ops/terraform/env/test/stateless
$ terraform plan -no-color -var 'etl_ami=foo' -var 'fhir_ami=foo' -var 'git_branch_name=foo' -var Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

module.stateless.module.fhir_asg.aws_autoscaling_group.main: Refreshing state...
module.stateless.module.etl_instance.aws_security_group.base: Refreshing state... [id=sg-08a5db0c457334064]
module.stateless.module.fhir_asg.aws_autoscaling_group.main: Refreshing state...
module.stateless.data.aws_security_group.remote: Refreshing state...
module.stateless.data.aws_sns_topic.cloudwatch_alarms: Refreshing state...
module.stateless.data.aws_route53_zone.local_zone: Refreshing state...
module.stateless.data.aws_security_group.tools: Refreshing state...
module.stateless.data.aws_db_instance.replica[2]: Refreshing state...
module.stateless.data.aws_vpc.mgmt: Refreshing state...
module.stateless.module.bfd_pipeline.module.ec2_instance.data.aws_caller_identity.current: Refreshing state...
module.stateless.data.aws_security_group.db_replicas: Refreshing state...
module.stateless.data.aws_db_instance.replica[1]: Refreshing state...
module.stateless.data.aws_db_instance.replica[0]: Refreshing state...
module.stateless.module.fhir_lb.data.aws_elb_service_account.main: Refreshing state...
module.stateless.data.aws_caller_identity.current: Refreshing state...
module.stateless.data.aws_iam_policy.ansible_vault_pw_ro_s3: Refreshing state...
module.stateless.data.aws_vpc.main: Refreshing state...
module.stateless.data.aws_security_group.vpn: Refreshing state...
module.stateless.data.aws_sns_topic.cloudwatch_ok: Refreshing state...
module.stateless.data.aws_security_group.db_primary: Refreshing state...
module.stateless.module.fhir_lb.data.aws_caller_identity.current: Refreshing state...
module.stateless.data.aws_vpc_peering_connection.peers[0]: Refreshing state...
module.stateless.data.aws_vpc_peering_connection.peers[1]: Refreshing state...
module.stateless.module.etl_instance.aws_instance.main: Refreshing state... [id=i-01b60c9f7d2b88fef]
module.stateless.data.aws_s3_bucket.etl: Refreshing state...
module.stateless.data.aws_s3_bucket.admin: Refreshing state...
module.stateless.data.aws_s3_bucket.elb: Refreshing state...
module.stateless.module.fhir_lb.data.aws_s3_bucket.logs: Refreshing state...
module.stateless.module.fhir_asg.data.aws_kms_key.master_key: Refreshing state...
module.stateless.module.fhir_asg.data.aws_subnet.app_subnets[0]: Refreshing state...
module.stateless.module.etl_iam.aws_iam_role.instance: Refreshing state... [id=bfd-test-etl-role]
module.stateless.module.fhir_asg.data.aws_subnet.app_subnets[1]: Refreshing state...
module.stateless.module.fhir_lb.data.aws_subnet.app_subnets[1]: Refreshing state...
module.stateless.module.fhir_lb.data.aws_subnet.app_subnets[0]: Refreshing state...
module.stateless.module.fhir_lb.data.aws_subnet.app_subnets[2]: Refreshing state...
module.stateless.module.fhir_asg.data.aws_subnet.app_subnets[2]: Refreshing state...
module.stateless.module.fhir_iam.aws_iam_role.instance: Refreshing state... [id=bfd-test-fhir-role]
module.stateless.module.bfd_pipeline.module.ec2_instance.data.aws_kms_key.master_key: Refreshing state...
module.stateless.module.bfd_pipeline.module.ec2_instance.data.aws_subnet.main: Refreshing state...
module.stateless.module.fhir_asg.aws_security_group.base: Refreshing state... [id=sg-08c2e0d1154beffde]
module.stateless.module.fhir_lb.aws_security_group.lb: Refreshing state... [id=sg-0d25576255b4d5dad]
module.stateless.module.fhir_lb.aws_s3_bucket_policy.logs: Refreshing state... [id=bfd-test-elb-577373831711]
module.stateless.module.fhir_iam.aws_iam_instance_profile.instance: Refreshing state... [id=bfd-test-fhir-profile]
module.stateless.aws_iam_role_policy_attachment.fhir_iam_ansible_vault_pw_ro_s3: Refreshing state... [id=bfd-test-fhir-role-20190912202743006800000001]
module.stateless.module.etl_iam.aws_iam_instance_profile.instance: Refreshing state... [id=bfd-test-etl-profile]
module.stateless.module.etl_iam.aws_iam_role_policy.s3_policy[0]: Refreshing state... [id=bfd-test-etl-role:bfd-test-etl-s3-policy]
module.stateless.aws_iam_role_policy_attachment.etl_iam_ansible_vault_pw_ro_s3: Refreshing state... [id=bfd-test-etl-role-20190912202743036100000002]
module.stateless.module.fhir_lb.aws_elb.main: Refreshing state... [id=bfd-test-fhir]
module.stateless.module.lb_alarms.aws_cloudwatch_metric_alarm.healthy_hosts[0]: Refreshing state... [id=bfd-test-fhir-healthy-hosts]
module.stateless.module.fhir_asg.aws_security_group.app[0]: Refreshing state... [id=sg-0cdc89644d5f3499d]
module.stateless.module.fhir_asg.aws_security_group_rule.allow_db_access[0]: Refreshing state... [id=sgrule-1088596715]
module.stateless.module.fhir_asg.aws_launch_template.main: Refreshing state... [id=lt-08cf8a855a25fdbf7]
module.stateless.module.fhir_asg.aws_autoscaling_group.main: Refreshing state... [id=bfd-test-fhir-51]
module.stateless.module.fhir_asg.aws_autoscaling_policy.low-cpu: Refreshing state... [id=bfd-test-fhir-low-cpu-scaledown]
module.stateless.module.fhir_asg.aws_autoscaling_policy.high-cpu: Refreshing state... [id=bfd-test-fhir-high-cpu-scaleup]
module.stateless.module.fhir_asg.aws_cloudwatch_metric_alarm.low-cpu: Refreshing state... [id=bfd-test-fhir-low-cpu]
module.stateless.module.fhir_asg.aws_cloudwatch_metric_alarm.high-cpu: Refreshing state... [id=bfd-test-fhir-high-cpu]

------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create
  ~ update in-place
  - destroy
-/+ destroy and then create replacement
+/- create replacement and then destroy

Terraform will perform the following actions:

  # module.stateless.module.bfd_pipeline.aws_security_group.app will be created
  + resource "aws_security_group" "app" {
      + arn                    = (known after apply)
      + description            = "Access specific to the BFD Pipeline application."
      + egress                 = [
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/0",
                ]
              + description      = ""
              + from_port        = 0
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "-1"
              + security_groups  = []
              + self             = false
              + to_port          = 0
            },
        ]
      + id                     = (known after apply)
      + ingress                = (known after apply)
      + name                   = "bfd-test-etl-app"
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Environment" = "test"
          + "Name"        = "bfd-test-etl-app"
          + "application" = "bfd"
          + "business"    = "oeda"
          + "stack"       = "test"
        }
      + vpc_id                 = "vpc-0d1667499d300a58b"
    }

  # module.stateless.module.bfd_pipeline.aws_security_group_rule.allow_db_primary_access will be created
  + resource "aws_security_group_rule" "allow_db_primary_access" {
      + description              = "Allows BFD Pipeline access to the primary DB."
      + from_port                = 5432
      + id                       = (known after apply)
      + protocol                 = "tcp"
      + security_group_id        = "sg-0ac1ebd5e7c3dd04b"
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 5432
      + type                     = "ingress"
    }

  # module.stateless.module.etl_instance.aws_instance.main will be destroyed
  - resource "aws_instance" "main" {
      - ami                          = "ami-04feabd8e9cefcae1" -> null
      - arn                          = "arn:aws:ec2:us-east-1:577373831711:instance/i-01b60c9f7d2b88fef" -> null
      - associate_public_ip_address  = false -> null
      - availability_zone            = "us-east-1b" -> null
      - cpu_core_count               = 4 -> null
      - cpu_threads_per_core         = 2 -> null
      - disable_api_termination      = false -> null
      - ebs_optimized                = true -> null
      - get_password_data            = false -> null
      - iam_instance_profile         = "bfd-test-etl-profile" -> null
      - id                           = "i-01b60c9f7d2b88fef" -> null
      - instance_state               = "running" -> null
      - instance_type                = "m5.2xlarge" -> null
      - ipv6_address_count           = 0 -> null
      - ipv6_addresses               = [] -> null
      - key_name                     = "bfd-test" -> null
      - monitoring                   = true -> null
      - primary_network_interface_id = "eni-04d0e54597da54a03" -> null
      - private_dns                  = "ip-10-235-21-38.ec2.internal" -> null
      - private_ip                   = "10.235.21.38" -> null
      - security_groups              = [] -> null
      - source_dest_check            = true -> null
      - subnet_id                    = "subnet-048c7b59678709fa4" -> null
      - tags                         = {
          - "Environment" = "test"
          - "Layer"       = "data"
          - "Name"        = "bfd-test-etl"
          - "application" = "bfd"
          - "business"    = "oeda"
          - "role"        = "etl"
          - "stack"       = "test"
        } -> null
      - tenancy                      = "default" -> null
      - user_data                    = "22603e405761d29403c2a84304a8fba1cd2958ae" -> null
      - volume_tags                  = {
          - "Environment" = "test"
          - "Layer"       = "data"
          - "Name"        = "bfd-test-etl"
          - "application" = "bfd"
          - "business"    = "oeda"
          - "role"        = "etl"
          - "snapshot"    = "true"
          - "stack"       = "test"
        } -> null
      - vpc_security_group_ids       = [
          - "sg-08a5db0c457334064",
          - "sg-0a1a9d02fe5ac3891",
        ] -> null

      - root_block_device {
          - delete_on_termination = true -> null
          - encrypted             = true -> null
          - iops                  = 300 -> null
          - kms_key_id            = "arn:aws:kms:us-east-1:577373831711:key/7dcca42a-da93-40b1-a4a8-2eb10050f449" -> null
          - volume_id             = "vol-0e2bfb1b46bc2d05a" -> null
          - volume_size           = 100 -> null
          - volume_type           = "gp2" -> null
        }
    }

  # module.stateless.module.etl_instance.aws_security_group.base will be destroyed
  - resource "aws_security_group" "base" {
      - arn                    = "arn:aws:ec2:us-east-1:577373831711:security-group/sg-08a5db0c457334064" -> null
      - description            = "Allow CI access to app servers" -> null
      - egress                 = [
          - {
              - cidr_blocks      = [
                  - "0.0.0.0/0",
                ]
              - description      = ""
              - from_port        = 0
              - ipv6_cidr_blocks = []
              - prefix_list_ids  = []
              - protocol         = "-1"
              - security_groups  = []
              - self             = false
              - to_port          = 0
            },
        ] -> null
      - id                     = "sg-08a5db0c457334064" -> null
      - ingress                = [
          - {
              - cidr_blocks      = [
                  - "10.252.40.0/21",
                ]
              - description      = ""
              - from_port        = 22
              - ipv6_cidr_blocks = []
              - prefix_list_ids  = []
              - protocol         = "tcp"
              - security_groups  = []
              - self             = false
              - to_port          = 22
            },
          - {
              - cidr_blocks      = []
              - description      = ""
              - from_port        = 22
              - ipv6_cidr_blocks = []
              - prefix_list_ids  = []
              - protocol         = "tcp"
              - security_groups  = [
                  - "sg-04d406660d1da0d6b",
                  - "sg-06296860a8f763227",
                  - "sg-0a1a9d02fe5ac3891",
                ]
              - self             = false
              - to_port          = 22
            },
        ] -> null
      - name                   = "bfd-test-etl-base" -> null
      - owner_id               = "577373831711" -> null
      - revoke_rules_on_delete = false -> null
      - tags                   = {
          - "Environment" = "test"
          - "Layer"       = "data"
          - "Name"        = "bfd-test-etl-base"
          - "application" = "bfd"
          - "business"    = "oeda"
          - "role"        = "etl"
          - "stack"       = "test"
        } -> null
      - vpc_id                 = "vpc-0d1667499d300a58b" -> null
    }

  # module.stateless.module.fhir_asg.aws_autoscaling_group.main must be replaced
+/- resource "aws_autoscaling_group" "main" {
      ~ arn                       = "arn:aws:autoscaling:us-east-1:577373831711:autoScalingGroup:f4369655-f06e-4bb2-be99-c4bb510ed0cf:autoScalingGroupName/bfd-test-fhir-51" -> (known after apply)
      ~ availability_zones        = [
          - "us-east-1a",
          - "us-east-1b",
          - "us-east-1c",
        ] -> (known after apply)
      ~ default_cooldown          = 300 -> (known after apply)
        desired_capacity          = 3
        enabled_metrics           = [
            "GroupDesiredCapacity",
            "GroupInServiceInstances",
            "GroupMaxSize",
            "GroupMinSize",
            "GroupPendingInstances",
            "GroupStandbyInstances",
            "GroupTerminatingInstances",
            "GroupTotalInstances",
        ]
        force_delete              = false
        health_check_grace_period = 300
        health_check_type         = "ELB"
      ~ id                        = "bfd-test-fhir-51" -> (known after apply)
        load_balancers            = [
            "bfd-test-fhir",
        ]
        max_size                  = 6
        metrics_granularity       = "1Minute"
        min_elb_capacity          = 3
        min_size                  = 3
      ~ name                      = "bfd-test-fhir-51" -> (known after apply) # forces replacement
        protect_from_scale_in     = false
      ~ service_linked_role_arn   = "arn:aws:iam::577373831711:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling" -> (known after apply)
      - suspended_processes       = [] -> null
      ~ target_group_arns         = [] -> (known after apply)
      - termination_policies      = [] -> null
        vpc_zone_identifier       = [
            "subnet-0334c1f4eec7a52af",
            "subnet-059284636c71808eb",
            "subnet-0a6ee82462453afbb",
        ]
        wait_for_capacity_timeout = "10m"
        wait_for_elb_capacity     = 3

      ~ launch_template {
          ~ id      = "lt-08cf8a855a25fdbf7" -> (known after apply)
            name    = "bfd-test-fhir"
          ~ version = "51" -> (known after apply)
        }

        tag {
            key                 = "Environment"
            propagate_at_launch = true
            value               = "test"
        }
        tag {
            key                 = "Layer"
            propagate_at_launch = true
            value               = "app"
        }
        tag {
            key                 = "Name"
            propagate_at_launch = true
            value               = "bfd-test-fhir"
        }
        tag {
            key                 = "application"
            propagate_at_launch = true
            value               = "bfd"
        }
        tag {
            key                 = "business"
            propagate_at_launch = true
            value               = "oeda"
        }
        tag {
            key                 = "role"
            propagate_at_launch = true
            value               = "fhir"
        }
        tag {
            key                 = "stack"
            propagate_at_launch = true
            value               = "test"
        }
    }

  # module.stateless.module.fhir_asg.aws_autoscaling_policy.high-cpu must be replaced
-/+ resource "aws_autoscaling_policy" "high-cpu" {
        adjustment_type           = "ChangeInCapacity"
      ~ arn                       = "arn:aws:autoscaling:us-east-1:577373831711:scalingPolicy:f074f5d4-f84f-4792-9f90-7ec671b56fa1:autoScalingGroupName/bfd-test-fhir-51:policyName/bfd-test-fhir-high-cpu-scaleup" -> (known after apply)
      ~ autoscaling_group_name    = "bfd-test-fhir-51" -> (known after apply) # forces replacement
        cooldown                  = 300
      - estimated_instance_warmup = 0 -> null
      ~ id                        = "bfd-test-fhir-high-cpu-scaleup" -> (known after apply)
      + metric_aggregation_type   = (known after apply)
        name                      = "bfd-test-fhir-high-cpu-scaleup"
        policy_type               = "SimpleScaling"
        scaling_adjustment        = 2
    }

  # module.stateless.module.fhir_asg.aws_autoscaling_policy.low-cpu must be replaced
-/+ resource "aws_autoscaling_policy" "low-cpu" {
        adjustment_type           = "ChangeInCapacity"
      ~ arn                       = "arn:aws:autoscaling:us-east-1:577373831711:scalingPolicy:9b2eca83-3620-4892-a336-acfe31cf5aa4:autoScalingGroupName/bfd-test-fhir-51:policyName/bfd-test-fhir-low-cpu-scaledown" -> (known after apply)
      ~ autoscaling_group_name    = "bfd-test-fhir-51" -> (known after apply) # forces replacement
        cooldown                  = 300
      - estimated_instance_warmup = 0 -> null
      ~ id                        = "bfd-test-fhir-low-cpu-scaledown" -> (known after apply)
      + metric_aggregation_type   = (known after apply)
        name                      = "bfd-test-fhir-low-cpu-scaledown"
        policy_type               = "SimpleScaling"
        scaling_adjustment        = -1
    }

  # module.stateless.module.fhir_asg.aws_cloudwatch_metric_alarm.high-cpu will be updated in-place
  ~ resource "aws_cloudwatch_metric_alarm" "high-cpu" {
        actions_enabled           = true
      ~ alarm_actions             = [
          - "arn:aws:autoscaling:us-east-1:577373831711:scalingPolicy:f074f5d4-f84f-4792-9f90-7ec671b56fa1:autoScalingGroupName/bfd-test-fhir-51:policyName/bfd-test-fhir-high-cpu-scaleup",
        ] -> (known after apply)
      ~ alarm_description         = "CPU usage for bfd-test-fhir-51 ASG" -> (known after apply)
        alarm_name                = "bfd-test-fhir-high-cpu"
        arn                       = "arn:aws:cloudwatch:us-east-1:577373831711:alarm:bfd-test-fhir-high-cpu"
        comparison_operator       = "GreaterThanOrEqualToThreshold"
        datapoints_to_alarm       = 0
      ~ dimensions                = {
          - "AutoScalingGroupName" = "bfd-test-fhir-51"
        } -> (known after apply)
        evaluation_periods        = 2
        id                        = "bfd-test-fhir-high-cpu"
        insufficient_data_actions = []
        metric_name               = "CPUUtilization"
        namespace                 = "AWS/EC2"
        ok_actions                = []
        period                    = 120
        statistic                 = "Average"
        tags                      = {}
        threshold                 = 60
        treat_missing_data        = "missing"
    }

  # module.stateless.module.fhir_asg.aws_cloudwatch_metric_alarm.low-cpu will be updated in-place
  ~ resource "aws_cloudwatch_metric_alarm" "low-cpu" {
        actions_enabled           = true
      ~ alarm_actions             = [
          - "arn:aws:autoscaling:us-east-1:577373831711:scalingPolicy:9b2eca83-3620-4892-a336-acfe31cf5aa4:autoScalingGroupName/bfd-test-fhir-51:policyName/bfd-test-fhir-low-cpu-scaledown",
        ] -> (known after apply)
      ~ alarm_description         = "CPU usage for bfd-test-fhir-51 ASG" -> (known after apply)
        alarm_name                = "bfd-test-fhir-low-cpu"
        arn                       = "arn:aws:cloudwatch:us-east-1:577373831711:alarm:bfd-test-fhir-low-cpu"
        comparison_operator       = "LessThanOrEqualToThreshold"
        datapoints_to_alarm       = 0
      ~ dimensions                = {
          - "AutoScalingGroupName" = "bfd-test-fhir-51"
        } -> (known after apply)
        evaluation_periods        = 2
        id                        = "bfd-test-fhir-low-cpu"
        insufficient_data_actions = []
        metric_name               = "CPUUtilization"
        namespace                 = "AWS/EC2"
        ok_actions                = []
        period                    = 120
        statistic                 = "Average"
        tags                      = {}
        threshold                 = 20
        treat_missing_data        = "missing"
    }

  # module.stateless.module.fhir_asg.aws_launch_template.main will be updated in-place
  ~ resource "aws_launch_template" "main" {
        arn                     = "arn:aws:ec2:us-east-1:577373831711:launch-template/lt-08cf8a855a25fdbf7"
        default_version         = 1
        description             = "Template for the test environment fhir servers"
        disable_api_termination = false
        ebs_optimized           = "true"
        id                      = "lt-08cf8a855a25fdbf7"
      ~ image_id                = "ami-0461b2ab2e05f7d2b" -> "foo"
        instance_type           = "m5.2xlarge"
      ~ key_name                = "bfd-test" -> "foo"
      ~ latest_version          = 51 -> (known after apply)
        name                    = "bfd-test-fhir"
        security_group_names    = []
        tags                    = {}
      ~ user_data               = "IyEvYmluL2Jhc2gKc2V0IC1lCgpleGVjID4gPih0ZWUgLWEgL3Zhci9sb2cvdXNlcl9kYXRhLmxvZyAyPiYxKQoKZ2l0IGNsb25lIGh0dHBzOi8vZ2l0aHViLmNvbS9DTVNnb3YvYmVuZWZpY2lhcnktZmhpci1kYXRhLmdpdCAtLWJyYW5jaCBtYXN0ZXIgLS1zaW5nbGUtYnJhbmNoCgpjZCBiZW5lZmljaWFyeS1maGlyLWRhdGEvb3BzL2Fuc2libGUvcGxheWJvb2tzLWNjcy8KCmdpdCBjaGVja291dCBtYXN0ZXIKCmF3cyBzMyBjcCBzMzovL2JmZC1tZ210LWFkbWluLTU3NzM3MzgzMTcxMS9hbnNpYmxlL3ZhdWx0LnBhc3N3b3JkIC4KCiMgVGhlIGV4dHJhX3ZhcnMuanNvbiBmaWxlIGZyb20gdGhlIHByZXZpb3VzIGJ1aWxkIHN0ZXAgY29udGFpbnMgYSBmZXcgaW5jb3JyZWN0IHZhbHVlcwojIGFuZCBuZWVkcyB0byBnZXQgdHJpbW1lZCBkb3duIHRvIHRoZSBmb2xsb3dpbmcKY2F0IDw8RU9GID4+IGV4dHJhX3ZhcnMuanNvbgp7CiAgICAiZW52IjoidGVzdCIsCiAgICAiZGF0YV9zZXJ2ZXJfdmVyc2lvbiI6IjEuMC4wLVNOQVBTSE9UIgp9CkVPRgoKYW5zaWJsZS1wbGF5Ym9vayAtLWV4dHJhLXZhcnMgJ0BleHRyYV92YXJzLmpzb24nIC0tdmF1bHQtcGFzc3dvcmQtZmlsZT12YXVsdC5wYXNzd29yZCAtLXRhZ3MgInBvc3QtYW1pIiBsYXVuY2hfYmZkLXNlcnZlci55bWwKCnJtIHZhdWx0LnBhc3N3b3JkCg==" -> "IyEvYmluL2Jhc2gKc2V0IC1lCgpleGVjID4gPih0ZWUgLWEgL3Zhci9sb2cvdXNlcl9kYXRhLmxvZyAyPiYxKQoKZ2l0IGNsb25lIGh0dHBzOi8vZ2l0aHViLmNvbS9DTVNnb3YvYmVuZWZpY2lhcnktZmhpci1kYXRhLmdpdCAtLWJyYW5jaCBmb28gLS1zaW5nbGUtYnJhbmNoCgpjZCBiZW5lZmljaWFyeS1maGlyLWRhdGEvb3BzL2Fuc2libGUvcGxheWJvb2tzLWNjcy8KCmdpdCBjaGVja291dCBmb28KCmF3cyBzMyBjcCBzMzovL2JmZC1tZ210LWFkbWluLTU3NzM3MzgzMTcxMS9hbnNpYmxlL3ZhdWx0LnBhc3N3b3JkIC4KCiMgVGhlIGV4dHJhX3ZhcnMuanNvbiBmaWxlIGZyb20gdGhlIHByZXZpb3VzIGJ1aWxkIHN0ZXAgY29udGFpbnMgYSBmZXcgaW5jb3JyZWN0IHZhbHVlcwojIGFuZCBuZWVkcyB0byBnZXQgdHJpbW1lZCBkb3duIHRvIHRoZSBmb2xsb3dpbmcKY2F0IDw8RU9GID4+IGV4dHJhX3ZhcnMuanNvbgp7CiAgICAiZW52IjoidGVzdCIsCiAgICAiZGF0YV9zZXJ2ZXJfdmVyc2lvbiI6IjEuMC4wLVNOQVBTSE9UIgp9CkVPRgoKYW5zaWJsZS1wbGF5Ym9vayAtLWV4dHJhLXZhcnMgJ0BleHRyYV92YXJzLmpzb24nIC0tdmF1bHQtcGFzc3dvcmQtZmlsZT12YXVsdC5wYXNzd29yZCAtLXRhZ3MgInBvc3QtYW1pIiBsYXVuY2hfYmZkLXNlcnZlci55bWwKCnJtIHZhdWx0LnBhc3N3b3JkCg=="
        vpc_security_group_ids  = [
            "sg-08c2e0d1154beffde",
            "sg-0cdc89644d5f3499d",
        ]

        block_device_mappings {
            device_name = "/dev/sda1"

            ebs {
                delete_on_termination = "true"
                encrypted             = "true"
                iops                  = 0
                kms_key_id            = "arn:aws:kms:us-east-1:577373831711:key/7dcca42a-da93-40b1-a4a8-2eb10050f449"
                volume_size           = 100
                volume_type           = "gp2"
            }
        }

        iam_instance_profile {
            name = "bfd-test-fhir-profile"
        }

        monitoring {
            enabled = true
        }

        placement {
            tenancy = "default"
        }

        tag_specifications {
            resource_type = "instance"
            tags          = {
                "Environment" = "test"
                "Layer"       = "app"
                "Name"        = "bfd-test-fhir"
                "application" = "bfd"
                "business"    = "oeda"
                "role"        = "fhir"
                "stack"       = "test"
            }
        }
        tag_specifications {
            resource_type = "volume"
            tags          = {
                "Environment" = "test"
                "Layer"       = "app"
                "Name"        = "bfd-test-fhir"
                "application" = "bfd"
                "business"    = "oeda"
                "role"        = "fhir"
                "snapshot"    = "true"
                "stack"       = "test"
            }
        }
    }

  # module.stateless.module.fhir_asg.aws_security_group_rule.allow_db_access[0] must be replaced
-/+ resource "aws_security_group_rule" "allow_db_access" {
      - cidr_blocks              = [] -> null
        description              = "Allows access to the replica db"
        from_port                = 5432
      ~ id                       = "sgrule-1088596715" -> (known after apply)
      - ipv6_cidr_blocks         = [] -> null
      - prefix_list_ids          = [] -> null
        protocol                 = "tcp"
        security_group_id        = "sg-0953595ad767d2c00"
        self                     = false
      ~ source_security_group_id = "sg-08c2e0d1154beffde" -> "sg-0cdc89644d5f3499d" # forces replacement
        to_port                  = 5432
        type                     = "ingress"
    }

  # module.stateless.module.bfd_pipeline.module.ec2_instance.aws_instance.main will be created
  + resource "aws_instance" "main" {
      + ami                          = "foo"
      + arn                          = (known after apply)
      + associate_public_ip_address  = false
      + availability_zone            = "us-east-1b"
      + cpu_core_count               = (known after apply)
      + cpu_threads_per_core         = (known after apply)
      + ebs_optimized                = true
      + get_password_data            = false
      + host_id                      = (known after apply)
      + iam_instance_profile         = "bfd-test-etl-profile"
      + id                           = (known after apply)
      + instance_state               = (known after apply)
      + instance_type                = "m5.2xlarge"
      + ipv6_address_count           = (known after apply)
      + ipv6_addresses               = (known after apply)
      + key_name                     = "foo"
      + monitoring                   = true
      + network_interface_id         = (known after apply)
      + password_data                = (known after apply)
      + placement_group              = (known after apply)
      + primary_network_interface_id = (known after apply)
      + private_dns                  = (known after apply)
      + private_ip                   = (known after apply)
      + public_dns                   = (known after apply)
      + public_ip                    = (known after apply)
      + security_groups              = (known after apply)
      + source_dest_check            = true
      + subnet_id                    = "subnet-048c7b59678709fa4"
      + tags                         = {
          + "Environment" = "test"
          + "Layer"       = "data"
          + "Name"        = "bfd-test-etl"
          + "application" = "bfd"
          + "business"    = "oeda"
          + "role"        = "etl"
          + "stack"       = "test"
        }
      + tenancy                      = "default"
      + user_data                    = "f9e78ef0c19b65c0be442c6aa5c4e8bab9e9031d"
      + volume_tags                  = {
          + "Environment" = "test"
          + "Layer"       = "data"
          + "Name"        = "bfd-test-etl"
          + "application" = "bfd"
          + "business"    = "oeda"
          + "role"        = "etl"
          + "snapshot"    = "true"
          + "stack"       = "test"
        }
      + vpc_security_group_ids       = (known after apply)

      + ebs_block_device {
          + delete_on_termination = (known after apply)
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + snapshot_id           = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = (known after apply)
          + volume_type           = (known after apply)
        }

      + ephemeral_block_device {
          + device_name  = (known after apply)
          + no_device    = (known after apply)
          + virtual_name = (known after apply)
        }

      + network_interface {
          + delete_on_termination = (known after apply)
          + device_index          = (known after apply)
          + network_interface_id  = (known after apply)
        }

      + root_block_device {
          + delete_on_termination = true
          + encrypted             = true
          + iops                  = (known after apply)
          + kms_key_id            = "alias/bfd-test-cmk"
          + volume_id             = (known after apply)
          + volume_size           = 100
          + volume_type           = "gp2"
        }
    }

  # module.stateless.module.bfd_pipeline.module.ec2_instance.aws_security_group.base will be created
  + resource "aws_security_group" "base" {
      + arn                    = (known after apply)
      + description            = "Allow CI access to app servers"
      + egress                 = [
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/0",
                ]
              + description      = ""
              + from_port        = 0
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "-1"
              + security_groups  = []
              + self             = false
              + to_port          = 0
            },
        ]
      + id                     = (known after apply)
      + ingress                = (known after apply)
      + name                   = "bfd-test-etl-base"
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags                   = {
          + "Environment" = "test"
          + "Layer"       = "data"
          + "Name"        = "bfd-test-etl-base"
          + "application" = "bfd"
          + "business"    = "oeda"
          + "role"        = "etl"
          + "stack"       = "test"
        }
      + vpc_id                 = "vpc-0d1667499d300a58b"
    }

Plan: 8 to add, 3 to change, 6 to destroy.

------------------------------------------------------------------------

Note: You didn't specify an "-out" parameter to save this plan, so Terraform
can't guarantee that exactly these actions will be performed if
"terraform apply" is subsequently run.


```

https://jira.cms.gov/browse/BLUEBUTTON-1288