### PR TITLE
BLUEBUTTON-1271: Startup smoke testing; Jetty edition

### DIFF
--- a/ops/ansible/playbooks-ccs/build_bfd-server.yml
+++ b/ops/ansible/playbooks-ccs/build_bfd-server.yml
@@ -62,8 +62,8 @@
         # automagically decrypt it as part of the copy operation.
         src: "{{ data_server_ssl_client_certificate_test }}"
         dest: "{{ bfd_server_dir }}/bluebutton-backend-test-data-server-client-test-keypair.pem"
-        owner: root
-        group: root
+        owner: "{{ data_server_user }}"
+        group: "{{ data_server_user }}"
         mode: 'u=rw,g=,o='
       become: true
       tags:

--- a/ops/ansible/playbooks-ccs/templates/cwagent-data-server.json.j2
+++ b/ops/ansible/playbooks-ccs/templates/cwagent-data-server.json.j2
@@ -45,6 +45,12 @@
             "log_group_name": "/bfd/{{ env }}/bfd-server/newrelic_agent.log",
             "log_stream_name": "{instance_id}",
             "timestamp_format": "%b %d, %Y %H:%M:%S %z"
+          },
+          {
+            "file_path": "{{ bfd_server_dir }}/bfd-server-startup.log",
+            "log_group_name": "/bfd/{{ env }}/bfd-server/bfd-server-startup.log",
+            "log_stream_name": "{instance_id}",
+            "timestamp_format": "%Y-%m-%d %H:%M:%S"
           }
         ]
       }

--- a/ops/ansible/playbooks-ccs/vars/test/group_vars/all/env_specific.yml
+++ b/ops/ansible/playbooks-ccs/vars/test/group_vars/all/env_specific.yml
@@ -46,7 +46,3 @@ data_server_ssl_client_certificates:
     certificate: "{{ lookup('file', 'files/client_data_server_performance_tester_certificate.pem') }}"
 
 data_server_startup_testing: true
-data_server_startup_testing_retries: 3
-data_server_startup_testing_boot_timeout: 30
-data_server_startup_testing_req_timeout: 15
-data_server_startup_testing_req_backoff_timeout: 10

--- a/ops/ansible/playbooks-ccs/vars/test/group_vars/all/env_specific.yml
+++ b/ops/ansible/playbooks-ccs/vars/test/group_vars/all/env_specific.yml
@@ -44,5 +44,3 @@ data_server_ssl_client_certificates:
     certificate: "{{ lookup('file', 'files/client_data_server_bluebutton_frontend_test_certificate.pem') }}"
   - alias: client_performance_tester
     certificate: "{{ lookup('file', 'files/client_data_server_performance_tester_certificate.pem') }}"
-
-data_server_startup_testing: true

--- a/ops/ansible/playbooks-ccs/vars/test/group_vars/all/env_specific.yml
+++ b/ops/ansible/playbooks-ccs/vars/test/group_vars/all/env_specific.yml
@@ -44,3 +44,9 @@ data_server_ssl_client_certificates:
     certificate: "{{ lookup('file', 'files/client_data_server_bluebutton_frontend_test_certificate.pem') }}"
   - alias: client_performance_tester
     certificate: "{{ lookup('file', 'files/client_data_server_performance_tester_certificate.pem') }}"
+
+data_server_startup_testing: true
+data_server_startup_testing_retries: 3
+data_server_startup_testing_boot_timeout: 30
+data_server_startup_testing_req_timeout: 15
+data_server_startup_testing_req_backoff_timeout: 10

--- a/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
+++ b/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
@@ -33,7 +33,6 @@ export NEW_RELIC_ENVIRONMENT='{{ data_server_new_relic_environment }}'
 {% endif %}
 {% endif %}
 
-{% if data_server_startup_testing is defined and data_server_startup_testing is sameas true %}
 # Begin smoke testing startup routine
 STARTUP_TESTING_RETRIES='3'
 STARTUP_TESTING_BOOT_TIMEOUT='30'
@@ -102,7 +101,6 @@ stop_service_if_failing() {
 
 (stop_service_if_failing >>"{{ data_server_dir }}/bfd-server-startup.log" 2>&1) &
 # End smoke testing startup routine
-{% endif %}
 
 # Set some additional variables.
 JVM_ARGS='{{ data_server_appserver_jvmargs }}'

--- a/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
+++ b/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
@@ -74,7 +74,7 @@ stop_service_if_failing() {
     STARTUP_TESTING_CHECK_METADATA=$(check_endpoint "https://localhost:7443/v1/fhir/metadata?_format=application%2Fjson%2Bfhir" "status")
     STARTUP_TESTING_CHECK_METADATA_EXIT=$?
 
-    log "Checking database endpoint"
+    log "Checking coverage resource endpoint for bene $STARTUP_TESTING_BENE_ID"
     STARTUP_TESTING_CHECK_DATABASE=$(check_endpoint "https://localhost:7443/v1/fhir/Coverage?beneficiary=$STARTUP_TESTING_BENE_ID&_format=application%2Fjson%2Bfhir" "id")
     STARTUP_TESTING_CHECK_DATABASE_EXIT=$?
 

--- a/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
+++ b/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
@@ -45,35 +45,35 @@ check_endpoint() {
 }
 
 stop_service_if_failing() {
-  echo "$(date): Waiting $STARTUP_TESTING_BOOT_TIMEOUT seconds for initial startup"
+  echo "$(date +%F\ %T): Waiting $STARTUP_TESTING_BOOT_TIMEOUT seconds for initial startup"
   sleep $STARTUP_TESTING_BOOT_TIMEOUT
 
   for I in $(seq $STARTUP_TESTING_RETRIES); do
-    echo "$(date): Checking metadata endpoint"
+    echo "$(date +%F\ %T): Checking metadata endpoint"
     STARTUP_TESTING_CHECK_METADATA=$(check_endpoint 'https://localhost:7443/v1/fhir/metadata?_format=application%2Fjson%2Bfhir' 'status')
     STARTUP_TESTING_CHECK_METADATA_EXIT=$?
 
-    echo "$(date): Checking database endpoint"
+    echo "$(date +%F\ %T): Checking database endpoint"
     STARTUP_TESTING_CHECK_DATABASE=$(check_endpoint 'https://localhost:7443/v1/fhir/Coverage?beneficiary=-201&_format=application%2Fjson%2Bfhir' 'id')
     STARTUP_TESTING_CHECK_DATABASE_EXIT=$?
 
     if [[ $STARTUP_TESTING_CHECK_METADATA_EXIT == 0 ]] && [[ $STARTUP_TESTING_CHECK_DATABASE_EXIT == 0 ]]; then
-      echo "$(date): Server started properly"
+      echo "$(date +%F\ %T): Server started properly"
       return 0
     elif [[ $I != $STARTUP_TESTING_RETRIES ]]; then
-      echo "$(date): Server failed to start properly, backing off"
+      echo "$(date +%F\ %T): Server failed to start properly, backing off"
       sleep $STARTUP_TESTING_REQ_BACKOFF_TIMEOUT
     fi
   done
 
-  echo "$(date): Server failed to start properly, shutting down"
+  echo "$(date +%F\ %T): Server failed to start properly, shutting down"
   STARTUP_TESTING_BFD_PID=$(ps -ef | grep 'DataServerLauncherApp' | grep -v grep | awk '{print $2}')
   STARTUP_TESTING_BFD_PID_EXIT=$?
 
   if [[ $STARTUP_TESTING_BFD_PID_EXIT == 0 ]] && kill -INT $STARTUP_TESTING_BFD_PID; then
-    echo "$(date): Server shut down gracefully"
+    echo "$(date +%F\ %T): Server shut down gracefully"
   else
-    echo "$(date): Error shutting down server gracefully"
+    echo "$(date +%F\ %T): Error shutting down server gracefully"
   fi
   return 1
 }

--- a/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
+++ b/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
@@ -60,7 +60,7 @@ stop_service_if_failing() {
     if [[ $STARTUP_TESTING_CHECK_METADATA_EXIT == 0 ]] && [[ $STARTUP_TESTING_CHECK_DATABASE_EXIT == 0 ]]; then
       echo "$(date): Server started properly"
       return 0
-    elif [[ $I != 3 ]]; then
+    elif [[ $I != $STARTUP_TESTING_RETRIES ]]; then
       echo "$(date): Server failed to start properly, backing off"
       sleep $STARTUP_TESTING_REQ_BACKOFF_TIMEOUT
     fi

--- a/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
+++ b/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
@@ -59,6 +59,7 @@ log() {
 # * $2: the value to confirm is present in the curl output; if not found, then the query should be regarded as unsuccessful
 ##
 check_endpoint() {
+  set -o pipefail
   curl --max-time $STARTUP_TESTING_REQ_TIMEOUT --silent --insecure --cert-type pem --cert "{{ data_server_dir }}/bluebutton-backend-test-data-server-client-test-keypair.pem" "$1" | grep "$2"
 }
 

--- a/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
+++ b/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
@@ -35,45 +35,66 @@ export NEW_RELIC_ENVIRONMENT='{{ data_server_new_relic_environment }}'
 
 {% if data_server_startup_testing is defined and data_server_startup_testing is sameas true %}
 # Begin smoke testing startup routine
-STARTUP_TESTING_RETRIES='{{ data_server_startup_testing_retries | default(3) }}'
-STARTUP_TESTING_BOOT_TIMEOUT='{{ data_server_startup_testing_boot_timeout | default(30) }}'
-STARTUP_TESTING_REQ_TIMEOUT='{{ data_server_startup_testing_req_timeout | default(15) }}'
-STARTUP_TESTING_REQ_BACKOFF_TIMEOUT='{{ data_server_startup_testing_req_backup_timeout | default(10) }}'
+STARTUP_TESTING_RETRIES='3'
+STARTUP_TESTING_BOOT_TIMEOUT='30'
+STARTUP_TESTING_REQ_TIMEOUT='15'
+STARTUP_TESTING_REQ_BACKOFF_TIMEOUT='10'
+STARTUP_TESTING_BENE_ID='-201'
 
+##
+# Prints out the specified message.
+#
+# Params:
+# * $1: the message to log
+##
+log() {
+  echo "$(date +%F\ %T): $1"
+}
+
+##
+# Verifies that the specified endpoint/query can be queried via curl without error and produced the expected output.
+#
+# Params:
+# * $1: the full URL to query via curl
+# * $2: the value to confirm is present in the curl output; if not found, then the query should be regarded as unsuccessful
+##
 check_endpoint() {
   curl --max-time $STARTUP_TESTING_REQ_TIMEOUT --silent --insecure --cert-type pem --cert "{{ data_server_dir }}/bluebutton-backend-test-data-server-client-test-keypair.pem" "$1" | grep "$2"
 }
 
+##
+# Runs test queries to verify that the server is working as expected. If not, issues a 'kill -INT' on the server's process to shut it down.
+##
 stop_service_if_failing() {
-  echo "$(date +%F\ %T): Waiting $STARTUP_TESTING_BOOT_TIMEOUT seconds for initial startup"
+  log "Waiting $STARTUP_TESTING_BOOT_TIMEOUT seconds for initial startup"
   sleep $STARTUP_TESTING_BOOT_TIMEOUT
 
   for I in $(seq $STARTUP_TESTING_RETRIES); do
-    echo "$(date +%F\ %T): Checking metadata endpoint"
-    STARTUP_TESTING_CHECK_METADATA=$(check_endpoint 'https://localhost:7443/v1/fhir/metadata?_format=application%2Fjson%2Bfhir' 'status')
+    log "Checking metadata endpoint"
+    STARTUP_TESTING_CHECK_METADATA=$(check_endpoint "https://localhost:7443/v1/fhir/metadata?_format=application%2Fjson%2Bfhir" "status")
     STARTUP_TESTING_CHECK_METADATA_EXIT=$?
 
-    echo "$(date +%F\ %T): Checking database endpoint"
-    STARTUP_TESTING_CHECK_DATABASE=$(check_endpoint 'https://localhost:7443/v1/fhir/Coverage?beneficiary=-201&_format=application%2Fjson%2Bfhir' 'id')
+    log "Checking database endpoint"
+    STARTUP_TESTING_CHECK_DATABASE=$(check_endpoint "https://localhost:7443/v1/fhir/Coverage?beneficiary=$STARTUP_TESTING_BENE_ID&_format=application%2Fjson%2Bfhir" "id")
     STARTUP_TESTING_CHECK_DATABASE_EXIT=$?
 
     if [[ $STARTUP_TESTING_CHECK_METADATA_EXIT == 0 ]] && [[ $STARTUP_TESTING_CHECK_DATABASE_EXIT == 0 ]]; then
-      echo "$(date +%F\ %T): Server started properly"
+      log "Server started properly"
       return 0
-    elif [[ $I != $STARTUP_TESTING_RETRIES ]]; then
-      echo "$(date +%F\ %T): Server failed to start properly, backing off"
+    elif [[ $I -lt $STARTUP_TESTING_RETRIES ]]; then
+      log "Server failed to start properly, backing off"
       sleep $STARTUP_TESTING_REQ_BACKOFF_TIMEOUT
     fi
   done
 
-  echo "$(date +%F\ %T): Server failed to start properly, shutting down"
+  log "Server failed to start properly, shutting down"
   STARTUP_TESTING_BFD_PID=$(ps -ef | grep 'DataServerLauncherApp' | grep -v grep | awk '{print $2}')
   STARTUP_TESTING_BFD_PID_EXIT=$?
 
   if [[ $STARTUP_TESTING_BFD_PID_EXIT == 0 ]] && kill -INT $STARTUP_TESTING_BFD_PID; then
-    echo "$(date +%F\ %T): Server shut down gracefully"
+    log "Server shut down gracefully"
   else
-    echo "$(date +%F\ %T): Error shutting down server gracefully"
+    log "Error shutting down server gracefully"
   fi
   return 1
 }

--- a/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
+++ b/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
@@ -66,10 +66,10 @@ stop_service_if_failing() {
   done
 
   echo "$(date): Server failed to start properly, shutting down"
-  BFD_PID=$(ps -ef | grep '\-Dbfd-server' | grep -v grep | awk '{print $2}')
-  BFD_PID_EXIT=$?
+  STARTUP_TESTING_BFD_PID=$(ps -ef | grep 'DataServerLauncherApp' | grep -v grep | awk '{print $2}')
+  STARTUP_TESTING_BFD_PID_EXIT=$?
 
-  if [[ $BFD_PID_EXIT == 0 ]] && kill -INT $BFD_PID; then
+  if [[ $STARTUP_TESTING_BFD_PID_EXIT == 0 ]] && kill -INT $STARTUP_TESTING_BFD_PID; then
     echo "$(date): Server shut down gracefully"
   else
     echo "$(date): Error shutting down server gracefully"

--- a/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
+++ b/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
@@ -33,6 +33,51 @@ export NEW_RELIC_ENVIRONMENT='{{ data_server_new_relic_environment }}'
 {% endif %}
 {% endif %}
 
+{% if data_server_startup_testing is defined and data_server_startup_testing is sameas true %}
+STARTUP_TESTING_RETRIES='{{ data_server_startup_testing_retries | default(3) }}'
+STARTUP_TESTING_BOOT_TIMEOUT='{{ data_server_startup_testing_boot_timeout | default(30) }}'
+STARTUP_TESTING_REQ_TIMEOUT='{{ data_server_startup_testing_req_timeout | default(15) }}'
+STARTUP_TESTING_REQ_BACKOFF_TIMEOUT='{{ data_server_startup_testing_req_backup_timeout | default(10) }}'
+
+check_endpoint() {
+  curl --max-time $STARTUP_TESTING_REQ_TIMEOUT --silent --insecure --cert-type pem --cert {{ data_server_dir }}/bluebutton-backend-test-data-server-client-test-keypair.pem "$1" | grep "$2"
+}
+
+stop_service_if_failing() {
+  echo "$(date): Waiting $STARTUP_TESTING_BOOT_TIMEOUT seconds for initial startup"
+  sleep $STARTUP_TESTING_BOOT_TIMEOUT
+
+  for I in $(seq $STARTUP_TESTING_RETRIES); do
+    echo "$(date): Checking metadata endpoint"
+    STARTUP_TESTING_CHECK_METADATA=$(check_endpoint 'https://localhost:7443/v1/fhir/metadata?_format=application%2Fjson%2Bfhir' 'status')
+    STARTUP_TESTING_CHECK_METADATA_EXIT=$?
+
+    echo "$(date): Checking database endpoint"
+    STARTUP_TESTING_CHECK_DATABASE=$(check_endpoint 'https://localhost:7443/v1/fhir/Coverage?beneficiary=-201&_format=application%2Fjson%2Bfhir' 'id')
+    STARTUP_TESTING_CHECK_DATABASE_EXIT=$?
+
+    if [[ $STARTUP_TESTING_CHECK_METADATA_EXIT == 0 ]] && [[ $STARTUP_TESTING_CHECK_DATABASE_EXIT == 0 ]]; then
+      echo "$(date): Server started properly"
+      return 0
+    elif [[ $I != 3 ]]; then
+      echo "$(date): Server failed to start properly, backing off"
+      sleep $STARTUP_TESTING_REQ_BACKOFF_TIMEOUT
+    fi
+  done
+
+  echo "$(date): Server failed to start properly, shutting down"
+  BFD_PID=$(ps -ef | grep '\-Dbfd-server' | grep -v grep | awk '{print $2}')
+  BFD_PID_EXIT=$?
+
+  if [[ $BFD_PID_EXIT == 0 ]] && kill -INT $BFD_PID; then
+    echo "$(date): Server shut down gracefully"
+  else
+    echo "$(date): Error shutting down server gracefully"
+  fi
+  return 1
+}
+{% endif %}
+
 # Set some additional variables.
 JVM_ARGS='{{ data_server_appserver_jvmargs }}'
 

--- a/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
+++ b/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
@@ -34,13 +34,14 @@ export NEW_RELIC_ENVIRONMENT='{{ data_server_new_relic_environment }}'
 {% endif %}
 
 {% if data_server_startup_testing is defined and data_server_startup_testing is sameas true %}
+# Begin smoke testing startup routine
 STARTUP_TESTING_RETRIES='{{ data_server_startup_testing_retries | default(3) }}'
 STARTUP_TESTING_BOOT_TIMEOUT='{{ data_server_startup_testing_boot_timeout | default(30) }}'
 STARTUP_TESTING_REQ_TIMEOUT='{{ data_server_startup_testing_req_timeout | default(15) }}'
 STARTUP_TESTING_REQ_BACKOFF_TIMEOUT='{{ data_server_startup_testing_req_backup_timeout | default(10) }}'
 
 check_endpoint() {
-  curl --max-time $STARTUP_TESTING_REQ_TIMEOUT --silent --insecure --cert-type pem --cert {{ data_server_dir }}/bluebutton-backend-test-data-server-client-test-keypair.pem "$1" | grep "$2"
+  curl --max-time $STARTUP_TESTING_REQ_TIMEOUT --silent --insecure --cert-type pem --cert "{{ data_server_dir }}/bluebutton-backend-test-data-server-client-test-keypair.pem" "$1" | grep "$2"
 }
 
 stop_service_if_failing() {
@@ -76,6 +77,9 @@ stop_service_if_failing() {
   fi
   return 1
 }
+
+(stop_service_if_failing >>"{{ data_server_dir }}/bfd-server-startup.log" 2>&1)
+# End smoke testing startup routine
 {% endif %}
 
 # Set some additional variables.

--- a/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
+++ b/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
@@ -78,7 +78,7 @@ stop_service_if_failing() {
   return 1
 }
 
-(stop_service_if_failing >>"{{ data_server_dir }}/bfd-server-startup.log" 2>&1)
+(stop_service_if_failing >>"{{ data_server_dir }}/bfd-server-startup.log" 2>&1) &
 # End smoke testing startup routine
 {% endif %}
 


### PR DESCRIPTION
This conditionally injects a backgrounded function into the startup routine that will make a number of attempts (with various configurable timeouts) to validate that one metadata endpoint and one database backed endpoint return expected values.  If not, it will attempt to safely stop the process as to prevent a successful deploy.

Need some feedback on a few things before it's readier to merge:
* Are the default timeouts sane?
* We probably want to check for a larger/more complete value, however I'm not sure what will be consistent between all environments.
* Should we attempt a more drastic process kill if safe kill fails?
* Any other error handling I'm missing?