### PR TITLE
BLUEBUTTON-1288: Create BFD Pipeline EC2 instance after SGs

### DIFF
--- a/ops/terraform/modules/resources/bfd_pipeline/main.tf
+++ b/ops/terraform/modules/resources/bfd_pipeline/main.tf
@@ -61,5 +61,5 @@ module "ec2_instance" {
   sg_ids          = [aws_security_group.app.id]
 
   # Ensure that the DB is accessible before the BFD Pipeline is launched.
-  dependencies    = ["${aws_security_group_rule.allow_db_primary_access.id}"]
+  ec2_depends_on_1 = "aws_security_group_rule.allow_db_primary_access"
 }

--- a/ops/terraform/modules/resources/bfd_pipeline/main.tf
+++ b/ops/terraform/modules/resources/bfd_pipeline/main.tf
@@ -59,4 +59,7 @@ module "ec2_instance" {
   }
 
   sg_ids          = [aws_security_group.app.id]
+
+  # Ensure that the DB is accessible before the BFD Pipeline is launched.
+  dependencies    = ["${aws_security_group_rule.allow_db_primary_access.id}"]
 }

--- a/ops/terraform/modules/resources/ec2/main.tf
+++ b/ops/terraform/modules/resources/ec2/main.tf
@@ -94,17 +94,7 @@ resource "aws_instance" "main" {
     gitCommitId = var.launch_config.git_commit
   })
 
-  depends_on                  = [null_resource.dependency_getter]
-}
-
-##
-# Module Dependency Workaround
-#
-# Note: This is a workaround for Terraform's lack of support for `depends_on` in modules.
-# See here for the inspiration: https://github.com/hashicorp/terraform/issues/1178#issuecomment-449158607
-##
-resource "null_resource" "dependency_getter" {
-  provisioner "local-exec" {
-    command = "echo ${length(var.dependencies)}"
-  }
+  # Note: This is a workaround for Terraform's lack of support for `depends_on` in modules.
+  # The value here must be a static list, so only a single dependency can be passed in per-variable.
+  depends_on                  = [var.ec2_depends_on_1]
 }

--- a/ops/terraform/modules/resources/ec2/main.tf
+++ b/ops/terraform/modules/resources/ec2/main.tf
@@ -93,4 +93,18 @@ resource "aws_instance" "main" {
     gitBranchName = var.launch_config.git_branch
     gitCommitId = var.launch_config.git_commit
   })
+
+  depends_on                  = [null_resource.dependency_getter]
+}
+
+##
+# Module Dependency Workaround
+#
+# Note: This is a workaround for Terraform's lack of support for `depends_on` in modules.
+# See here for the inspiration: https://github.com/hashicorp/terraform/issues/1178#issuecomment-449158607
+##
+resource "null_resource" "dependency_getter" {
+  provisioner "local-exec" {
+    command = "echo ${length(var.dependencies)}"
+  }
 }

--- a/ops/terraform/modules/resources/ec2/variables.tf
+++ b/ops/terraform/modules/resources/ec2/variables.tf
@@ -30,3 +30,9 @@ variable "sg_ids" {
   default     = []
   description = "The IDs of the additional security groups that this EC2 instance should be added to."
 }
+
+variable "dependencies" {
+  type        = list(string)
+  default     = []
+  description = "The IDs of the AWS resources that this module's EC2 instance should depend on, e.g. SGs or other resources that it relies on to function properly."
+}

--- a/ops/terraform/modules/resources/ec2/variables.tf
+++ b/ops/terraform/modules/resources/ec2/variables.tf
@@ -31,8 +31,8 @@ variable "sg_ids" {
   description = "The IDs of the additional security groups that this EC2 instance should be added to."
 }
 
-variable "dependencies" {
-  type        = list(string)
-  default     = []
-  description = "The IDs of the AWS resources that this module's EC2 instance should depend on, e.g. SGs or other resources that it relies on to function properly."
+variable "ec2_depends_on_1" {
+  type        = string
+  default     = null
+  description = "The Terraform resource name/ID of a resource that this module's EC2 instance should depend on, if any."
 }


### PR DESCRIPTION
When I rolled out my previous PR to the `test` environment, the BFD Pipeline app failed to launch the first time, because the RDS security group it depended on wasn't in place.

This is a rather gross hack, but should fix it. It's be much simpler if Terraform just supported `depends_on` for modules, but it apparently doesn't yet.

Note: I don't think this workaround will trigger if the SG is changed; it only ensures it's _created_ first.  🤷‍♂ 

https://jira.cms.gov/browse/BLUEBUTTON-1288