### PR TITLE
BLUEBUTTON-1288: Lock deploys to the test environment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,12 +160,13 @@ if (deployEnvironment == 'ccs') {
 }
 
 stage('Deploy to TEST') {
-	milestone(label: 'stage_deploy_test_start')
+	lock(resource: 'env_test', inversePrecendence: true) {
+		milestone(label: 'stage_deploy_test_start')
 
-	node {
-		scriptForDeploys.deploy('test', gitBranchName, gitCommitId, amiIds, appBuildResults)
+		node {
+			scriptForDeploys.deploy('test', gitBranchName, gitCommitId, amiIds, appBuildResults)
+		}
 	}
-
 }
 
 stage('Manual Approval') {


### PR DESCRIPTION
Prevent one deploy from stomping on another. This should fix the "`Error: Error locking state: Error acquiring the state lock: ConditionalCheckFailedException: The conditional request failed`" errors that we've been getting from Terraform.

https://jira.cms.gov/browse/BLUEBUTTON-1288