### PR TITLE
BLUEBUTTON 1340: Fix logging bucket

### DIFF
--- a/ops/terraform/modules/resources/lb/main.tf
+++ b/ops/terraform/modules/resources/lb/main.tf
@@ -30,7 +30,7 @@ data "aws_subnet" "app_subnets" {
   }
 }
 
-# S3 admin bucket for logs
+# S3 bucket for logs
 #
 data "aws_s3_bucket" "logs" {
   bucket = var.log_bucket

--- a/ops/terraform/modules/resources/s3/main.tf
+++ b/ops/terraform/modules/resources/s3/main.tf
@@ -22,18 +22,9 @@ resource "aws_s3_bucket" "main" {
   # Always apply encryption, Customer CMK or AWS AES256
   server_side_encryption_configuration {
     rule {
-      dynamic "apply_server_side_encryption_by_default" {
-        for_each = var.kms_key_id == null ? ["doit"] : []
-        content {
-          sse_algorithm     = "AES256"
-        }
-      }
-      dynamic "apply_server_side_encryption_by_default" {
-        for_each = var.kms_key_id != null ? ["doit"] : []
-        content {
-          sse_algorithm     = "aws:kms"
-          kms_master_key_id = var.kms_key_id
-        }
+      apply_server_side_encryption_by_default {
+        sse_algorithm     = var.kms_key_id != null ? "aws:kms" : "AES256"
+        kms_master_key_id = var.kms_key_id 
       }
     }
   }

--- a/ops/terraform/modules/resources/s3/main.tf
+++ b/ops/terraform/modules/resources/s3/main.tf
@@ -19,15 +19,26 @@ resource "aws_s3_bucket" "main" {
   acl                     = var.acl
   tags                    = local.tags
 
+  # Always apply encryption, Customer CMK or AWS AES256
   server_side_encryption_configuration {
     rule {
-      apply_server_side_encryption_by_default {
-        kms_master_key_id = var.kms_key_id
-        sse_algorithm     = "aws:kms"
+      dynamic "apply_server_side_encryption_by_default" {
+        for_each = var.kms_key_id == null ? ["doit"] : []
+        content {
+          sse_algorithm     = "AES256"
+        }
+      }
+      dynamic "apply_server_side_encryption_by_default" {
+        for_each = var.kms_key_id != null ? ["doit"] : []
+        content {
+          sse_algorithm     = "aws:kms"
+          kms_master_key_id = var.kms_key_id
+        }
       }
     }
   }
 
+  # Add logging if specified
   dynamic "logging" {
     for_each        = var.log_bucket == "" ? [] : [var.log_bucket]
     content {
@@ -37,4 +48,13 @@ resource "aws_s3_bucket" "main" {
   }
 
   # TODO add retention policy
+}
+
+# For safety, block public access to the bucket
+#
+resource "aws_s3_bucket_public_access_block" "main" {
+  bucket = aws_s3_bucket.main.id
+
+  block_public_acls   = true
+  block_public_policy = true
 }

--- a/ops/terraform/modules/resources/s3/main.tf
+++ b/ops/terraform/modules/resources/s3/main.tf
@@ -43,7 +43,7 @@ resource "aws_s3_bucket" "main" {
     for_each        = var.log_bucket == "" ? [] : [var.log_bucket]
     content {
       target_bucket = logging.value
-      target_prefix   = "logs/${var.role}"
+      target_prefix   = "${var.role}_s3_access_logs"
     }
   }
 

--- a/ops/terraform/modules/resources/s3/variables.tf
+++ b/ops/terraform/modules/resources/s3/variables.tf
@@ -9,6 +9,7 @@ variable "role" {
 
 variable "kms_key_id" {
   type        = string
+  default     = null
 }
 
 variable "log_bucket" {

--- a/ops/terraform/modules/stateful/main.tf
+++ b/ops/terraform/modules/stateful/main.tf
@@ -424,23 +424,23 @@ module "replica3_alarms" {
   ok_notification_arn = aws_sns_topic.cloudwatch_ok.arn
 }
 
-# S3 Admin bucket for logs and other adminstrative 
+# S3 Admin bucket for adminstrative stuff
 #
 module "admin" { 
   source              = "../resources/s3"
   role                = "admin"
   env_config          = local.env_config
   kms_key_id          = data.aws_kms_key.master_key.arn
-  acl                 = "log-delivery-write"
+  log_bucket          = module.logs.id
 }
 
-# S3 Admin bucket for logs and other adminstrative 
+# S3 bucket for logs 
 #
-module "elb" { 
+module "logs" { 
   source              = "../resources/s3"
-  role                = "elb"
+  role                = "logs"
   env_config          = local.env_config
-  kms_key_id          = data.aws_kms_key.master_key.arn
+  acl                 = "log-delivery-write" 
 }
 
 # S3 bucket for ETL files
@@ -450,7 +450,7 @@ module "etl" {
   role                = "etl"
   env_config          = local.env_config
   kms_key_id          = data.aws_kms_key.master_key.arn
-  log_bucket          = module.admin.id
+  log_bucket          = module.logs.id
 }
 
 # IAM policy, user, and attachment to allow external read-write

--- a/ops/terraform/modules/stateful/main.tf
+++ b/ops/terraform/modules/stateful/main.tf
@@ -440,7 +440,8 @@ module "logs" {
   source              = "../resources/s3"
   role                = "logs"
   env_config          = local.env_config
-  acl                 = "log-delivery-write" 
+  acl                 = "log-delivery-write"  # For AWS bucket logs
+  kms_key_id          = null                  # Use AWS encryption to support AWS Agents writing to this bucket
 }
 
 # S3 bucket for ETL files

--- a/ops/terraform/modules/stateless/main.tf
+++ b/ops/terraform/modules/stateless/main.tf
@@ -76,8 +76,8 @@ data "aws_s3_bucket" "admin" {
   bucket = "bfd-${var.env_config.env}-admin-${data.aws_caller_identity.current.account_id}"
 }
 
-data "aws_s3_bucket" "elb" {
-  bucket = "bfd-${var.env_config.env}-elb-${data.aws_caller_identity.current.account_id}"
+data "aws_s3_bucket" "logs" {
+  bucket = "bfd-${var.env_config.env}-logs-${data.aws_caller_identity.current.account_id}"
 }
 
 # CloudWatch
@@ -188,7 +188,7 @@ module "fhir_lb" {
   env_config      = local.env_config
   role            = "fhir"
   layer           = "dmz"
-  log_bucket      = data.aws_s3_bucket.elb.id
+  log_bucket      = data.aws_s3_bucket.logs.id
 
   ingress = {
     description   = "From VPC peerings, the MGMT VPC, and self"


### PR DESCRIPTION
**Why**
To ensure the ability to audit, record S3 and ELB access

**Problem Fixed**
The previous logging bucket, the ELB bucket, was setup by TF was created with CMK encryption. This type of encryption was incompatible with ELB logging. 

**What Changed**
- Created a per environment bfd-<env>-logs bucket. Setup this bucket with AES256 encryption and Log Delivery ACLs.
- Point S3 and ELBs to write access logs to this bucket
- Added block public access lock to all S3 buckets for safety

**Notes**
- Tested in test environment
- TF Plan in comments
 

