### PR TITLE
BLUEBUTTON-1288: Revert accidental changes to DB migrations

### DIFF
--- a/apps/bfd-model/bfd-model-rif/src/main/resources/db/migration/V11__Create_medicare_beneficiary_id_history_table.sql
+++ b/apps/bfd-model/bfd-model-rif/src/main/resources/db/migration/V11__Create_medicare_beneficiary_id_history_table.sql
@@ -1,7 +1,7 @@
 /*
  * Creates the MedicareBeneficiaryIdHistory table required by the application. This
  * schema is derived from the JPA metadata, via the 
- * gov.cms.bfd.pipeline.rif.schema.HibernateSchemaPrinter
+ * gov.hhs.cms.bluebutton.data.pipeline.rif.schema.HibernateSchemaPrinter 
  * utility.
  */
 

--- a/apps/bfd-model/bfd-model-rif/src/main/resources/db/migration/V13__Create_beneficiary_history_temp_table.sql
+++ b/apps/bfd-model/bfd-model-rif/src/main/resources/db/migration/V13__Create_beneficiary_history_temp_table.sql
@@ -1,7 +1,7 @@
 /*
  * Creates the beneficiary ID history table required by the application. This
  * schema is derived from the JPA metadata, via the 
- * gov.cms.bfd.pipeline.rif.schema.HibernateSchemaPrinter
+ * gov.hhs.cms.bluebutton.data.pipeline.rif.schema.HibernateSchemaPrinter 
  * utility.
  */
 

--- a/apps/bfd-model/bfd-model-rif/src/main/resources/db/migration/V1__Create_beneficiary_and_claim_tables.sql
+++ b/apps/bfd-model/bfd-model-rif/src/main/resources/db/migration/V1__Create_beneficiary_and_claim_tables.sql
@@ -1,7 +1,7 @@
 /*
  * Creates the beneficiary and claim tables required by the application. This
  * schema is derived from the JPA metadata, via the 
- * gov.cms.bfd.pipeline.rif.schema.HibernateSchemaPrinter
+ * gov.hhs.cms.bluebutton.data.pipeline.rif.schema.HibernateSchemaPrinter 
  * utility.
  */
 

--- a/apps/bfd-model/bfd-model-rif/src/main/resources/db/migration/V9__Create_beneficiary_history_table.sql
+++ b/apps/bfd-model/bfd-model-rif/src/main/resources/db/migration/V9__Create_beneficiary_history_table.sql
@@ -1,7 +1,7 @@
 /*
  * Creates the beneficiary ID history table required by the application. This
  * schema is derived from the JPA metadata, via the 
- * gov.cms.bfd.pipeline.rif.schema.HibernateSchemaPrinter
+ * gov.hhs.cms.bluebutton.data.pipeline.rif.schema.HibernateSchemaPrinter 
  * utility.
  */
 


### PR DESCRIPTION
Back during the monorepo migration, I accidentally made some changes to these scripts.

These migration scripts **can't** be modified at all, for any reason, once deployed, as Flyway tracks their checksums and reports errors if it detects a mismatch.

Reverting the changes should resolve the checksum mismatches for the CCS and hhsdevcloud environments.

https://jira.cms.gov/browse/BLUEBUTTON-1288