### PR TITLE
BLUEBUTTON-1288: CloudWatch log groups

### DIFF
--- a/ops/ansible/playbooks-ccs/templates/cwagent-data-pipeline.json.j2
+++ b/ops/ansible/playbooks-ccs/templates/cwagent-data-pipeline.json.j2
@@ -17,7 +17,7 @@
           },
           {
             "file_path": "/bluebutton-data-pipeline/bluebutton-data-pipeline.log",
-            "log_group_name": "/bfd/{{ env }}/data-pipeline/message.txt",
+            "log_group_name": "/bfd/{{ env }}/bfd-pipeline/message.txt",
             "log_stream_name": "{instance_id}",
             "timestamp_format": "%Y-%m-%d %H:%M:%S,%f",
             "multi_line_start_pattern": "^[\\d\\d\\d\\d-\\d\\d-\\d\\d ]"

--- a/ops/ansible/playbooks-ccs/templates/cwagent-data-pipeline.json.j2
+++ b/ops/ansible/playbooks-ccs/templates/cwagent-data-pipeline.json.j2
@@ -5,13 +5,13 @@
         "collect_list": [
           {
             "file_path": "/var/log/messages",
-            "log_group_name": "/var/log/messages",
+            "log_group_name": "/bfd/{{ env }}/var/log/messages",
             "log_stream_name": "{instance_id}",
             "timestamp_format": "%b %d %H:%M:%S"
           },
           {
             "file_path": "/var/log/secure",
-            "log_group_name": "/var/log/secure",
+            "log_group_name": "/bfd/{{ env }}/var/log/secure",
             "log_stream_name": "{instance_id}",
             "timestamp_format": "%b %d %H:%M:%S"
           },

--- a/ops/ansible/playbooks-ccs/templates/cwagent-data-server.json.j2
+++ b/ops/ansible/playbooks-ccs/templates/cwagent-data-server.json.j2
@@ -16,7 +16,7 @@
             "timestamp_format": "%b %d %H:%M:%S"
           },
           {
-            "file_path": "{{ bfd_server_dir }}/bluebutton-server-app-log-access.json",
+            "file_path": "{{ bfd_server_dir }}/access.json",
             "log_group_name": "/bfd/{{ env }}/bfd-server/access.json",
             "log_stream_name": "{instance_id}",
             "timestamp_format": "%Y-%m-%dT%H:%M:%S%z"

--- a/ops/ansible/playbooks-ccs/templates/cwagent-data-server.json.j2
+++ b/ops/ansible/playbooks-ccs/templates/cwagent-data-server.json.j2
@@ -5,13 +5,13 @@
         "collect_list": [
           {
             "file_path": "/var/log/messages",
-            "log_group_name": "/var/log/messages",
+            "log_group_name": "/bfd/{{ env }}/var/log/messages",
             "log_stream_name": "{instance_id}",
             "timestamp_format": "%b %d %H:%M:%S"
           },
           {
             "file_path": "/var/log/secure",
-            "log_group_name": "/var/log/secure",
+            "log_group_name": "/bfd/{{ env }}/var/log/secure",
             "log_stream_name": "{instance_id}",
             "timestamp_format": "%b %d %H:%M:%S"
           },

--- a/ops/terraform/modules/stateful/main.tf
+++ b/ops/terraform/modules/stateful/main.tf
@@ -519,38 +519,38 @@ resource "aws_cloudwatch_log_group" "var_log_secure" {
   tags       = local.env_config.tags
 }
 
-resource "aws_cloudwatch_log_group" "var_log_messages" {
+resource "aws_cloudwatch_log_group" "bfd_pipeline_messages_txt" {
   name       = "/bfd/${var.env_config.env}/bfd-pipeline/messages.txt"
   kms_key_id = data.aws_kms_key.master_key.arn
   tags       = var.env_config.tags
 }
 
 resource "aws_cloudwatch_log_group" "bfd_server_access_txt" {
-  name       = "/bfd/${var.env}/bfd-server/access.txt"
+  name       = "/bfd/${var.env_config.env}/bfd-server/access.txt"
   kms_key_id = data.aws_kms_key.master_key.arn
   tags       = var.env_config.tags
 }
 
 resource "aws_cloudwatch_log_group" "bfd_server_access_json" {
-  name       = "/bfd/${var.env}/bfd-server/access.json"
+  name       = "/bfd/${var.env_config.env}/bfd-server/access.json"
   kms_key_id = data.aws_kms_key.master_key.arn
   tags       = var.env_config.tags
 }
 
 resource "aws_cloudwatch_log_group" "bfd_server_messages_json" {
-  name       = "/bfd/${var.env}/bfd-server/messages.json"
+  name       = "/bfd/${var.env_config.env}/bfd-server/messages.json"
   kms_key_id = data.aws_kms_key.master_key.arn
   tags       = var.env_config.tags
 }
 
 resource "aws_cloudwatch_log_group" "bfd_server_newrelic_agent" {
-  name       = "/bfd/${var.env}/bfd-server/newrelic_agent.log"
+  name       = "/bfd/${var.env_config.env}/bfd-server/newrelic_agent.log"
   kms_key_id = data.aws_kms_key.master_key.arn
   tags       = var.env_config.tags
 }
 
 resource "aws_cloudwatch_log_group" "bfd_server_gc" {
-  name       = "/bfd/${var.env}/bfd-server/gc.log"
+  name       = "/bfd/${var.env_config.env}/bfd-server/gc.log"
   kms_key_id = data.aws_kms_key.master_key.arn
   tags       = var.env_config.tags
 }

--- a/ops/terraform/modules/stateful/main.tf
+++ b/ops/terraform/modules/stateful/main.tf
@@ -504,3 +504,53 @@ resource "aws_iam_user_policy_attachment" "etl_rw_s3" {
   user       = aws_iam_user.etl.name
   policy_arn = aws_iam_policy.etl_rw_s3.arn
 }
+
+# CloudWatch Log Groups
+#
+resource "aws_cloudwatch_log_group" "var_log_messages" {
+  name       = "/bfd/${var.env_config.env}/var/log/messages"
+  kms_key_id = data.aws_kms_key.master_key.arn
+  tags       = local.env_config.tags
+}
+
+resource "aws_cloudwatch_log_group" "var_log_secure" {
+  name       = "/bfd/${var.env_config.env}/var/log/secure"
+  kms_key_id = data.aws_kms_key.master_key.arn
+  tags       = local.env_config.tags
+}
+
+resource "aws_cloudwatch_log_group" "var_log_messages" {
+  name       = "/bfd/${var.env_config.env}/bfd-pipeline/messages.txt"
+  kms_key_id = data.aws_kms_key.master_key.arn
+  tags       = var.env_config.tags
+}
+
+resource "aws_cloudwatch_log_group" "bfd_server_access_txt" {
+  name       = "/bfd/${var.env}/bfd-server/access.txt"
+  kms_key_id = data.aws_kms_key.master_key.arn
+  tags       = var.env_config.tags
+}
+
+resource "aws_cloudwatch_log_group" "bfd_server_access_json" {
+  name       = "/bfd/${var.env}/bfd-server/access.json"
+  kms_key_id = data.aws_kms_key.master_key.arn
+  tags       = var.env_config.tags
+}
+
+resource "aws_cloudwatch_log_group" "bfd_server_messages_json" {
+  name       = "/bfd/${var.env}/bfd-server/messages.json"
+  kms_key_id = data.aws_kms_key.master_key.arn
+  tags       = var.env_config.tags
+}
+
+resource "aws_cloudwatch_log_group" "bfd_server_newrelic_agent" {
+  name       = "/bfd/${var.env}/bfd-server/newrelic_agent.log"
+  kms_key_id = data.aws_kms_key.master_key.arn
+  tags       = var.env_config.tags
+}
+
+resource "aws_cloudwatch_log_group" "bfd_server_gc" {
+  name       = "/bfd/${var.env}/bfd-server/gc.log"
+  kms_key_id = data.aws_kms_key.master_key.arn
+  tags       = var.env_config.tags
+}


### PR DESCRIPTION
Create all of the CloudWatch log groups as part of the stateful Terraform setup.

Why? Won't the CloudWatch agent just create all of these when it pushes records into them? Yes, it will, but this fixes two things:
1. It ensures that all of the data written to the log groups is encrypted.
2. It ensures that creating the CloudWatch metrics against these groups don't fail.

https://jira.cms.gov/browse/BLUEBUTTON-1288