### PR TITLE
BLUEBUTTON-1288: Allow EC2 instances to push to CloudWatch logs

### DIFF
--- a/ops/terraform/modules/resources/iam/main.tf
+++ b/ops/terraform/modules/resources/iam/main.tf
@@ -28,6 +28,27 @@ resource "aws_iam_role" "instance" {
   EOF
 }
 
+resource "aws_iam_role_policy" "logs_policy" {
+  name = "bfd-${var.env_config.env}-${var.name}-logs-policy"
+  role = aws_iam_role.instance.id
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "logs:PutLogEvents",
+          "logs:CreateLogStream"
+        ],
+        "Resource": ["*"]
+      }
+    ]
+  }
+  EOF
+}
+
 resource "aws_iam_role_policy" "s3_policy" {
   count = length(var.s3_bucket_arns) > 0 ? 1 : 0
   name = "bfd-${var.env_config.env}-${var.name}-s3-policy"


### PR DESCRIPTION
This is apparently working for the BFD Server? No idea why; I'm not seeing the permissions that enable that anywhere in our Terraform.

Nevertheless, it definitely wasn't working for the BFD Pipeline, so I'm adding this fix, which will cover both of them.

https://jira.cms.gov/browse/BLUEBUTTON-1288