### PR TITLE
BLUEBUTTON-1288: Fixed the bfd-pipeline/messages.txt log group name

### DIFF
--- a/ops/ansible/playbooks-ccs/templates/cwagent-data-pipeline.json.j2
+++ b/ops/ansible/playbooks-ccs/templates/cwagent-data-pipeline.json.j2
@@ -17,7 +17,7 @@
           },
           {
             "file_path": "/bluebutton-data-pipeline/bluebutton-data-pipeline.log",
-            "log_group_name": "/bfd/{{ env }}/bfd-pipeline/message.txt",
+            "log_group_name": "/bfd/{{ env }}/bfd-pipeline/messages.txt",
             "log_stream_name": "{instance_id}",
             "timestamp_format": "%Y-%m-%d %H:%M:%S,%f",
             "multi_line_start_pattern": "^[\\d\\d\\d\\d-\\d\\d-\\d\\d ]"


### PR DESCRIPTION
Had a silly typo there that needed to be fixed.

https://jira.cms.gov/browse/BLUEBUTTON-1288