### PR TITLE
BLUEBUTTON-1288: Allow EC2 instances to view EC2 tags

### DIFF
--- a/ops/terraform/modules/resources/iam/main.tf
+++ b/ops/terraform/modules/resources/iam/main.tf
@@ -39,6 +39,7 @@ resource "aws_iam_role_policy" "logs_policy" {
       {
         "Effect": "Allow",
         "Action": [
+          "ec2:DescribeTags",
           "logs:PutLogEvents",
           "logs:CreateLogStream"
         ],


### PR DESCRIPTION
This is required by the CloudWatch agent running on these boxes.

Doesn't stop it from running entirely, but should fix these errors that I'm seeing in its log:

```
2019-10-06T03:42:37Z E! refresh EC2 Instance Tags failed: UnauthorizedOperation: You are not authorized to perform this operation.
        status code: 403, request id: d45bc71d-6243-4edb-9f10-c19df94e4aff, metrics will be dropped until it got fixed
```

https://jira.cms.gov/browse/BLUEBUTTON-1288