### PR TITLE
BLUEBUTTON-1359: Fix New Relic app name in CCS prod

### DIFF
--- a/ops/ansible/playbooks-ccs/vars/prod/group_vars/all/env_specific.yml
+++ b/ops/ansible/playbooks-ccs/vars/prod/group_vars/all/env_specific.yml
@@ -41,6 +41,3 @@ data_server_ssl_client_certificates:
     certificate: "{{ lookup('file', 'files/client_data_server_mct_prod_certificate.pem') }}"
   - alias: client_performance_tester
     certificate: "{{ lookup('file', 'files/client_data_server_performance_tester_certificate.pem') }}"
-
-# Adjust the default New Relic `app_name` setting to include AWS env name.
-data_server_new_relic_app_name: "BFD Server ({{ env_name_std }}, HealtAPT)"


### PR DESCRIPTION
Was causing New Relic data for the _CCS_ `prod` env to be stored under the "BFD Server (prod, _HealthAPT_)" app. Whoops.

I have no clue how this ended up here (other than -- obviously -- I goofed it at some point). The variable isn't redefined in the same file for the other CCS envs, nor should it be: the default in the playbooks is fine.

https://jira.cms.gov/browse/BLUEBUTTON-1359