### PR TITLE
BLUEBUTTON-1360: Use Reserve Instances

### DIFF
--- a/ops/terraform/modules/resources/bfd_pipeline/main.tf
+++ b/ops/terraform/modules/resources/bfd_pipeline/main.tf
@@ -1,3 +1,7 @@
+locals {
+  is_prod               = var.env_config.env == "prod" 
+}
+
 # Locate the S3 bucket that stores the RIF data to be processed by the BFD Pipeline application.
 #
 data "aws_s3_bucket" "rif" {
@@ -114,8 +118,8 @@ module "ec2_instance" {
   az              = "us-east-1b" # Same as the master db
 
   launch_config   = {
-    instance_type = "m5.2xlarge"
-    volume_size   = 100 # GB
+    instance_type = local.is_prod ? "m5.4xlarge" : "m5.xlarge"  # Use reserve instances (4x and 1x). Prod only has big workloads  
+    volume_size   = 200 # GB                                    # Have enough space to download RIF files
     ami_id        = var.launch_config.ami_id
 
     key_name      = var.launch_config.ssh_key_name

--- a/ops/terraform/modules/resources/bfd_pipeline/main.tf
+++ b/ops/terraform/modules/resources/bfd_pipeline/main.tf
@@ -118,8 +118,8 @@ module "ec2_instance" {
   az              = "us-east-1b" # Same as the master db
 
   launch_config   = {
-    instance_type = local.is_prod ? "m5.4xlarge" : "m5.xlarge"  # Use reserve instances (4x and 1x). Prod only has big workloads  
-    volume_size   = 200 # GB                                    # Have enough space to download RIF files
+    instance_type = local.is_prod ? "m5.4xlarge" : "m5.xlarge"  # Use reserve instances. Use 4x only in prod. 
+    volume_size   = 200 # GB                                    # Make sure we have nough space to download RIF files
     ami_id        = var.launch_config.ami_id
 
     key_name      = var.launch_config.ssh_key_name

--- a/ops/terraform/modules/stateless/main.tf
+++ b/ops/terraform/modules/stateless/main.tf
@@ -223,7 +223,7 @@ module "fhir_asg" {
   }
 
   launch_config   = {
-    instance_type   = "m5.2xlarge" 
+    instance_type   = "m5.xlarge"             # Use reserve instances
     volume_size     = 100 # GB
     ami_id          = var.fhir_ami 
     key_name        = var.ssh_key_name 


### PR DESCRIPTION
**Why**
To save costs, use reserve instances when possible. Also, add a bump in volume size of the ETL servers to get them to run with real data. 

**What Changed**
- FHIR servers are m5.xlarge in size
- ETL servers are m5.4xLarge in `prod`, m5.xlarge elsewhere
- ETL servers have a 200GB volume size

**Notes**
- Not deployed to test or prod-sbx yet
- Terraform plan is attached in comments