### PR TITLE
Implement dynamic param passing for RDS per env, tune prod params

### DIFF
--- a/ops/terraform/env/prod-sbx/stateful/main.tf
+++ b/ops/terraform/env/prod-sbx/stateful/main.tf
@@ -16,6 +16,8 @@ module "stateful" {
     allocated_storage = 2000
   }
 
+  db_params = []
+
   db_import_mode = {
     enabled = false
     maintenance_work_mem = "1048576"

--- a/ops/terraform/env/prod/stateful/main.tf
+++ b/ops/terraform/env/prod/stateful/main.tf
@@ -16,6 +16,13 @@ module "stateful" {
     allocated_storage = 16000
   }
 
+  db_params = [
+    {name="max_worker_processes", value="16", apply_on_reboot=true},
+    {name="random_page_cost", value="1", apply_on_reboot=false},
+    {name="temp_buffers", value="8192", apply_on_reboot=false},
+    {name="work_mem", value="32768", apply_on_reboot=false}
+  ]
+
   db_import_mode = {
     enabled = false
     maintenance_work_mem = "4194304"

--- a/ops/terraform/env/prod/stateful/main.tf
+++ b/ops/terraform/env/prod/stateful/main.tf
@@ -12,7 +12,7 @@ module "stateful" {
 
   db_config = { 
     instance_class    = "db.r5.24xlarge"
-    iops              = 80000
+    iops              = 64000
     allocated_storage = 16000
   }
 

--- a/ops/terraform/env/prod/stateful/main.tf
+++ b/ops/terraform/env/prod/stateful/main.tf
@@ -17,7 +17,10 @@ module "stateful" {
   }
 
   db_params = [
-    {name="max_worker_processes", value="16", apply_on_reboot=true},
+    {name="effective_io_concurrency", value="300", apply_on_reboot=false},
+    {name="default_statistics_target", value="1000", apply_on_reboot=false},
+    {name="max_worker_processes", value="96", apply_on_reboot=true},
+    {name="max_parallel_workers_per_gather", value="48", apply_on_reboot=false},
     {name="random_page_cost", value="1", apply_on_reboot=false},
     {name="temp_buffers", value="8192", apply_on_reboot=false},
     {name="work_mem", value="32768", apply_on_reboot=false}

--- a/ops/terraform/env/test/stateful/main.tf
+++ b/ops/terraform/env/test/stateful/main.tf
@@ -16,7 +16,15 @@ module "stateful" {
     allocated_storage = 12000
   }
 
-  db_params = []
+  db_params = [
+    {name="effective_io_concurrency", value="300", apply_on_reboot=false},
+    {name="default_statistics_target", value="1000", apply_on_reboot=false},
+    {name="max_worker_processes", value="96", apply_on_reboot=true},
+    {name="max_parallel_workers_per_gather", value="48", apply_on_reboot=false},
+    {name="random_page_cost", value="1", apply_on_reboot=false},
+    {name="temp_buffers", value="8192", apply_on_reboot=false},
+    {name="work_mem", value="32768", apply_on_reboot=false}
+  ]
 
   db_import_mode = {
     enabled = false

--- a/ops/terraform/env/test/stateful/main.tf
+++ b/ops/terraform/env/test/stateful/main.tf
@@ -16,6 +16,8 @@ module "stateful" {
     allocated_storage = 12000
   }
 
+  db_params = []
+
   db_import_mode = {
     enabled = false
     maintenance_work_mem = "4194304"

--- a/ops/terraform/modules/stateful/main.tf
+++ b/ops/terraform/modules/stateful/main.tf
@@ -195,6 +195,15 @@ resource "aws_db_parameter_group" "default_mode" {
   name        = "bfd-${local.env_config.env}-default-mode-parameter-group"
   family      = "postgres9.6"
   description = "Sets parameters for standard operation"
+
+  dynamic "parameter" {
+    for_each = var.db_params
+    content {
+      name         = parameter.value.name
+      value        = parameter.value.value
+      apply_method = parameter.value.apply_on_reboot ? "pending-reboot" : null
+    }
+  }
 }
 
 resource "aws_db_parameter_group" "import_mode" {

--- a/ops/terraform/modules/stateful/variables.tf
+++ b/ops/terraform/modules/stateful/variables.tf
@@ -3,6 +3,11 @@ variable "db_config" {
   type              = object({instance_class = string, allocated_storage=number, iops = number})
 }
 
+variable "db_params" {
+  description       = "Parameters that populate the default parameter group"
+  type              = list(object({name = string, value = string, apply_on_reboot = bool}))
+}
+
 variable "db_import_mode" {
   description       = "Enable or disable parameters that optimize bulk data imports"
   type              = object({enabled = bool, maintenance_work_mem = string})


### PR DESCRIPTION
This allows us to more easily tune RDS parameters per environment.  This also tunes 4 parameters in prod CCS RDS that were much lower than their HealthApt equivalents.

Side note: Do we need import mode any longer?  Would be great to rip it out if unneeded.  It's unclear to me whether it even helped with the bulk imports at all.