### PR TITLE
BLUEBUTTON-1288: Bump space for RIF downloads to 1TB

### DIFF
--- a/ops/terraform/modules/resources/bfd_pipeline/main.tf
+++ b/ops/terraform/modules/resources/bfd_pipeline/main.tf
@@ -119,7 +119,7 @@ module "ec2_instance" {
 
   launch_config   = {
     instance_type = local.is_prod ? "m5.4xlarge" : "m5.xlarge"  # Use reserve instances. Use 4x only in prod. 
-    volume_size   = 200 # GB                                    # Make sure we have nough space to download RIF files
+    volume_size   = 1000 # GB                                   # Make sure we have nough space to download RIF files
     ami_id        = var.launch_config.ami_id
 
     key_name      = var.launch_config.ssh_key_name


### PR DESCRIPTION
That's really all the BFD Pipeline app does with disk space: download RIF files ahead of time, so it doesn't have to wait later on in processing.

https://jira.cms.gov/browse/BLUEBUTTON-1288