### PR TITLE
Extend gold image defined root partition with all available free space

### DIFF
--- a/ops/terraform/modules/resources/bfd_pipeline/main.tf
+++ b/ops/terraform/modules/resources/bfd_pipeline/main.tf
@@ -118,6 +118,7 @@ module "ec2_instance" {
   az              = "us-east-1b" # Same as the master db
 
   launch_config   = {
+    # instance_type must support NVMe EBS volumes: https://github.com/CMSgov/beneficiary-fhir-data/pull/110
     instance_type = local.is_prod ? "m5.4xlarge" : "m5.xlarge"  # Use reserve instances. Use 4x only in prod. 
     volume_size   = 1000 # GB                                   # Make sure we have nough space to download RIF files
     ami_id        = var.launch_config.ami_id

--- a/ops/terraform/modules/resources/templates/fhir_server.tpl
+++ b/ops/terraform/modules/resources/templates/fhir_server.tpl
@@ -3,6 +3,12 @@ set -e
 
 exec > >(tee -a /var/log/user_data.log 2>&1)
 
+# Extend gold image defined root partition with all available free space
+sudo growpart /dev/nvme0n1 2
+sudo pvresize /dev/nvme0n1p2
+sudo lvextend -l +100%FREE /dev/VolGroup00/rootVol
+sudo xfs_growfs /
+
 git clone https://github.com/CMSgov/beneficiary-fhir-data.git --branch ${gitBranchName} --single-branch
 
 cd beneficiary-fhir-data/ops/ansible/playbooks-ccs/

--- a/ops/terraform/modules/resources/templates/pipeline_server.tpl
+++ b/ops/terraform/modules/resources/templates/pipeline_server.tpl
@@ -3,6 +3,12 @@ set -e
 
 exec > >(tee -a /var/log/user_data.log 2>&1)
 
+# Extend gold image defined root partition with all available free space
+sudo growpart /dev/nvme0n1 2
+sudo pvresize /dev/nvme0n1p2
+sudo lvextend -l +100%FREE /dev/VolGroup00/rootVol
+sudo xfs_growfs /
+
 git clone https://github.com/CMSgov/beneficiary-fhir-data.git --branch ${gitBranchName} --single-branch
 
 cd beneficiary-fhir-data/ops/ansible/playbooks-ccs/

--- a/ops/terraform/modules/stateless/main.tf
+++ b/ops/terraform/modules/stateless/main.tf
@@ -223,6 +223,7 @@ module "fhir_asg" {
   }
 
   launch_config   = {
+    # instance_type must support NVMe EBS volumes: https://github.com/CMSgov/beneficiary-fhir-data/pull/110
     instance_type   = "m5.xlarge"             # Use reserve instances
     volume_size     = 100 # GB
     ami_id          = var.fhir_ami 


### PR DESCRIPTION
@karlmdavis discovered that despite us setting the EBS volume size on deploy, the instance was not properly utilizing the space.  This fixes that.  Only issue I see is if for some reason we had to revert to older instance classes that do not support [NVMe volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances), this would break deploys without more logic.