### PR TITLE
Use high compute instance in prod for initial data load

### DIFF
--- a/ops/terraform/modules/resources/bfd_pipeline/main.tf
+++ b/ops/terraform/modules/resources/bfd_pipeline/main.tf
@@ -119,7 +119,7 @@ module "ec2_instance" {
 
   launch_config   = {
     # instance_type must support NVMe EBS volumes: https://github.com/CMSgov/beneficiary-fhir-data/pull/110
-    instance_type = local.is_prod ? "m5.4xlarge" : "m5.xlarge"  # Use reserve instances. Use 4x only in prod. 
+    instance_type = local.is_prod ? "c5.18xlarge" : "m5.xlarge"  # Use reserve instances. 2019-10-08: Use high compute instance in prod for initial data load
     volume_size   = 1000 # GB                                   # Make sure we have nough space to download RIF files
     ami_id        = var.launch_config.ami_id
 


### PR DESCRIPTION
Per @karlmdavis, lets massively bump up the compute resources on prod ETL while the initial data load is attempted.