### PR TITLE
BBrooks/IncreaseASG

### DIFF
--- a/ops/ansible/playbooks-hhsdevcloud/group_vars/all/main.yml
+++ b/ops/ansible/playbooks-hhsdevcloud/group_vars/all/main.yml
@@ -44,7 +44,7 @@ data_pipeline_jvm_args: '-Xmx58g'
 data_pipeline_loader_threads: 100  # The service will use x2 this number of DB connections.
 data_server_appserver_jvmargs: '-Xmx58g -XX:MaxMetaspaceSize=4g'
 data_server_db_connections_max: '40'
-data_server_asg_max_size: 24  # Watch out that this (plus extra instances for next deploy) doesn't exceed the max allowed DB connections!
+data_server_asg_max_size: 7  # Watch out that this (plus extra instances for next deploy) doesn't exceed the max allowed DB connections!
 # When `true`, Ansible will configure the FHIR server to run such that Java
 # flame graphs can be collected. This will incur a performance penalty of 1%-
 # 3%, and so should be left disabled unless specifically needed.

--- a/ops/ansible/playbooks-hhsdevcloud/group_vars/all/main.yml
+++ b/ops/ansible/playbooks-hhsdevcloud/group_vars/all/main.yml
@@ -44,7 +44,7 @@ data_pipeline_jvm_args: '-Xmx58g'
 data_pipeline_loader_threads: 100  # The service will use x2 this number of DB connections.
 data_server_appserver_jvmargs: '-Xmx58g -XX:MaxMetaspaceSize=4g'
 data_server_db_connections_max: '40'
-data_server_asg_max_size: 7  # Watch out that this (plus extra instances for next deploy) doesn't exceed the max allowed DB connections!
+data_server_asg_max_size: 24  # Watch out that this (plus extra instances for next deploy) doesn't exceed the max allowed DB connections!
 # When `true`, Ansible will configure the FHIR server to run such that Java
 # flame graphs can be collected. This will incur a performance penalty of 1%-
 # 3%, and so should be left disabled unless specifically needed.

--- a/ops/terraform/modules/resources/asg/main.tf
+++ b/ops/terraform/modules/resources/asg/main.tf
@@ -216,9 +216,9 @@ resource "aws_cloudwatch_metric_alarm" "high-cpu" {
   evaluation_periods  = 2
   metric_name         = "CPUUtilization"
   namespace           = "AWS/EC2"
-  period              = 120
+  period              = 60
   statistic           = "Average"
-  threshold           = 60
+  threshold           = 50
 
   dimensions = {
     AutoScalingGroupName = aws_autoscaling_group.main.name

--- a/ops/terraform/modules/stateless/main.tf
+++ b/ops/terraform/modules/stateless/main.tf
@@ -217,7 +217,7 @@ module "fhir_asg" {
   # Initial size is one server per AZ
   asg_config      = {
     min           = length(local.azs)
-    max           = 2*length(local.azs)
+    max           = 8*length(local.azs)
     desired       = length(local.azs)
     sns_topic_arn = ""
   }


### PR DESCRIPTION
3. At the same time, we should bump our ASG’s max size to 24 (in all envs).
4. We may want to tweak our scaling to policy to 2x after 1 minute past 50% CPU usage.