### PR TITLE
BLUEBUTTON-1362: Fix BB2 connection to prod

### DIFF
--- a/ops/terraform/modules/stateless/main.tf
+++ b/ops/terraform/modules/stateless/main.tf
@@ -18,7 +18,7 @@ locals {
     prod            = [
       "bfd-prod-vpc-to-mct-prod-vpc", "bfd-prod-vpc-to-mct-prod-dr-vpc", 
       "bfd-prod-vpc-to-dpc-prod-vpc", 
-      "bfd-prod-vpc-to-dpc-prod-vpc", 
+      "bfd-prod-vpc-to-bluebutton-prod", 
       "bfd-prod-vpc-to-bcda-prod-vpc"
     ],
     prod-sbx        = [


### PR DESCRIPTION
**Why**
Fix the connection from BB2 to CCS prod

**What Changed**
Add the BB2 VPC peering CIDR to the LB's security group. Only affects prod. 