### PR TITLE
Enable connection draining on ELBs

### DIFF
--- a/ops/terraform/modules/resources/lb/main.tf
+++ b/ops/terraform/modules/resources/lb/main.tf
@@ -52,9 +52,10 @@ resource "aws_elb" "main" {
   subnets               = data.aws_subnet.app_subnets[*].id # Gives AZs and VPC association
   security_groups       = [aws_security_group.lb.id]
 
-  cross_zone_load_balancing = false   # Match HealthApt
-  idle_timeout              = 60      # (seconds) Match HealthApt
-  connection_draining       = false   # Match HealthApt
+  cross_zone_load_balancing   = false   # Match HealthApt
+  idle_timeout                = 60      # (seconds) Match HealthApt
+  connection_draining         = true
+  connection_draining_timeout = 60
 
   listener {
     lb_protocol         = "TCP"


### PR DESCRIPTION
This allows us to more safely remove an ASG instance from service.  According to Rick MCT does not let go of connections so this will not make instance removal entirely safe, but will hopefully provide a buffer so that reduces errors for new incoming requests.