### PR TITLE
Fix duplicate EOB latency alarm name

### DIFF
--- a/ops/terraform/modules/resources/cw_metric_alarms/main.tf
+++ b/ops/terraform/modules/resources/cw_metric_alarms/main.tf
@@ -53,7 +53,7 @@ resource "aws_cloudwatch_metric_alarm" "http-500" {
 
 # EOB Slow Response > 4s p90
 resource "aws_cloudwatch_metric_alarm" "http-requests-latency-fhir-eob-4s" {
-  alarm_name                = "${var.app}-${var.env}-http-requests-latency-fhir-eob"
+  alarm_name                = "${var.app}-${var.env}-http-requests-latency-fhir-eob-4s"
   comparison_operator       = "GreaterThanThreshold"
   evaluation_periods        = local.http_latency_4s.eval_periods
   period                    = local.http_latency_4s.period
@@ -73,7 +73,7 @@ resource "aws_cloudwatch_metric_alarm" "http-requests-latency-fhir-eob-4s" {
 
 # EOB Slow Response > 6s p99 over 1h
 resource "aws_cloudwatch_metric_alarm" "http-requests-latency-fhir-eob-6s" {
-  alarm_name                = "${var.app}-${var.env}-http-requests-latency-fhir-eob"
+  alarm_name                = "${var.app}-${var.env}-http-requests-latency-fhir-eob-6s"
   comparison_operator       = "GreaterThanThreshold"
   evaluation_periods        = local.http_latency_6s.eval_periods
   period                    = local.http_latency_6s.period


### PR DESCRIPTION
This bug was causing terraform to constantly try to replace a single alarm with either the 4s one or the 6s one (depending which apply "won" on a last apply).