### PR TITLE
BLUEBUTTON 1363:  Narrow VPN ingress

### DIFF
--- a/ops/terraform/modules/resources/asg/main.tf
+++ b/ops/terraform/modules/resources/asg/main.tf
@@ -42,11 +42,17 @@ data "aws_kms_key" "master_key" {
 #
 resource "aws_security_group" "base" {
   name          = "bfd-${var.env_config.env}-${var.role}-base"
-  description   = "Allow CI access to app servers"
+  description   = "Allow CI and SSH access to servers"
   vpc_id        = var.env_config.vpc_id
   tags          = merge({Name="bfd-${var.env_config.env}-${var.role}-base"}, local.tags)
 
   # Note: If we want to allow Jenkins to SSH into boxes, that would go here.
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = var.mgmt_config.ci_cidrs
+  }
 
   egress {
     from_port   = 0

--- a/ops/terraform/modules/resources/asg/main.tf
+++ b/ops/terraform/modules/resources/asg/main.tf
@@ -42,17 +42,11 @@ data "aws_kms_key" "master_key" {
 #
 resource "aws_security_group" "base" {
   name          = "bfd-${var.env_config.env}-${var.role}-base"
-  description   = "Allow CI and SSH access to servers"
+  description   = "Allow CI access to app servers"
   vpc_id        = var.env_config.vpc_id
   tags          = merge({Name="bfd-${var.env_config.env}-${var.role}-base"}, local.tags)
 
   # Note: If we want to allow Jenkins to SSH into boxes, that would go here.
-  ingress {
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = var.mgmt_config.ci_cidrs
-  }
 
   egress {
     from_port   = 0

--- a/ops/terraform/modules/resources/asg/main.tf
+++ b/ops/terraform/modules/resources/asg/main.tf
@@ -93,7 +93,7 @@ resource "aws_security_group_rule" "allow_db_access" {
 resource "aws_launch_template" "main" {
   name                          = "bfd-${var.env_config.env}-${var.role}"
   description                   = "Template for the ${var.env_config.env} environment ${var.role} servers"
-  vpc_security_group_ids        = concat([aws_security_group.base.id], aws_security_group.app[*].id)
+  vpc_security_group_ids        = concat([aws_security_group.base.id, var.mgmt_config.vpn_sg], aws_security_group.app[*].id)
   key_name                      = var.launch_config.key_name
   image_id                      = var.launch_config.ami_id
   instance_type                 = var.launch_config.instance_type

--- a/ops/terraform/modules/resources/asg/main.tf
+++ b/ops/terraform/modules/resources/asg/main.tf
@@ -38,7 +38,7 @@ data "aws_kms_key" "master_key" {
 # Security groups
 #
 
-# Base security includes management SSH access
+# Base security group with egress 
 #
 resource "aws_security_group" "base" {
   name          = "bfd-${var.env_config.env}-${var.role}-base"
@@ -46,8 +46,8 @@ resource "aws_security_group" "base" {
   vpc_id        = var.env_config.vpc_id
   tags          = merge({Name="bfd-${var.env_config.env}-${var.role}-base"}, local.tags)
 
-  # Note: If we want to allow Jenkins to SSH into boxes, that would go here.
-
+  ingress       = []  # Make the ingress empty for this SG. 
+  
   egress {
     from_port   = 0
     protocol    = "-1"


### PR DESCRIPTION
**Why**
To narrow the VPN ingress on our FHIR servers. This problem was caught in the audit that @cthulhuplus did. Fixing this is part of good defense in depth practice. 

**Details**
Our current `bfd-<env>-fhir-base` security groups have a wide 10.0.0.0/8 ingress rule. There appears to be a bug in TF where this ingress rule isn't being cleared in deploys. Hence, if we rebuilt our environments they wouldn't have VPN access. 

@karlmdavis ran into this problem during the pipeline bring-up and found the solution. We need to add the private-vpn security group to each instance. 