### PR TITLE
Increase ASG capacity wait timeout to 20m

### DIFF
--- a/ops/terraform/modules/resources/asg/main.tf
+++ b/ops/terraform/modules/resources/asg/main.tf
@@ -156,7 +156,7 @@ resource "aws_autoscaling_group" "main" {
   # If an lb is defined, wait for the ELB 
   min_elb_capacity          = var.lb_config == null ? null : var.asg_config.min
   wait_for_elb_capacity     = var.lb_config == null ? null : var.asg_config.min
-  wait_for_capacity_timeout = var.lb_config == null ? null : "10m"
+  wait_for_capacity_timeout = var.lb_config == null ? null : "20m"
 
   health_check_grace_period = 300
   health_check_type         = var.lb_config == null ? "EC2" : "ELB" # Failures of ELB healthchecks are asg failures


### PR DESCRIPTION
Our deploy times have crept up in length, possibly due to adding more work at launch time to handle disk partitioning: https://github.com/CMSgov/beneficiary-fhir-data/pull/110

AWS operations are also generally unreliable.  In the last 2 days I have seen numerous instances were we did not get to full capacity before terraform hit its ASG timeout:
```
Error: "bfd-test-fhir-120": Waiting up to 10m0s: Need at least 3 healthy instances in ELB, have 2.
```

This causes issues where the old ASG is not properly cleaned up and more concerning, scaling policies are not properly applied to the new ASG. A better long term solution is to investigate ways to speed up our deploys, but I think this will help in the interim.