### PR TITLE
Prefer the behavior of min_elb_capacity to wait_for_elb_capacity

### DIFF
--- a/ops/terraform/modules/resources/asg/main.tf
+++ b/ops/terraform/modules/resources/asg/main.tf
@@ -155,7 +155,6 @@ resource "aws_autoscaling_group" "main" {
 
   # If an lb is defined, wait for the ELB 
   min_elb_capacity          = var.lb_config == null ? null : var.asg_config.min
-  wait_for_elb_capacity     = var.lb_config == null ? null : var.asg_config.min
   wait_for_capacity_timeout = var.lb_config == null ? null : "20m"
 
   health_check_grace_period = 300


### PR DESCRIPTION
Discussion here: https://cmsgov.slack.com/archives/CJQRH9RLG/p1570746279101600

Please sanity check me on the behavior by reading this doc: https://www.terraform.io/docs/providers/aws/r/autoscaling_group.html#waiting-for-capacity