### PR TITLE
BLUEBUTTON 1370: Remove RDS disk queue depth alarms

### DIFF
--- a/ops/terraform/modules/stateful/main.tf
+++ b/ops/terraform/modules/stateful/main.tf
@@ -336,11 +336,8 @@ module "master_alarms" {
     threshold         = local.cw_latency
   }
 
-  disk_queue_depth = {
-    period            = local.cw_period
-    eval_periods      = local.cw_eval_periods
-    threshold         = local.cw_disk_queue_depth
-  }
+  # Do not alarm on disk_queue_depth. This metric didn't
+  # have much correlation to a healthy database
 
   alarm_notification_arn = aws_sns_topic.cloudwatch_alarms.arn
   ok_notification_arn = aws_sns_topic.cloudwatch_ok.arn

--- a/ops/terraform/modules/stateful/main.tf
+++ b/ops/terraform/modules/stateful/main.tf
@@ -359,17 +359,14 @@ module "replica1_alarms" {
     threshold         = local.cw_latency
   }
 
-  disk_queue_depth = {
-    period            = local.cw_period
-    eval_periods      = local.cw_eval_periods
-    threshold         = local.cw_disk_queue_depth
-  }
-
   replica_lag = {
     period            = local.cw_period
     eval_periods      = local.cw_eval_periods
     threshold         = local.cw_replica_lag
   }
+
+  # Do not alarm on disk_queue_depth. This metric didn't
+  # have much correlation to a healthy database
 
   alarm_notification_arn = aws_sns_topic.cloudwatch_alarms.arn
   ok_notification_arn = aws_sns_topic.cloudwatch_ok.arn
@@ -388,17 +385,14 @@ module "replica2_alarms" {
     threshold         = local.cw_latency
   }
 
-  disk_queue_depth = {
-    period            = local.cw_period
-    eval_periods      = local.cw_eval_periods
-    threshold         = local.cw_disk_queue_depth
-  }
-
   replica_lag = {
     period            = local.cw_period
     eval_periods      = local.cw_eval_periods
     threshold         = local.cw_replica_lag
   }
+
+  # Do not alarm on disk_queue_depth. This metric didn't
+  # have much correlation to a healthy database
 
   alarm_notification_arn = aws_sns_topic.cloudwatch_alarms.arn
   ok_notification_arn = aws_sns_topic.cloudwatch_ok.arn
@@ -417,17 +411,14 @@ module "replica3_alarms" {
     threshold         = local.cw_latency
   }
 
-  disk_queue_depth = {
-    period            = local.cw_period
-    eval_periods      = local.cw_eval_periods
-    threshold         = local.cw_disk_queue_depth
-  }
-
   replica_lag = {
     period            = local.cw_period
     eval_periods      = local.cw_eval_periods
     threshold         = local.cw_replica_lag
   }
+  
+  # Do not alarm on disk_queue_depth. This metric didn't
+  # have much correlation to a healthy database
 
   alarm_notification_arn = aws_sns_topic.cloudwatch_alarms.arn
   ok_notification_arn = aws_sns_topic.cloudwatch_ok.arn


### PR DESCRIPTION
**Why**
During testing disk queue depth went up higher than expected, but that event didn't correlate with overall RDS health. Since we don't want to be waken up for false events, remove the alarm on this metric.  

**What**
Simple change in the stateless module. 