### PR TITLE
BLUEBUTTON 1372: Smooth traffic migration between HealthApt to CCS

### DIFF
--- a/ops/terraform/env/prod-sbx/migration/main.tf
+++ b/ops/terraform/env/prod-sbx/migration/main.tf
@@ -15,6 +15,12 @@ module "migration" {
     tags              = {application="bfd", business="oeda", stack="prod-sbx", Environment="prod-sbx"}
   }  
 
+  # These values control the CCS and HealthApt DNS record weight for each partner
+  # A value of:
+  #   100 - 100% CCS, 0% HealthApt
+  #    50 - 50% CCS, 50% HealthApt
+  #     0 - 0 CCS, 100% HealthApt
+  #
   bb      = 50
   bcda    = 100
   dpc     = 100

--- a/ops/terraform/env/prod-sbx/migration/main.tf
+++ b/ops/terraform/env/prod-sbx/migration/main.tf
@@ -15,7 +15,7 @@ module "migration" {
     tags              = {application="bfd", business="oeda", stack="prod-sbx", Environment="prod-sbx"}
   }  
 
-  bb      = 100
+  bb      = 50
   bcda    = 100
   dpc     = 100
   mct     = 100

--- a/ops/terraform/env/prod/migration/main.tf
+++ b/ops/terraform/env/prod/migration/main.tf
@@ -16,7 +16,7 @@ module "migration" {
   }  
 
   bb      = 50
-  bcda    = 0
+  bcda    = 50
   dpc     = 0
   mct     = 0
 }

--- a/ops/terraform/env/prod/migration/main.tf
+++ b/ops/terraform/env/prod/migration/main.tf
@@ -15,6 +15,12 @@ module "migration" {
     tags              = {application="bfd", business="oeda", stack="prod", Environment="prod"}
   }  
 
+  # These values control the CCS and HealthApt DNS record weight for each partner
+  # A value of:
+  #   100 - 100% CCS, 0% HealthApt
+  #    50 - 50% CCS, 50% HealthApt
+  #     0 - 0 CCS, 100% HealthApt
+  #
   bb      = 50
   bcda    = 50
   dpc     = 50  

--- a/ops/terraform/env/prod/migration/main.tf
+++ b/ops/terraform/env/prod/migration/main.tf
@@ -15,7 +15,7 @@ module "migration" {
     tags              = {application="bfd", business="oeda", stack="prod", Environment="prod"}
   }  
 
-  bb      = 0
+  bb      = 50
   bcda    = 0
   dpc     = 0
   mct     = 0

--- a/ops/terraform/env/prod/migration/main.tf
+++ b/ops/terraform/env/prod/migration/main.tf
@@ -17,6 +17,6 @@ module "migration" {
 
   bb      = 50
   bcda    = 50
-  dpc     = 0
-  mct     = 0
+  dpc     = 50  
+  mct     = 50
 }

--- a/ops/terraform/env/test/migration/main.tf
+++ b/ops/terraform/env/test/migration/main.tf
@@ -15,6 +15,12 @@ module "migration" {
     tags              = {application="bfd", business="oeda", stack="test", Environment="test"}
   }  
 
+  # These values control the CCS and HealthApt DNS record weight for each partner
+  # A value of:
+  #   100 - 100% CCS, 0% HealthApt
+  #    50 - 50% CCS, 50% HealthApt
+  #     0 - 0 CCS, 100% HealthApt
+  #
   bb      = 100
   bcda    = 100
   dpc     = 100


### PR DESCRIPTION
The latest 50/50 settings for the migration scripts. These changes have already been applied to `prod` and `prod-sbx`