### PR TITLE
BLUEBUTTON-1374: Bump max_wal_senders to more gracefully handle replication between 3 read nodes during data load

### DIFF
--- a/ops/terraform/env/prod-sbx/stateful/main.tf
+++ b/ops/terraform/env/prod-sbx/stateful/main.tf
@@ -16,7 +16,9 @@ module "stateful" {
     allocated_storage = 2000
   }
 
-  db_params = []
+  db_params = [
+    {name="max_wal_senders", value="15", apply_on_reboot=true},
+  ]
 
   db_import_mode = {
     enabled = false

--- a/ops/terraform/env/prod/stateful/main.tf
+++ b/ops/terraform/env/prod/stateful/main.tf
@@ -20,6 +20,7 @@ module "stateful" {
     {name="effective_io_concurrency", value="300", apply_on_reboot=false},
     {name="default_statistics_target", value="1000", apply_on_reboot=false},
     {name="max_worker_processes", value="96", apply_on_reboot=true},
+    {name="max_wal_senders", value="15", apply_on_reboot=false},
     {name="max_parallel_workers_per_gather", value="48", apply_on_reboot=false},
     {name="random_page_cost", value="1", apply_on_reboot=false},
     {name="temp_buffers", value="8192", apply_on_reboot=false},

--- a/ops/terraform/env/prod/stateful/main.tf
+++ b/ops/terraform/env/prod/stateful/main.tf
@@ -20,7 +20,7 @@ module "stateful" {
     {name="effective_io_concurrency", value="300", apply_on_reboot=false},
     {name="default_statistics_target", value="1000", apply_on_reboot=false},
     {name="max_worker_processes", value="96", apply_on_reboot=true},
-    {name="max_wal_senders", value="15", apply_on_reboot=false},
+    {name="max_wal_senders", value="15", apply_on_reboot=true},
     {name="max_parallel_workers_per_gather", value="48", apply_on_reboot=false},
     {name="random_page_cost", value="1", apply_on_reboot=false},
     {name="temp_buffers", value="8192", apply_on_reboot=false},

--- a/ops/terraform/env/test/stateful/main.tf
+++ b/ops/terraform/env/test/stateful/main.tf
@@ -20,6 +20,7 @@ module "stateful" {
     {name="effective_io_concurrency", value="300", apply_on_reboot=false},
     {name="default_statistics_target", value="1000", apply_on_reboot=false},
     {name="max_worker_processes", value="96", apply_on_reboot=true},
+    {name="max_wal_senders", value="15", apply_on_reboot=false},
     {name="max_parallel_workers_per_gather", value="48", apply_on_reboot=false},
     {name="random_page_cost", value="1", apply_on_reboot=false},
     {name="temp_buffers", value="8192", apply_on_reboot=false},

--- a/ops/terraform/env/test/stateful/main.tf
+++ b/ops/terraform/env/test/stateful/main.tf
@@ -20,7 +20,7 @@ module "stateful" {
     {name="effective_io_concurrency", value="300", apply_on_reboot=false},
     {name="default_statistics_target", value="1000", apply_on_reboot=false},
     {name="max_worker_processes", value="96", apply_on_reboot=true},
-    {name="max_wal_senders", value="15", apply_on_reboot=false},
+    {name="max_wal_senders", value="15", apply_on_reboot=true},
     {name="max_parallel_workers_per_gather", value="48", apply_on_reboot=false},
     {name="random_page_cost", value="1", apply_on_reboot=false},
     {name="temp_buffers", value="8192", apply_on_reboot=false},


### PR DESCRIPTION
**DO NOT MERGE UNTIL 10/21**

Initially we were planning to just bump up the replica lag alert threshold, however I took a deeper dive into replica lag across all 3 read nodes and found only replica 3 had ever hit our current threshold.  I came across a solid article from AWS on working with read replicas: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PostgreSQL.Replication.ReadReplicas.html

Based on this article its appeared that `max_wal_senders` being too low had the highest probability of causing an issue with the number of replicas we had.  I've increased this to 15 (default is 10) on the assumption that 5 per read replica is a good number (since replica 1 and 2 have not had issues), open to debate.