### PR TITLE
Tune autovacuum vacuum and analyze scale factors

### DIFF
--- a/ops/terraform/env/prod/stateful/main.tf
+++ b/ops/terraform/env/prod/stateful/main.tf
@@ -17,6 +17,8 @@ module "stateful" {
   }
 
   db_params = [
+    {name="autovacuum_vacuum_scale_factor", value="0.005", apply_on_reboot=false},
+    {name="autovacuum_analyze_scale_factor", value="0.0025", apply_on_reboot=false},
     {name="effective_io_concurrency", value="300", apply_on_reboot=false},
     {name="default_statistics_target", value="1000", apply_on_reboot=false},
     {name="max_worker_processes", value="96", apply_on_reboot=true},

--- a/ops/terraform/env/test/stateful/main.tf
+++ b/ops/terraform/env/test/stateful/main.tf
@@ -17,6 +17,8 @@ module "stateful" {
   }
 
   db_params = [
+    {name="autovacuum_vacuum_scale_factor", value="0.005", apply_on_reboot=false},
+    {name="autovacuum_analyze_scale_factor", value="0.0025", apply_on_reboot=false},
     {name="effective_io_concurrency", value="300", apply_on_reboot=false},
     {name="default_statistics_target", value="1000", apply_on_reboot=false},
     {name="max_worker_processes", value="96", apply_on_reboot=true},


### PR DESCRIPTION
This lowers the vacuum scale factor to 0.005 and analyze scale factor to 0.0025 of invalidated rows.  For our largest tables of roughly 10 billion rows, this means a vacuum will get triggered on 50 million invalidated rows and analyze on 25 million invalidated rows.

These values are just a starting point to get the discussion going but are likely very off base.  I had a look through the pipeline logs as of the 10/12 import, but I'm not sure if I have the correct sense of how many rows get updated per table (grep on RifLoader.records.UPDATED ?).  I'm also not sure how much variance there can be between weekly imports.