### PR TITLE
BLUEBUTTON-1500: Log plan on queries slower than 6s

### DIFF
--- a/ops/terraform/env/prod/stateful/main.tf
+++ b/ops/terraform/env/prod/stateful/main.tf
@@ -17,6 +17,7 @@ module "stateful" {
   }
 
   db_params = [
+    {name="auto_explain.log_min_duration", value="6000", apply_on_reboot=false},
     {name="effective_io_concurrency", value="300", apply_on_reboot=false},
     {name="default_statistics_target", value="1000", apply_on_reboot=false},
     {name="max_worker_processes", value="96", apply_on_reboot=true},

--- a/ops/terraform/env/test/stateful/main.tf
+++ b/ops/terraform/env/test/stateful/main.tf
@@ -17,6 +17,7 @@ module "stateful" {
   }
 
   db_params = [
+    {name="auto_explain.log_min_duration", value="6000", apply_on_reboot=false},
     {name="effective_io_concurrency", value="300", apply_on_reboot=false},
     {name="default_statistics_target", value="1000", apply_on_reboot=false},
     {name="max_worker_processes", value="96", apply_on_reboot=true},


### PR DESCRIPTION
**DO NOT MERGE UNTIL 10/21**

This allows us to obtain better debugging info for slow queries when they happen.  The auto_explain module can also run an analyze, but at a performance cost:

Ref: https://www.postgresql.org/docs/9.6/auto-explain.html

> Note: When this parameter is on, per-plan-node timing occurs for all statements executed, whether or not they run long enough to actually get logged. This can have an extremely negative impact on performance. Turning off auto_explain.log_timing ameliorates the performance cost, at the price of obtaining less information.

