### PR TITLE
BLUEBUTTON-1513: Revert high IOPS configurations of databases post migration

### DIFF
--- a/ops/terraform/env/prod-sbx/stateful/main.tf
+++ b/ops/terraform/env/prod-sbx/stateful/main.tf
@@ -12,7 +12,7 @@ module "stateful" {
 
   db_config = { 
     instance_class    = "db.m5.2xlarge"
-    iops              = 4000
+    iops              = 1000
     allocated_storage = 2000
   }
 

--- a/ops/terraform/env/prod/stateful/main.tf
+++ b/ops/terraform/env/prod/stateful/main.tf
@@ -12,7 +12,7 @@ module "stateful" {
 
   db_config = { 
     instance_class    = "db.r5.24xlarge"
-    iops              = 64000
+    iops              = 16000
     allocated_storage = 16000
   }
 

--- a/ops/terraform/env/test/stateful/main.tf
+++ b/ops/terraform/env/test/stateful/main.tf
@@ -12,7 +12,7 @@ module "stateful" {
 
   db_config = { 
     instance_class    = "db.r5.24xlarge"
-    iops              = 16000
+    iops              = 1000
     allocated_storage = 12000
   }
 


### PR DESCRIPTION
This reverts prod back to its previous value of 16k IOPS, and greatly reduces prod-sbx and test.  Data imports are the only time a high amount of write IOPS are used, and the only time we even approached 16k write IOPS in prod was during the initial data catch up.  RDS metrics show that we have stayed under 10k write IOPS during the last two data loads.  Our read IOPS on the replicas stays in the hundreds even during (thus far) peak loads.

This is definitely up for debate.  I think we could safely move prod IOPS to 10k unless we needed to process an abnormally large data load again.  Since no regular data loading is happening in test or prod-sbx I believe these are more than safe to move to 1k IOPS, at least for the time being.