### PR TITLE
Minimum permitted IOPS ratio by AWS is 0.5

### DIFF
--- a/ops/terraform/env/test/stateful/main.tf
+++ b/ops/terraform/env/test/stateful/main.tf
@@ -12,7 +12,7 @@ module "stateful" {
 
   db_config = { 
     instance_class    = "db.r5.24xlarge"
-    iops              = 1000
+    iops              = 6000
     allocated_storage = 12000
   }
 


### PR DESCRIPTION
Fix for #127.