### PR TITLE
BLUEBUTTON 1509:  Return meta.lastUpdated

### DIFF
--- a/apps/bfd-model/bfd-model-codegen/src/main/java/gov/cms/bfd/model/codegen/MappingSpec.java
+++ b/apps/bfd-model/bfd-model-codegen/src/main/java/gov/cms/bfd/model/codegen/MappingSpec.java
@@ -34,6 +34,7 @@ public final class MappingSpec {
   private String headerEntityGeneratedIdField;
   private boolean hasLines = false;
   private String lineTable;
+  private boolean hasLastUpdated = true;
   private List<String> headerEntityTransientFields;
   private List<RifField> headerEntityAdditionalDatabaseFields;
   private List<InnerJoinRelationship> innerJoinRelationship;
@@ -155,6 +156,20 @@ public final class MappingSpec {
   /** @param hasLines the new value for {@link #getHasLines()} */
   public MappingSpec setHasLines(boolean hasLines) {
     this.hasLines = hasLines;
+    return this;
+  }
+
+  /**
+   * @return <code>true</code> if the entity should contain a lastUpdated field, <code>false</code>
+   *     if not
+   */
+  public boolean getHasLastUpdated() {
+    return hasLastUpdated;
+  }
+
+  /** @param hasLastUpdated the new value for {@link #getHasLastUpdated()} */
+  public MappingSpec setHasLastUpdated(boolean hasLastUpdated) {
+    this.hasLastUpdated = hasLastUpdated;
     return this;
   }
 

--- a/apps/bfd-model/bfd-model-codegen/src/main/java/gov/cms/bfd/model/codegen/RifLayoutsProcessor.java
+++ b/apps/bfd-model/bfd-model-codegen/src/main/java/gov/cms/bfd/model/codegen/RifLayoutsProcessor.java
@@ -24,9 +24,9 @@ import java.io.Writer;
 import java.math.BigDecimal;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -751,11 +751,11 @@ public final class RifLayoutsProcessor extends AbstractProcessor {
       }
     }
 
-    // Add a lastUpdated field. Use the Hibernate UpdateTimestamp feature to set field.
+    // Add a lastUpdated field. Use the Hibernate UpdateTimestamp feature to set this field.
     if (mappingSpec.getHasLastUpdated()) {
       // lastUpdated field
       FieldSpec lastUpdatedField =
-          FieldSpec.builder(Timestamp.class, "lastUpdated", Modifier.PRIVATE)
+          FieldSpec.builder(OffsetDateTime.class, "lastUpdated", Modifier.PRIVATE)
               .addAnnotation(
                   AnnotationSpec.builder(Column.class)
                       .addMember("name", "$S", "lastUpdated")
@@ -770,7 +770,7 @@ public final class RifLayoutsProcessor extends AbstractProcessor {
           MethodSpec.methodBuilder("getLastUpdated")
               .addModifiers(Modifier.PUBLIC)
               .addStatement("return lastUpdated")
-              .returns(Timestamp.class)
+              .returns(OffsetDateTime.class)
               .build();
       headerEntityClass.addMethod(lastUpdatedGetter);
     }

--- a/apps/bfd-model/bfd-model-codegen/src/main/java/gov/cms/bfd/model/codegen/RifLayoutsProcessor.java
+++ b/apps/bfd-model/bfd-model-codegen/src/main/java/gov/cms/bfd/model/codegen/RifLayoutsProcessor.java
@@ -769,8 +769,8 @@ public final class RifLayoutsProcessor extends AbstractProcessor {
       MethodSpec lastUpdatedGetter =
           MethodSpec.methodBuilder("getLastUpdated")
               .addModifiers(Modifier.PUBLIC)
-              .addStatement("return lastUpdated")
-              .returns(OffsetDateTime.class)
+              .addStatement("return Optional.of(lastUpdated)")
+              .returns(ParameterizedTypeName.get(Optional.class, OffsetDateTime.class))
               .build();
       headerEntityClass.addMethod(lastUpdatedGetter);
     }

--- a/apps/bfd-model/bfd-model-codegen/src/main/java/gov/cms/bfd/model/codegen/RifLayoutsProcessor.java
+++ b/apps/bfd-model/bfd-model-codegen/src/main/java/gov/cms/bfd/model/codegen/RifLayoutsProcessor.java
@@ -769,7 +769,7 @@ public final class RifLayoutsProcessor extends AbstractProcessor {
       MethodSpec lastUpdatedGetter =
           MethodSpec.methodBuilder("getLastUpdated")
               .addModifiers(Modifier.PUBLIC)
-              .addStatement("return Optional.of(lastUpdated)")
+              .addStatement("return Optional.ofNullable(lastUpdated)")
               .returns(ParameterizedTypeName.get(Optional.class, OffsetDateTime.class))
               .build();
       headerEntityClass.addMethod(lastUpdatedGetter);

--- a/apps/bfd-model/bfd-model-rif/src/main/resources/db/migration/V21__Add_lastUpdated_columns.sql
+++ b/apps/bfd-model/bfd-model-rif/src/main/resources/db/migration/V21__Add_lastUpdated_columns.sql
@@ -1,0 +1,33 @@
+-- Add a column without writing a data to every row
+--
+-- From the PostgreSQL 9.6 ALTER command documentation...
+--
+-- When a column is added with ADD COLUMN, all existing rows in the table are initialized with the
+-- column's default value (NULL if no DEFAULT clause is specified). If there is no DEFAULT clause, this is merely a
+-- metadata change and does not require any immediate update of the table's data; the added NULL values are supplied
+-- on readout, instead.
+--
+-- Based on this information, alters have the implicit default null
+
+
+alter table "Beneficiaries" add column lastUpdated timestamp;
+
+alter table "BeneficiariesHistory" add column lastUpdated timestamp;
+
+alter table "MedicareBeneficiaryIdHistory" add column lastUpdated timestamp;
+
+alter table "PartDEvents" add column lastUpdated timestamp;
+
+alter table "CarrierClaims" add column lastUpdated timestamp;
+
+alter table "InpatientClaims" add column lastUpdated timestamp;
+
+alter table "OutpatientClaims" add column lastUpdated timestamp;
+
+alter table "HHAClaims" add column lastUpdated timestamp;
+
+alter table "DMEClaims" add column lastUpdated timestamp;
+
+alter table "HospiceClaims" add column lastUpdated timestamp;
+
+alter table "SNFClaims" add column lastUpdated timestamp;

--- a/apps/bfd-model/bfd-model-rif/src/main/resources/db/migration/V21__Add_lastUpdated_columns.sql
+++ b/apps/bfd-model/bfd-model-rif/src/main/resources/db/migration/V21__Add_lastUpdated_columns.sql
@@ -10,24 +10,24 @@
 -- Based on this information, alters have the implicit default null
 
 
-alter table "Beneficiaries" add column lastUpdated timestamp;
+alter table "Beneficiaries" add column lastUpdated timestamp with time zone;
 
-alter table "BeneficiariesHistory" add column lastUpdated timestamp;
+alter table "BeneficiariesHistory" add column lastUpdated timestamp with time zone;
 
-alter table "MedicareBeneficiaryIdHistory" add column lastUpdated timestamp;
+alter table "MedicareBeneficiaryIdHistory" add column lastUpdated timestamp with time zone;
 
-alter table "PartDEvents" add column lastUpdated timestamp;
+alter table "PartDEvents" add column lastUpdated timestamp with time zone;
 
-alter table "CarrierClaims" add column lastUpdated timestamp;
+alter table "CarrierClaims" add column lastUpdated timestamp with time zone;
 
-alter table "InpatientClaims" add column lastUpdated timestamp;
+alter table "InpatientClaims" add column lastUpdated timestamp with time zone;
 
-alter table "OutpatientClaims" add column lastUpdated timestamp;
+alter table "OutpatientClaims" add column lastUpdated timestamp with time zone;
 
-alter table "HHAClaims" add column lastUpdated timestamp;
+alter table "HHAClaims" add column lastUpdated timestamp with time zone;
 
-alter table "DMEClaims" add column lastUpdated timestamp;
+alter table "DMEClaims" add column lastUpdated timestamp with time zone;
 
-alter table "HospiceClaims" add column lastUpdated timestamp;
+alter table "HospiceClaims" add column lastUpdated timestamp with time zone;
 
-alter table "SNFClaims" add column lastUpdated timestamp;
+alter table "SNFClaims" add column lastUpdated timestamp with time zone;

--- a/apps/bfd-pipeline/bfd-pipeline-rif-load/src/test/java/gov/cms/bfd/pipeline/rif/load/RifLoaderIT.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rif-load/src/test/java/gov/cms/bfd/pipeline/rif/load/RifLoaderIT.java
@@ -79,12 +79,15 @@ public final class RifLoaderIT {
       for (BeneficiaryHistory beneHistory : beneficiaryHistoryEntries) {
         Assert.assertEquals("567834", beneHistory.getBeneficiaryId());
         // A recent lastUpdated timestamp
-        Assert.assertNotNull("Expected a lastUpdated field", beneHistory.getLastUpdated());
-        Assert.assertTrue(
-            "Expected a recent lastUpdated timestamp",
-            beneHistory
-                .getLastUpdated()
-                .isAfter(OffsetDateTime.now().minus(1, ChronoUnit.MINUTES)));
+        Assert.assertTrue("Expected a lastUpdated field", beneHistory.getLastUpdated().isPresent());
+        beneHistory
+            .getLastUpdated()
+            .ifPresent(
+                lastUpdated -> {
+                  Assert.assertTrue(
+                      "Expected a recent lastUpdated timestamp",
+                      lastUpdated.isAfter(OffsetDateTime.now().minus(1, ChronoUnit.MINUTES)));
+                });
       }
       Assert.assertEquals(4, beneficiaryHistoryEntries.size());
 
@@ -95,12 +98,16 @@ public final class RifLoaderIT {
       Assert.assertEquals("John", beneficiaryFromDb.getNameGiven());
       Assert.assertEquals(new Character('A'), beneficiaryFromDb.getNameMiddleInitial().get());
       // A recent lastUpdated timestamp
-      Assert.assertNotNull("Expected a lastUpdated field", beneficiaryFromDb.getLastUpdated());
       Assert.assertTrue(
-          "Expected a recent lastUpdated timestamp",
-          beneficiaryFromDb
-              .getLastUpdated()
-              .isAfter(OffsetDateTime.now().minus(1, ChronoUnit.MINUTES)));
+          "Expected a lastUpdated field", beneficiaryFromDb.getLastUpdated().isPresent());
+      beneficiaryFromDb
+          .getLastUpdated()
+          .ifPresent(
+              lastUpdated -> {
+                Assert.assertTrue(
+                    "Expected a recent lastUpdated timestamp",
+                    lastUpdated.isAfter(OffsetDateTime.now().minus(1, ChronoUnit.MINUTES)));
+              });
 
       CarrierClaim carrierRecordFromDb = entityManager.find(CarrierClaim.class, "9991831999");
       Assert.assertEquals('N', carrierRecordFromDb.getFinalAction());
@@ -109,12 +116,16 @@ public final class RifLoaderIT {
           LocalDate.of(2000, Month.OCTOBER, 27), carrierRecordFromDb.getDateThrough());
       Assert.assertEquals(1, carrierRecordFromDb.getLines().size());
       // A recent lastUpdated timestamp
-      Assert.assertNotNull("Expected a lastUpdated field", carrierRecordFromDb.getLastUpdated());
       Assert.assertTrue(
-          "Expected a recent lastUpdated timestamp",
-          carrierRecordFromDb
-              .getLastUpdated()
-              .isAfter(OffsetDateTime.now().minus(1, ChronoUnit.MINUTES)));
+          "Expected a lastUpdated field", carrierRecordFromDb.getLastUpdated().isPresent());
+      carrierRecordFromDb
+          .getLastUpdated()
+          .ifPresent(
+              lastUpdated -> {
+                Assert.assertTrue(
+                    "Expected a recent lastUpdated timestamp",
+                    lastUpdated.isAfter(OffsetDateTime.now().minus(1, ChronoUnit.MINUTES)));
+              });
 
       CarrierClaimLine carrierLineRecordFromDb = carrierRecordFromDb.getLines().get(0);
       // CliaLabNumber inserted with value BB889999AA

--- a/apps/bfd-pipeline/bfd-pipeline-rif-load/src/test/java/gov/cms/bfd/pipeline/rif/load/RifLoaderIT.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rif-load/src/test/java/gov/cms/bfd/pipeline/rif/load/RifLoaderIT.java
@@ -16,6 +16,7 @@ import gov.cms.bfd.pipeline.rif.extract.RifFilesProcessor;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.Month;
+import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
@@ -77,13 +78,13 @@ public final class RifLoaderIT {
               .getResultList();
       for (BeneficiaryHistory beneHistory : beneficiaryHistoryEntries) {
         Assert.assertEquals("567834", beneHistory.getBeneficiaryId());
+        // A recent lastUpdated timestamp
         Assert.assertNotNull("Expected a lastUpdated field", beneHistory.getLastUpdated());
         Assert.assertTrue(
             "Expected a recent lastUpdated timestamp",
             beneHistory
                 .getLastUpdated()
-                .toInstant()
-                .isAfter(Instant.now().minus(1, ChronoUnit.MINUTES)));
+                .isAfter(OffsetDateTime.now().minus(1, ChronoUnit.MINUTES)));
       }
       Assert.assertEquals(4, beneficiaryHistoryEntries.size());
 
@@ -99,8 +100,7 @@ public final class RifLoaderIT {
           "Expected a recent lastUpdated timestamp",
           beneficiaryFromDb
               .getLastUpdated()
-              .toInstant()
-              .isAfter(Instant.now().minus(1, ChronoUnit.MINUTES)));
+              .isAfter(OffsetDateTime.now().minus(1, ChronoUnit.MINUTES)));
 
       CarrierClaim carrierRecordFromDb = entityManager.find(CarrierClaim.class, "9991831999");
       Assert.assertEquals('N', carrierRecordFromDb.getFinalAction());
@@ -114,8 +114,7 @@ public final class RifLoaderIT {
           "Expected a recent lastUpdated timestamp",
           carrierRecordFromDb
               .getLastUpdated()
-              .toInstant()
-              .isAfter(Instant.now().minus(1, ChronoUnit.MINUTES)));
+              .isAfter(OffsetDateTime.now().minus(1, ChronoUnit.MINUTES)));
 
       CarrierClaimLine carrierLineRecordFromDb = carrierRecordFromDb.getLines().get(0);
       // CliaLabNumber inserted with value BB889999AA

--- a/apps/bfd-pipeline/bfd-pipeline-rif-load/src/test/java/gov/cms/bfd/pipeline/rif/load/RifLoaderIT.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rif-load/src/test/java/gov/cms/bfd/pipeline/rif/load/RifLoaderIT.java
@@ -16,6 +16,7 @@ import gov.cms.bfd.pipeline.rif.extract.RifFilesProcessor;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.Month;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -76,6 +77,13 @@ public final class RifLoaderIT {
               .getResultList();
       for (BeneficiaryHistory beneHistory : beneficiaryHistoryEntries) {
         Assert.assertEquals("567834", beneHistory.getBeneficiaryId());
+        Assert.assertNotNull("Expected a lastUpdated field", beneHistory.getLastUpdated());
+        Assert.assertTrue(
+            "Expected a recent lastUpdated timestamp",
+            beneHistory
+                .getLastUpdated()
+                .toInstant()
+                .isAfter(Instant.now().minus(1, ChronoUnit.MINUTES)));
       }
       Assert.assertEquals(4, beneficiaryHistoryEntries.size());
 
@@ -85,6 +93,14 @@ public final class RifLoaderIT {
       // Following fields were NOT changed in update record
       Assert.assertEquals("John", beneficiaryFromDb.getNameGiven());
       Assert.assertEquals(new Character('A'), beneficiaryFromDb.getNameMiddleInitial().get());
+      // A recent lastUpdated timestamp
+      Assert.assertNotNull("Expected a lastUpdated field", beneficiaryFromDb.getLastUpdated());
+      Assert.assertTrue(
+          "Expected a recent lastUpdated timestamp",
+          beneficiaryFromDb
+              .getLastUpdated()
+              .toInstant()
+              .isAfter(Instant.now().minus(1, ChronoUnit.MINUTES)));
 
       CarrierClaim carrierRecordFromDb = entityManager.find(CarrierClaim.class, "9991831999");
       Assert.assertEquals('N', carrierRecordFromDb.getFinalAction());
@@ -92,6 +108,14 @@ public final class RifLoaderIT {
       Assert.assertEquals(
           LocalDate.of(2000, Month.OCTOBER, 27), carrierRecordFromDb.getDateThrough());
       Assert.assertEquals(1, carrierRecordFromDb.getLines().size());
+      // A recent lastUpdated timestamp
+      Assert.assertNotNull("Expected a lastUpdated field", carrierRecordFromDb.getLastUpdated());
+      Assert.assertTrue(
+          "Expected a recent lastUpdated timestamp",
+          carrierRecordFromDb
+              .getLastUpdated()
+              .toInstant()
+              .isAfter(Instant.now().minus(1, ChronoUnit.MINUTES)));
 
       CarrierClaimLine carrierLineRecordFromDb = carrierRecordFromDb.getLines().get(0);
       // CliaLabNumber inserted with value BB889999AA

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/BeneficiaryTransformer.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/BeneficiaryTransformer.java
@@ -7,10 +7,7 @@ import gov.cms.bfd.model.rif.Beneficiary;
 import gov.cms.bfd.model.rif.BeneficiaryHistory;
 import gov.cms.bfd.model.rif.MedicareBeneficiaryIdHistory;
 import gov.cms.bfd.server.war.stu3.providers.PatientResourceProvider.IncludeIdentifiersMode;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 import org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender;
 import org.hl7.fhir.dstu3.model.Extension;
@@ -237,6 +234,9 @@ final class BeneficiaryTransformer {
               CcwCodebookVariable.DUAL_12,
               beneficiary.getMedicaidDualEligibilityDecCode()));
     }
+
+    // Add lastUpdated
+    TransformerUtils.setLastUpdated(patient, beneficiary.getLastUpdated());
 
     return patient;
   }

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/CarrierClaimTransformer.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/CarrierClaimTransformer.java
@@ -260,6 +260,7 @@ final class CarrierClaimTransformer {
       }
     }
 
+    TransformerUtils.setLastUpdated(eob, claimGroup.getLastUpdated());
     return eob;
   }
 }

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/CoverageTransformer.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/CoverageTransformer.java
@@ -135,6 +135,7 @@ final class CoverageTransformer {
     }
 
     transformEntitlementBuyInIndicators(coverage, beneficiary);
+    TransformerUtils.setLastUpdated(coverage, beneficiary.getLastUpdated());
 
     timer.stop();
     return coverage;
@@ -189,6 +190,7 @@ final class CoverageTransformer {
     }
 
     transformEntitlementBuyInIndicators(coverage, beneficiary);
+    TransformerUtils.setLastUpdated(coverage, beneficiary.getLastUpdated());
 
     timer.stop();
     return coverage;
@@ -518,6 +520,7 @@ final class CoverageTransformer {
           TransformerUtils.createExtensionCoding(
               coverage, CcwCodebookVariable.HMO_IND_12, beneficiary.getHmoIndicatorDecInd()));
     }
+    TransformerUtils.setLastUpdated(coverage, beneficiary.getLastUpdated());
 
     timer.stop();
     return coverage;
@@ -937,6 +940,7 @@ final class CoverageTransformer {
               CcwCodebookVariable.RDSIND12,
               beneficiary.getPartDRetireeDrugSubsidyDecInd()));
     }
+    TransformerUtils.setLastUpdated(coverage, beneficiary.getLastUpdated());
 
     timer.stop();
     return coverage;

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/DMEClaimTransformer.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/DMEClaimTransformer.java
@@ -262,6 +262,7 @@ final class DMEClaimTransformer {
                     claimLine.getSupplierTypeCode()));
       }
     }
+    TransformerUtils.setLastUpdated(eob, claimGroup.getLastUpdated());
     return eob;
   }
 }

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/HHAClaimTransformer.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/HHAClaimTransformer.java
@@ -239,6 +239,7 @@ final class HHAClaimTransformer {
       TransformerUtils.mapEobCommonGroupInpHHAHospiceSNFCoinsurance(
           eob, item, claimLine.getDeductibleCoinsuranceCd());
     }
+    TransformerUtils.setLastUpdated(eob, claimGroup.getLastUpdated());
     return eob;
   }
 }

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/HospiceClaimTransformer.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/HospiceClaimTransformer.java
@@ -230,6 +230,7 @@ final class HospiceClaimTransformer {
       TransformerUtils.mapEobCommonGroupInpHHAHospiceSNFCoinsurance(
           eob, item, claimLine.getDeductibleCoinsuranceCd());
     }
+    TransformerUtils.setLastUpdated(eob, claimGroup.getLastUpdated());
     return eob;
   }
 }

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/InpatientClaimTransformer.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/InpatientClaimTransformer.java
@@ -292,6 +292,7 @@ final class InpatientClaimTransformer {
       TransformerUtils.mapEobCommonGroupInpHHAHospiceSNFCoinsurance(
           eob, item, claimLine.getDeductibleCoinsuranceCd());
     }
+    TransformerUtils.setLastUpdated(eob, claimGroup.getLastUpdated());
     return eob;
   }
 

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/OutpatientClaimTransformer.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/OutpatientClaimTransformer.java
@@ -453,6 +453,7 @@ final class OutpatientClaimTransformer {
               TransformerUtils.createExtensionCoding(
                   eob, CcwCodebookVariable.REV_CNTR_STUS_IND_CD, claimLine.getStatusCode()));
     }
+    TransformerUtils.setLastUpdated(eob, claimGroup.getLastUpdated());
     return eob;
   }
 }

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PartDEventTransformer.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PartDEventTransformer.java
@@ -354,6 +354,7 @@ final class PartDEventTransformer {
           CcwCodebookVariable.SUBMSN_CLR_CD,
           claimGroup.getSubmissionClarificationCode());
 
+    TransformerUtils.setLastUpdated(eob, claimGroup.getLastUpdated());
     return eob;
   }
 }

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/SNFClaimTransformer.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/SNFClaimTransformer.java
@@ -348,6 +348,7 @@ final class SNFClaimTransformer {
       TransformerUtils.mapEobCommonGroupInpHHAHospiceSNFCoinsurance(
           eob, item, claimLine.getDeductibleCoinsuranceCd());
     }
+    TransformerUtils.setLastUpdated(eob, claimGroup.getLastUpdated());
     return eob;
   }
 }

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerConstants.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerConstants.java
@@ -4,6 +4,7 @@ import gov.cms.bfd.model.codebook.data.CcwCodebookVariable;
 import gov.cms.bfd.model.codebook.model.Variable;
 import gov.cms.bfd.model.rif.Beneficiary;
 import gov.cms.bfd.model.rif.CarrierClaimColumn;
+import java.time.OffsetDateTime;
 import org.hl7.fhir.dstu3.model.Coding;
 import org.hl7.fhir.dstu3.model.Coverage;
 import org.hl7.fhir.dstu3.model.Coverage.GroupComponent;
@@ -211,6 +212,10 @@ public final class TransformerConstants {
    */
   public static final String CODING_BBAPI_MEDICARE_BENEFICIARY_ID_UNHASHED =
       "http://hl7.org/fhir/sid/us-mbi";
+
+  /** The timestamp used for entities that do not have lastUpdated value. */
+  public static final OffsetDateTime DEFAULT_LAST_UPDATED =
+      OffsetDateTime.parse("2019-10-21T00:00:00.000Z");
 
   /**
    * The {@link #CODING_BBAPI_BENE_HICN_HASH} used in earlier versions of the API, which is still

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtils.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtils.java
@@ -45,7 +45,9 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -3098,5 +3100,17 @@ public final class TransformerUtils {
         String.format("%s.duration_milliseconds", keyPrefix),
         Long.toString(queryDurationNanoseconds / 1000000));
     MDC.put(String.format("%s.record_count", keyPrefix), Long.toString(recordCount));
+  }
+
+  /**
+   * Sets the lastUpdated value in the resource
+   *
+   * @param resource is the FHIR resource to set LastUp
+   * @param lastUpdated is the lastUpdated value from the entity
+   */
+  public static void setLastUpdated(IAnyResource resource, Optional<OffsetDateTime> lastUpdated) {
+    Instant lastUpdatedInstant =
+        lastUpdated.orElse(TransformerConstants.DEFAULT_LAST_UPDATED).toInstant();
+    resource.getMeta().setLastUpdated(Date.from(lastUpdatedInstant));
   }
 }

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/BeneficiaryTransformerTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/BeneficiaryTransformerTest.java
@@ -160,5 +160,12 @@ public final class BeneficiaryTransformerTest {
     if (beneficiary.getBeneEnrollmentReferenceYear().isPresent())
       TransformerTestUtils.assertExtensionDateYearEquals(
           CcwCodebookVariable.RFRNC_YR, beneficiary.getBeneEnrollmentReferenceYear(), patient);
+    beneficiary
+        .getLastUpdated()
+        .ifPresent(
+            lastUpdated -> {
+              Assert.assertEquals(
+                  patient.getMeta().getLastUpdated().toInstant(), lastUpdated.toInstant());
+            });
   }
 }

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/BeneficiaryTransformerTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/BeneficiaryTransformerTest.java
@@ -160,12 +160,7 @@ public final class BeneficiaryTransformerTest {
     if (beneficiary.getBeneEnrollmentReferenceYear().isPresent())
       TransformerTestUtils.assertExtensionDateYearEquals(
           CcwCodebookVariable.RFRNC_YR, beneficiary.getBeneEnrollmentReferenceYear(), patient);
-    beneficiary
-        .getLastUpdated()
-        .ifPresent(
-            lastUpdated -> {
-              Assert.assertEquals(
-                  patient.getMeta().getLastUpdated().toInstant(), lastUpdated.toInstant());
-            });
+
+    TransformerTestUtils.assertLastUpdatedEquals(beneficiary.getLastUpdated(), patient);
   }
 }

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/CarrierClaimTransformerTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/CarrierClaimTransformerTest.java
@@ -225,5 +225,8 @@ public final class CarrierClaimTransformerTest {
         claimLine1.getHctHgbTestResult(),
         claimLine1.getCmsServiceTypeCode(),
         claimLine1.getNationalDrugCode());
+
+    // Test lastUpdated
+    TransformerTestUtils.assertLastUpdatedEquals(claim.getLastUpdated(), eob);
   }
 }

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/CoverageTransformerTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/CoverageTransformerTest.java
@@ -73,6 +73,7 @@ public final class CoverageTransformerTest {
     Assert.assertEquals(
         TransformerConstants.COVERAGE_PLAN_PART_A, coverage.getGrouping().getSubPlan());
     Assert.assertEquals(CoverageStatus.ACTIVE, coverage.getStatus());
+    TransformerTestUtils.assertLastUpdatedEquals(beneficiary.getLastUpdated(), coverage);
 
     if (beneficiary.getMedicareCoverageStartDate().isPresent())
       TransformerTestUtils.assertPeriodEquals(
@@ -116,6 +117,7 @@ public final class CoverageTransformerTest {
     Assert.assertEquals(
         TransformerConstants.COVERAGE_PLAN_PART_B, coverage.getGrouping().getSubPlan());
     Assert.assertEquals(CoverageStatus.ACTIVE, coverage.getStatus());
+    TransformerTestUtils.assertLastUpdatedEquals(beneficiary.getLastUpdated(), coverage);
 
     if (beneficiary.getMedicareCoverageStartDate().isPresent())
       TransformerTestUtils.assertPeriodEquals(
@@ -151,6 +153,7 @@ public final class CoverageTransformerTest {
     Assert.assertEquals(
         TransformerConstants.COVERAGE_PLAN_PART_C, coverage.getGrouping().getSubPlan());
     Assert.assertEquals(CoverageStatus.ACTIVE, coverage.getStatus());
+    TransformerTestUtils.assertLastUpdatedEquals(beneficiary.getLastUpdated(), coverage);
 
     if (beneficiary.getPartCContractNumberAugId().isPresent())
       TransformerTestUtils.assertExtensionCodingEquals(
@@ -191,6 +194,7 @@ public final class CoverageTransformerTest {
       TransformerTestUtils.assertExtensionCodingEquals(
           CcwCodebookVariable.MS_CD, beneficiary.getMedicareEnrollmentStatusCode(), coverage);
     Assert.assertEquals(CoverageStatus.ACTIVE, coverage.getStatus());
+    TransformerTestUtils.assertLastUpdatedEquals(beneficiary.getLastUpdated(), coverage);
 
     if (beneficiary.getPartDContractNumberAugId().isPresent())
       TransformerTestUtils.assertExtensionCodingEquals(

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/DMEClaimTransformerTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/DMEClaimTransformerTest.java
@@ -206,5 +206,8 @@ public final class DMEClaimTransformerTest {
         claimLine1.getHctHgbTestResult(),
         claimLine1.getCmsServiceTypeCode(),
         claimLine1.getNationalDrugCode());
+
+    // Test lastUpdated
+    TransformerTestUtils.assertLastUpdatedEquals(claim.getLastUpdated(), eob);
   }
 }

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/HHAClaimTransformerTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/HHAClaimTransformerTest.java
@@ -170,5 +170,8 @@ public final class HHAClaimTransformerTest {
         Optional.empty(),
         Optional.of(claim.getNearLineRecordIdCode()),
         Optional.of(claim.getClaimTypeCode()));
+
+    // Test lastUpdated
+    TransformerTestUtils.assertLastUpdatedEquals(claim.getLastUpdated(), eob);
   }
 }

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/HospiceClaimTransformerTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/HospiceClaimTransformerTest.java
@@ -168,5 +168,8 @@ public final class HospiceClaimTransformerTest {
         Optional.of(org.hl7.fhir.dstu3.model.codesystems.ClaimType.INSTITUTIONAL),
         Optional.of(claim.getNearLineRecordIdCode()),
         Optional.of(claim.getClaimTypeCode()));
+
+    // Test lastUpdated
+    TransformerTestUtils.assertLastUpdatedEquals(claim.getLastUpdated(), eob);
   }
 }

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/InpatientClaimTransformerTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/InpatientClaimTransformerTest.java
@@ -231,5 +231,8 @@ public final class InpatientClaimTransformerTest {
         Optional.of(org.hl7.fhir.dstu3.model.codesystems.ClaimType.INSTITUTIONAL),
         Optional.of(claim.getNearLineRecordIdCode()),
         Optional.of(claim.getClaimTypeCode()));
+
+    // Test lastUpdated
+    TransformerTestUtils.assertLastUpdatedEquals(claim.getLastUpdated(), eob);
   }
 }

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/OutpatientClaimTransformerTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/OutpatientClaimTransformerTest.java
@@ -234,5 +234,8 @@ public final class OutpatientClaimTransformerTest {
         CcwCodebookVariable.REV_CNTR_STUS_IND_CD,
         claimLine1.getStatusCode(),
         eobItem0.getRevenue());
+
+    // Test lastUpdated
+    TransformerTestUtils.assertLastUpdatedEquals(claim.getLastUpdated(), eob);
   }
 }

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/PartDEventTransformerTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/PartDEventTransformerTest.java
@@ -221,6 +221,7 @@ public final class PartDEventTransformerTest {
           CcwCodebookVariable.SUBMSN_CLR_CD,
           claim.getSubmissionClarificationCode(),
           eob);
+    TransformerTestUtils.assertLastUpdatedEquals(claim.getLastUpdated(), eob);
     try {
       TransformerTestUtils.assertFDADrugCodeDisplayEquals(
           claim.getNationalDrugCode(), "Childrens Acetaminophen Cherry - ACETAMINOPHEN");

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/SNFClaimTransformerTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/SNFClaimTransformerTest.java
@@ -203,5 +203,8 @@ public final class SNFClaimTransformerTest {
         Optional.of(org.hl7.fhir.dstu3.model.codesystems.ClaimType.INSTITUTIONAL),
         Optional.of(claim.getNearLineRecordIdCode()),
         Optional.of(claim.getClaimTypeCode()));
+
+    // Test lastUpdated
+    TransformerTestUtils.assertLastUpdatedEquals(claim.getLastUpdated(), eob);
   }
 }

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/TransformerTestUtils.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/TransformerTestUtils.java
@@ -31,6 +31,7 @@ import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.List;
@@ -60,6 +61,7 @@ import org.hl7.fhir.dstu3.model.Resource;
 import org.hl7.fhir.dstu3.model.codesystems.BenefitCategory;
 import org.hl7.fhir.dstu3.model.codesystems.ClaimCareteamrole;
 import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.instance.model.api.IAnyResource;
 import org.hl7.fhir.instance.model.api.IBaseExtension;
 import org.hl7.fhir.instance.model.api.IBaseHasExtensions;
 import org.junit.Assert;
@@ -1994,5 +1996,22 @@ final class TransformerTestUtils {
   static void assertNPICodeDisplayEquals(String npiCode, String npiCodeDisplayValue)
       throws IOException {
     Assert.assertEquals(TransformerUtils.retrieveNpiCodeDisplay(npiCode), npiCodeDisplayValue);
+  }
+
+  /**
+   * Test that the NPI
+   *
+   * @param expectedDateTime
+   * @param actualResource
+   */
+  static void assertLastUpdatedEquals(
+      Optional<OffsetDateTime> expectedDateTime, IAnyResource actualResource) {
+    expectedDateTime.ifPresent(
+        lastUpdated -> {
+          Assert.assertEquals(
+              "Expect lastUpdated to be equal",
+              actualResource.getMeta().getLastUpdated().toInstant(),
+              lastUpdated.toInstant());
+        });
   }
 }

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/utils/EndpointJsonResponseComparatorIT.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/utils/EndpointJsonResponseComparatorIT.java
@@ -907,7 +907,10 @@ public final class EndpointJsonResponseComparatorIT {
     pattern.append("|\"/link/[0-9]/url\"");
     pattern.append("|\"/implementation/url\"");
     pattern.append("|\"/entry/[0-9]/fullUrl\"");
+    pattern.append("|\"/meta\"");
     pattern.append("|\"/meta/lastUpdated\"");
+    pattern.append("|\"/entry/[0-9]/resource/meta/lastUpdated\"");
+    pattern.append("|\"/entry/[0-9]/resource/meta\"");
     pattern.append("|\"/procedure/[0-9]/date\"");
     pattern.append("|\"/entry/[0-9]/resource/procedure/[0-9]/date\"");
     pattern.append("|\"/software/version\"");


### PR DESCRIPTION
> Note: 1508 must be applied before this PR is merged

**Why**
Second, in a series of PRs to add lastUpdated support. This task returns the lastUpdated value that was written to the DB in the last PR. 

**What Changed**
- Modified the transformers that take an Entity from the DB and transform them into FHIR resources
- Modified the tests of these transformers to test for lastUpdated
- Created TransformerUtil methods to handle lastUpdate setting and 