### PR TITLE
BLUEBUTTON-1361: Temporary debug logging

### DIFF
--- a/apps/bfd-pipeline/bfd-pipeline-app/src/main/resources/logback.xml
+++ b/apps/bfd-pipeline/bfd-pipeline-app/src/main/resources/logback.xml
@@ -18,6 +18,10 @@
 	<!-- Log each SQL statement run by Flyway, to give us a rough progress indicator. Note that this may need to be revisited when/if our Flyway scripts get longer/larger: dozens of extra log events are fine but thousands are probably not. -->
 	<logger name="org.flywaydb.core.internal.dbsupport.SqlScript" level="debug" />
 
+	<!-- BLUEBUTTON-1361: Temporary debug logging for the following classes -->
+	<logger name="gov.cms.bfd.pipeline.rif.extract.s3.DataSetMonitorWorker" level="debug" />
+	<logger name="gov.cms.bfd.pipeline.rif.extract.s3.task.DataSetMoveTask" level="debug" />
+
 	<!-- Configure the root logger to filter to 'info' and more severe, and 
 		send all events to 'STDOUT'. -->
 	<root level="info">


### PR DESCRIPTION
This sets debug logging for DataSetMonitorWorker and DataSetMoveTask to help diagnose why data sets are not getting moved on successful process.  This also assists with level-setting the implementation of BLUEBUTTON-1499.