### PR TITLE
BLUEBUTTON-1379: Added support for running ITs against PostgreSQL

### DIFF
--- a/apps/bfd-model/bfd-model-rif/pom.xml
+++ b/apps/bfd-model/bfd-model-rif/pom.xml
@@ -156,10 +156,20 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<!-- In-memory database that is used in some tests to speed things up. -->
+			<!-- In-memory database that can be used for testing. -->
 			<groupId>org.hsqldb</groupId>
 			<artifactId>hsqldb</artifactId>
-			<scope>test</scope>
+			<!-- Only used by tests, but included in compile scope for use with test
+				utilities in that scope. -->
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<!-- The DB that BFD uses in production environments, included here for use in tests. -->
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<!-- Only used by tests, but included in compile scope for use with test
+				utilities in that scope. -->
+			<scope>compile</scope>
 		</dependency>
 	</dependencies>
 

--- a/apps/bfd-model/bfd-model-rif/src/main/java/gov/cms/bfd/model/rif/schema/DatabaseTestHelper.java
+++ b/apps/bfd-model/bfd-model-rif/src/main/java/gov/cms/bfd/model/rif/schema/DatabaseTestHelper.java
@@ -28,7 +28,7 @@ public final class DatabaseTestHelper {
   private static final String HSQL_SERVER_PASSWORD = "test";
 
   /** @return the JDBC URL for the test DB to use */
-  private static String getTestDatabaseJdbcUrl() {
+  private static String getTestDatabaseUrl() {
     // Build a default DB URL that uses HSQL, just as it's configured in the parent POM.
     String urlDefault = String.format("%shsqldb:mem", JDBC_URL_PREFIX_BLUEBUTTON_TEST);
 
@@ -59,7 +59,7 @@ public final class DatabaseTestHelper {
    *     schema-fied first
    */
   public static DataSource getTestDatabase() {
-    String url = getTestDatabaseJdbcUrl();
+    String url = getTestDatabaseUrl();
     String username = getTestDatabaseUsername();
     String password = getTestDatabasePassword();
     return getTestDatabase(url, username, password);
@@ -92,7 +92,7 @@ public final class DatabaseTestHelper {
     DataSource dataSource = getTestDatabase();
 
     // Try to prevent career-limiting moves.
-    String url = getTestDatabaseJdbcUrl();
+    String url = getTestDatabaseUrl();
     if (!url.contains("localhost") && !url.contains("127.0.0.1") && !url.contains("hsqldb:mem")) {
       throw new BadCodeMonkeyException("Our builds can only be run against local test DBs.");
     }

--- a/apps/bfd-model/bfd-model-rif/src/main/java/gov/cms/bfd/model/rif/schema/DatabaseTestHelper.java
+++ b/apps/bfd-model/bfd-model-rif/src/main/java/gov/cms/bfd/model/rif/schema/DatabaseTestHelper.java
@@ -125,10 +125,7 @@ public final class DatabaseTestHelper {
    * @return a HSQL {@link DataSource} for the test DB
    */
   private static DataSource createDataSourceForHsqlEmbeddedWithServer(String url) {
-    if (!url.startsWith(JDBC_URL_PREFIX_BLUEBUTTON_TEST)) {
-      throw new IllegalArgumentException();
-    }
-    if (!url.endsWith(":hsqldb:mem")) {
+    if (!url.startsWith(JDBC_URL_PREFIX_BLUEBUTTON_TEST + "hsqldb:mem")) {
       throw new IllegalArgumentException();
     }
 

--- a/apps/bfd-model/bfd-model-rif/src/main/java/gov/cms/bfd/model/rif/schema/DatabaseTestHelper.java
+++ b/apps/bfd-model/bfd-model-rif/src/main/java/gov/cms/bfd/model/rif/schema/DatabaseTestHelper.java
@@ -1,0 +1,267 @@
+package gov.cms.bfd.model.rif.schema;
+
+import com.justdavis.karl.misc.exceptions.BadCodeMonkeyException;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.ServerSocket;
+import javax.sql.DataSource;
+import org.flywaydb.core.Flyway;
+import org.hsqldb.jdbc.JDBCDataSource;
+import org.hsqldb.persist.HsqlProperties;
+import org.hsqldb.server.ServerAcl.AclFormatException;
+import org.postgresql.ds.PGSimpleDataSource;
+
+/**
+ * Provides utilities for managing the database in integration tests.
+ *
+ * <p>Note: This is placed in <code>src/main/java</code> (rather than <code>src/test/java</code>)
+ * for convenience: test dependencies aren't transitive, which tends to eff things up.
+ */
+public final class DatabaseTestHelper {
+  /**
+   * This fake JDBC URL prefix is used for custom database setups only used in integration tests,
+   * e.g. {@link #createDataSourceForHsqlEmbeddedWithServer(String)}.
+   */
+  public static final String JDBC_URL_PREFIX_BLUEBUTTON_TEST = "jdbc:bfd-test:";
+
+  private static final String HSQL_SERVER_USERNAME = "test";
+  private static final String HSQL_SERVER_PASSWORD = "test";
+
+  /** @return the JDBC URL for the test DB to use */
+  private static String getTestDatabaseJdbcUrl() {
+    // Build a default DB URL that uses HSQL, just as it's configured in the parent POM.
+    String urlDefault = String.format("%shsqldb:mem", JDBC_URL_PREFIX_BLUEBUTTON_TEST);
+
+    // Pull the DB URL from the system properties.
+    String url = System.getProperty("its.db.url", urlDefault);
+
+    return url;
+  }
+
+  /** @return the username for the test DB to use */
+  private static String getTestDatabaseUsername() {
+    // Pull the DB URL from the system properties.
+    String username = System.getProperty("its.db.username", null);
+    if (username != null && username.trim().isEmpty()) username = null;
+    return username;
+  }
+
+  /** @return the password for the test DB to use */
+  private static String getTestDatabasePassword() {
+    // Pull the DB URL from the system properties.
+    String password = System.getProperty("its.db.password", null);
+    if (password != null && password.trim().isEmpty()) password = null;
+    return password;
+  }
+
+  /**
+   * @return a {@link DataSource} for the test DB, which will <strong>not</strong> be cleaned or
+   *     schema-fied first
+   */
+  public static DataSource getTestDatabase() {
+    String url = getTestDatabaseJdbcUrl();
+    String username = getTestDatabaseUsername();
+    String password = getTestDatabasePassword();
+    return getTestDatabase(url, username, password);
+  }
+
+  /**
+   * @param url the JDBC URL for the test database to connect to
+   * @param username the username for the test database to connect to
+   * @param password the password for the test database to connect to
+   * @return a {@link DataSource} for the test DB, which will <strong>not</strong> be cleaned or
+   *     schema-fied first
+   */
+  public static DataSource getTestDatabase(String url, String username, String password) {
+    DataSource dataSource;
+    if (url.startsWith(JDBC_URL_PREFIX_BLUEBUTTON_TEST + "hsqldb:mem")) {
+      dataSource = createDataSourceForHsqlEmbeddedWithServer(url);
+    } else if (url.startsWith("jdbc:hsqldb:hsql://localhost")) {
+      dataSource = createDataSourceForHsqlServer(url, username, password);
+    } else if (url.startsWith("jdbc:postgresql:")) {
+      dataSource = createDataSourceForPostgresql(url, username, password);
+    } else {
+      throw new BadCodeMonkeyException("Unsupported test DB URL: " + url);
+    }
+
+    return dataSource;
+  }
+
+  /** @return a {@link DataSource} for the test DB, which will be cleaned (i.e. wiped) first */
+  public static DataSource getTestDatabaseAfterClean() {
+    DataSource dataSource = getTestDatabase();
+
+    // Try to prevent career-limiting moves.
+    String url = getTestDatabaseJdbcUrl();
+    if (!url.contains("localhost") && !url.contains("127.0.0.1") && !url.contains("hsqldb:mem")) {
+      throw new BadCodeMonkeyException("Our builds can only be run against local test DBs.");
+    }
+
+    // Clean the DB so that it's fresh and ready for a new test case.
+    Flyway flyway = new Flyway();
+    flyway.setDataSource(dataSource);
+    flyway.clean();
+    return dataSource;
+  }
+
+  /**
+   * @return a {@link DataSource} for the test DB, which will be cleaned (i.e. wiped) and then have
+   *     the BFD schema applied to it, first
+   */
+  public static DataSource getTestDatabaseAfterCleanAndSchema() {
+    DataSource dataSource = getTestDatabaseAfterClean();
+
+    // Schema-ify it so it's ready to go.
+    DatabaseSchemaManager.createOrUpdateSchema(dataSource);
+
+    return dataSource;
+  }
+
+  /**
+   * Creates an embedded HSQL DB that is also accessible on a local port (via {@link
+   * org.hsqldb.server.Server}).
+   *
+   * @param url the JDBC URL that the application was configured to use
+   * @return a HSQL {@link DataSource} for the test DB
+   */
+  private static DataSource createDataSourceForHsqlEmbeddedWithServer(String url) {
+    if (!url.startsWith(JDBC_URL_PREFIX_BLUEBUTTON_TEST)) {
+      throw new IllegalArgumentException();
+    }
+    if (!url.endsWith(":hsqldb:mem")) {
+      throw new IllegalArgumentException();
+    }
+
+    /*
+     * Select a random local port to run the HSQL DB server on, so that one test run doesn't
+     * conflict with another.
+     */
+    int hsqldbPort = findFreePort();
+
+    HsqlProperties hsqlProperties = new HsqlProperties();
+    hsqlProperties.setProperty(
+        "server.database.0",
+        String.format(
+            "mem:test-embedded;user=%s;password=%s", HSQL_SERVER_USERNAME, HSQL_SERVER_PASSWORD));
+    hsqlProperties.setProperty("server.dbname.0", "test-embedded");
+    hsqlProperties.setProperty("server.port", "" + hsqldbPort);
+    hsqlProperties.setProperty("hsqldb.tx", "mvcc");
+    org.hsqldb.server.Server server = new org.hsqldb.server.Server();
+
+    try {
+      server.setProperties(hsqlProperties);
+    } catch (IOException | AclFormatException e) {
+      throw new BadCodeMonkeyException(e);
+    }
+
+    server.setLogWriter(null);
+    server.setErrWriter(null);
+    server.start();
+
+    // Create the DataSource to connect to that shiny new DB.
+    DataSource dataSource =
+        createDataSourceForHsqlServer(
+            String.format("jdbc:hsqldb:hsql://localhost:%d/test-embedded", hsqldbPort),
+            HSQL_SERVER_USERNAME,
+            HSQL_SERVER_PASSWORD);
+    return dataSource;
+  }
+
+  /**
+   * @param url the JDBC URL that the application was configured to use
+   * @param username the username for the test database to connect to
+   * @param password the password for the test database to connect to
+   * @return a HSQL {@link DataSource} for the test DB
+   */
+  private static DataSource createDataSourceForHsqlServer(
+      String url, String username, String password) {
+    if (!url.startsWith("jdbc:hsqldb:hsql://localhost")) {
+      throw new IllegalArgumentException();
+    }
+
+    JDBCDataSource dataSource = new JDBCDataSource();
+    dataSource.setUrl(url);
+    if (username != null) dataSource.setUser(username);
+    if (password != null) dataSource.setPassword(password);
+
+    return dataSource;
+  }
+
+  /**
+   * Note: It's possible for this to result in race conditions, if the random port selected enters
+   * use after this method returns and before whatever called this method gets a chance to grab it.
+   * It's pretty unlikely, though, and there's not much we can do about it, either. So.
+   *
+   * @return a free local port number
+   */
+  private static int findFreePort() {
+    try (ServerSocket socket = new ServerSocket(0)) {
+      socket.setReuseAddress(true);
+      return socket.getLocalPort();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  /**
+   * @param url the PostgreSQL JDBC URL to use
+   * @param username the username for the test database to connect to
+   * @param password the password for the test database to connect to
+   * @return a PostgreSQL {@link DataSource} for the test DB
+   */
+  private static DataSource createDataSourceForPostgresql(
+      String url, String username, String password) {
+    PGSimpleDataSource dataSource = new PGSimpleDataSource();
+    dataSource.setUrl(url);
+    if (username != null) dataSource.setUser(username);
+    if (password != null) dataSource.setPassword(password);
+    return dataSource;
+  }
+
+  /**
+   * Represents the components required to construct a {@link DataSource} for our test DBs.
+   *
+   * <p>This is wildly insufficient for more complicated {@link DataSource}s; we're leaning heavily
+   * on the very constrained set of simple {@link DataSource}s that are supported for our tests.
+   */
+  public static final class DataSourceComponents {
+    private final String url;
+    private final String username;
+    private final String password;
+
+    /**
+     * Constructs a {@link DataSourceComponents} instance for the specified test {@link DataSource}
+     * (does not support more complicated {@link DataSource}s, as discussed in the class' JavaDoc)
+     */
+    public DataSourceComponents(DataSource dataSource) {
+      if (dataSource instanceof JDBCDataSource) {
+        JDBCDataSource hsqlDataSource = (JDBCDataSource) dataSource;
+        this.url = hsqlDataSource.getUrl();
+        this.username = hsqlDataSource.getUser();
+        this.password = HSQL_SERVER_PASSWORD; // no getter available; hardcoded
+      } else if (dataSource instanceof PGSimpleDataSource) {
+        PGSimpleDataSource pgDataSource = (PGSimpleDataSource) dataSource;
+        this.url = pgDataSource.getUrl();
+        this.username = pgDataSource.getUser();
+        this.password = pgDataSource.getPassword();
+      } else {
+        throw new BadCodeMonkeyException();
+      }
+    }
+
+    /** @return the JDBC URL that should be used to connect to the test DB */
+    public String getUrl() {
+      return url;
+    }
+
+    /** @return the username that should be used to connect to the test DB */
+    public String getUsername() {
+      return username;
+    }
+
+    /** @return the password that should be used to connect to the test DB */
+    public String getPassword() {
+      return password;
+    }
+  }
+}

--- a/apps/bfd-model/bfd-model-rif/src/main/java/gov/cms/bfd/model/rif/schema/DatabaseTestHelper.java
+++ b/apps/bfd-model/bfd-model-rif/src/main/java/gov/cms/bfd/model/rif/schema/DatabaseTestHelper.java
@@ -235,6 +235,11 @@ public final class DatabaseTestHelper {
         JDBCDataSource hsqlDataSource = (JDBCDataSource) dataSource;
         this.url = hsqlDataSource.getUrl();
         this.username = hsqlDataSource.getUser();
+        /*
+         * HSQL's implementation doesn't expose the DataSource's password, which is dumb. Because
+         * I'm lazy, I just hardcode it here. If you need this to NOT be hardcoded, simplest fix
+         * would be to write a helper method that pulls the field's value via reflection.
+         */
         this.password = HSQL_SERVER_PASSWORD; // no getter available; hardcoded
       } else if (dataSource instanceof PGSimpleDataSource) {
         PGSimpleDataSource pgDataSource = (PGSimpleDataSource) dataSource;

--- a/apps/bfd-model/bfd-model-rif/src/test/java/gov/cms/bfd/model/rif/schema/DatabaseSchemaManagerTest.java
+++ b/apps/bfd-model/bfd-model-rif/src/test/java/gov/cms/bfd/model/rif/schema/DatabaseSchemaManagerTest.java
@@ -1,6 +1,6 @@
 package gov.cms.bfd.model.rif.schema;
 
-import org.hsqldb.jdbc.JDBCDataSource;
+import javax.sql.DataSource;
 import org.junit.Test;
 
 /** Unit tests for {@link gov.cms.bfd.model.rif.schema.DatabaseSchemaManager}. */
@@ -11,10 +11,9 @@ public final class DatabaseSchemaManagerTest {
    */
   @Test
   public void createOrUpdateSchemaOnHsql() {
-    JDBCDataSource hsqlDataSource = new JDBCDataSource();
-    hsqlDataSource.setUrl("jdbc:hsqldb:mem:test");
+    DataSource testDbDataSource = DatabaseTestHelper.getTestDatabaseAfterClean();
 
     // Ensure that this runs without errors.
-    DatabaseSchemaManager.createOrUpdateSchema(hsqlDataSource);
+    DatabaseSchemaManager.createOrUpdateSchema(testDbDataSource);
   }
 }

--- a/apps/bfd-pipeline/bfd-pipeline-app/src/test/java/gov/cms/bfd/pipeline/app/AppConfigurationTestIT.java
+++ b/apps/bfd-pipeline/bfd-pipeline-app/src/test/java/gov/cms/bfd/pipeline/app/AppConfigurationTestIT.java
@@ -1,6 +1,8 @@
 package gov.cms.bfd.pipeline.app;
 
 import gov.cms.bfd.model.rif.RifFileType;
+import gov.cms.bfd.model.rif.schema.DatabaseTestHelper;
+import gov.cms.bfd.model.rif.schema.DatabaseTestHelper.DataSourceComponents;
 import gov.cms.bfd.pipeline.rif.load.RifLoaderTestUtils;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -11,6 +13,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.stream.Collectors;
+import javax.sql.DataSource;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
 import org.junit.Assert;
@@ -38,6 +41,9 @@ public final class AppConfigurationTestIT {
   public void normalUsage()
       throws IOException, InterruptedException, ClassNotFoundException, URISyntaxException,
           DecoderException {
+    DataSource dataSource = DatabaseTestHelper.getTestDatabase();
+    DataSourceComponents dataSourceComponents = new DataSourceComponents(dataSource);
+
     ProcessBuilder testAppBuilder = createProcessBuilderForTestDriver();
     testAppBuilder.environment().put(AppConfiguration.ENV_VAR_KEY_BUCKET, "foo");
     testAppBuilder
@@ -55,15 +61,13 @@ public final class AppConfigurationTestIT {
             Hex.encodeHexString(RifLoaderTestUtils.HICN_HASH_PEPPER));
     testAppBuilder
         .environment()
-        .put(AppConfiguration.ENV_VAR_KEY_DATABASE_URL, RifLoaderTestUtils.DB_URL);
+        .put(AppConfiguration.ENV_VAR_KEY_DATABASE_URL, dataSourceComponents.getUrl());
     testAppBuilder
         .environment()
-        .put(AppConfiguration.ENV_VAR_KEY_DATABASE_USERNAME, RifLoaderTestUtils.DB_USERNAME);
+        .put(AppConfiguration.ENV_VAR_KEY_DATABASE_USERNAME, dataSourceComponents.getUsername());
     testAppBuilder
         .environment()
-        .put(
-            AppConfiguration.ENV_VAR_KEY_DATABASE_PASSWORD,
-            String.valueOf(RifLoaderTestUtils.DB_PASSWORD));
+        .put(AppConfiguration.ENV_VAR_KEY_DATABASE_PASSWORD, dataSourceComponents.getPassword());
     testAppBuilder.environment().put(AppConfiguration.ENV_VAR_KEY_LOADER_THREADS, "42");
     testAppBuilder.environment().put(AppConfiguration.ENV_VAR_KEY_IDEMPOTENCY_REQUIRED, "true");
     Process testApp = testAppBuilder.start();

--- a/apps/bfd-pipeline/bfd-pipeline-app/src/test/java/gov/cms/bfd/pipeline/app/S3ToDatabaseLoadAppIT.java
+++ b/apps/bfd-pipeline/bfd-pipeline-app/src/test/java/gov/cms/bfd/pipeline/app/S3ToDatabaseLoadAppIT.java
@@ -4,6 +4,8 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.Bucket;
 import gov.cms.bfd.model.rif.RifFileType;
 import gov.cms.bfd.model.rif.samples.StaticRifResource;
+import gov.cms.bfd.model.rif.schema.DatabaseTestHelper;
+import gov.cms.bfd.model.rif.schema.DatabaseTestHelper.DataSourceComponents;
 import gov.cms.bfd.pipeline.rif.extract.s3.DataSetManifest;
 import gov.cms.bfd.pipeline.rif.extract.s3.DataSetManifest.DataSetManifestEntry;
 import gov.cms.bfd.pipeline.rif.extract.s3.DataSetMonitor;
@@ -23,6 +25,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
+import javax.sql.DataSource;
 import org.apache.commons.codec.binary.Hex;
 import org.awaitility.Awaitility;
 import org.awaitility.Duration;
@@ -342,6 +345,9 @@ public final class S3ToDatabaseLoadAppIT {
     ProcessBuilder appRunBuilder = new ProcessBuilder(command);
     appRunBuilder.redirectErrorStream(true);
 
+    DataSource dataSource = DatabaseTestHelper.getTestDatabaseAfterClean();
+    DataSourceComponents dataSourceComponents = new DataSourceComponents(dataSource);
+
     appRunBuilder.environment().put(AppConfiguration.ENV_VAR_KEY_BUCKET, bucket.getName());
     appRunBuilder
         .environment()
@@ -355,15 +361,13 @@ public final class S3ToDatabaseLoadAppIT {
             Hex.encodeHexString(RifLoaderTestUtils.HICN_HASH_PEPPER));
     appRunBuilder
         .environment()
-        .put(AppConfiguration.ENV_VAR_KEY_DATABASE_URL, RifLoaderTestUtils.DB_URL);
+        .put(AppConfiguration.ENV_VAR_KEY_DATABASE_URL, dataSourceComponents.getUrl());
     appRunBuilder
         .environment()
-        .put(AppConfiguration.ENV_VAR_KEY_DATABASE_USERNAME, RifLoaderTestUtils.DB_USERNAME);
+        .put(AppConfiguration.ENV_VAR_KEY_DATABASE_USERNAME, dataSourceComponents.getUsername());
     appRunBuilder
         .environment()
-        .put(
-            AppConfiguration.ENV_VAR_KEY_DATABASE_PASSWORD,
-            String.valueOf(RifLoaderTestUtils.DB_PASSWORD));
+        .put(AppConfiguration.ENV_VAR_KEY_DATABASE_PASSWORD, dataSourceComponents.getPassword());
     appRunBuilder
         .environment()
         .put(

--- a/apps/bfd-pipeline/bfd-pipeline-rif-load/src/main/java/gov/cms/bfd/pipeline/rif/load/LoadAppOptions.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rif-load/src/main/java/gov/cms/bfd/pipeline/rif/load/LoadAppOptions.java
@@ -1,6 +1,7 @@
 package gov.cms.bfd.pipeline.rif.load;
 
 import java.io.Serializable;
+import javax.sql.DataSource;
 
 /** Models the user-configurable application options. */
 public final class LoadAppOptions implements Serializable {
@@ -24,6 +25,7 @@ public final class LoadAppOptions implements Serializable {
   private final String databaseUrl;
   private final String databaseUsername;
   private final char[] databasePassword;
+  private final DataSource databaseDataSource;
   private final int loaderThreads;
   private final boolean idempotencyRequired;
 
@@ -53,6 +55,34 @@ public final class LoadAppOptions implements Serializable {
     this.databaseUrl = databaseUrl;
     this.databaseUsername = databaseUsername;
     this.databasePassword = databasePassword;
+    this.databaseDataSource = null;
+    this.loaderThreads = loaderThreads;
+    this.idempotencyRequired = idempotencyRequired;
+  }
+
+  /**
+   * Constructs a new {@link LoadAppOptions} instance.
+   *
+   * @param hicnHashIterations the value to use for {@link #getHicnHashIterations()}
+   * @param hicnHashPepper the value to use for {@link #getHicnHashPepper()}
+   * @param databaseDataSource the value to use for {@link #getDatabaseDataSource()}
+   * @param loaderThreads the value to use for {@link #getLoaderThreads()}
+   * @param idempotencyRequired the value to use for {@link #isIdempotencyRequired()}
+   */
+  public LoadAppOptions(
+      int hicnHashIterations,
+      byte[] hicnHashPepper,
+      DataSource databaseDataSource,
+      int loaderThreads,
+      boolean idempotencyRequired) {
+    if (loaderThreads < 1) throw new IllegalArgumentException();
+
+    this.hicnHashIterations = hicnHashIterations;
+    this.hicnHashPepper = hicnHashPepper;
+    this.databaseUrl = null;
+    this.databaseUsername = null;
+    this.databasePassword = null;
+    this.databaseDataSource = databaseDataSource;
     this.loaderThreads = loaderThreads;
     this.idempotencyRequired = idempotencyRequired;
   }
@@ -73,19 +103,36 @@ public final class LoadAppOptions implements Serializable {
     return hicnHashPepper;
   }
 
-  /** @return the JDBC URL of the database to load into */
+  /**
+   * @return the JDBC URL of the database to load into, or <code>null</code> if {@link
+   *     #getDatabaseDataSource()} is used, instead
+   */
   public String getDatabaseUrl() {
     return databaseUrl;
   }
 
-  /** @return the database username to connect as when loading data */
+  /**
+   * @return the database username to connect as when loading data, or <code>null</code> if {@link
+   *     #getDatabaseDataSource()} is used, instead
+   */
   public String getDatabaseUsername() {
     return databaseUsername;
   }
 
-  /** @return the database password to connect with when loading data */
+  /**
+   * @return the database password to connect with when loading data, or <code>null</code> if {@link
+   *     #getDatabaseDataSource()} is used, instead
+   */
   public char[] getDatabasePassword() {
     return databasePassword;
+  }
+
+  /**
+   * @return a {@link DataSource} for the database to connect to when loading data, or <code>null
+   *     </code> if {@link #getDatabaseUrl()} is used, instead
+   */
+  public DataSource getDatabaseDataSource() {
+    return databaseDataSource;
   }
 
   /**
@@ -121,6 +168,8 @@ public final class LoadAppOptions implements Serializable {
     builder.append(", databaseUsername=");
     builder.append("***");
     builder.append(", databasePassword=");
+    builder.append("***");
+    builder.append(", databaseDataSource=");
     builder.append("***");
     builder.append(", loaderThreads=");
     builder.append(loaderThreads);

--- a/apps/bfd-pipeline/bfd-pipeline-rif-load/src/main/java/gov/cms/bfd/pipeline/rif/load/RifLoaderTestUtils.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rif-load/src/main/java/gov/cms/bfd/pipeline/rif/load/RifLoaderTestUtils.java
@@ -1,21 +1,8 @@
 package gov.cms.bfd.pipeline.rif.load;
 
-import com.codahale.metrics.MetricRegistry;
-import com.justdavis.karl.misc.exceptions.BadCodeMonkeyException;
-import gov.cms.bfd.model.rif.Beneficiary;
 import java.nio.charset.StandardCharsets;
-import java.util.Comparator;
-import java.util.List;
-import java.util.stream.Collectors;
-import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
-import javax.persistence.EntityTransaction;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaDelete;
 import javax.sql.DataSource;
-import org.flywaydb.core.Flyway;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Contains utilities that are useful when running the {@link RifLoader}.
@@ -30,122 +17,21 @@ public final class RifLoaderTestUtils {
   /** The value to use for {@link LoadAppOptions#getHicnHashPepper()} in tests. */
   public static final byte[] HICN_HASH_PEPPER = "nottherealpepper".getBytes(StandardCharsets.UTF_8);
 
-  /**
-   * The value to use for {@link LoadAppOptions#getDatabaseUrl()}. It's occasionally useful for devs
-   * to manually change this to one of these values:
-   *
-   * <ul>
-   *   <li>In-memory HSQL DB (this is the default): <code>jdbc:hsqldb:mem:test;hsqldb.tx=mvcc</code>
-   *   <li>On-disk HSQL DB (useful when the in-memory DB is running out of memory): <code>
-   *       jdbc:hsqldb:file:target/hsql-db-for-its;hsqldb.tx=mvcc</code>
-   * </ul>
-   *
-   * <p>Note: The <code>hsqldb.tx=mvcc</code> option included in the URL is needed to avoid locking
-   * problems with some concurrent tests that access the DB. See <a
-   * href="http://hsqldb.org/doc/guide/sessions-chapt.html#snc_tx_mvcc">HSQL DB: MVCC</a> for
-   * details.
-   */
-  public static final String DB_URL = "jdbc:hsqldb:mem:test;hsqldb.tx=mvcc";
-
-  /** The value to use for {@link LoadAppOptions#getDatabaseUsername()}. */
-  public static final String DB_USERNAME = "";
-
-  /** The value to use for {@link LoadAppOptions#getDatabasePassword()}. */
-  public static final char[] DB_PASSWORD = "".toCharArray();
-
   /** The value to use for {@link LoadAppOptions#isIdempotencyRequired()}. */
   public static final boolean IDEMPOTENCY_REQUIRED = true;
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(RifLoaderTestUtils.class);
-
   /**
-   * <strong>Serious Business:</strong> deletes all resources from the database server used in
-   * tests.
-   *
-   * @param options the {@link LoadAppOptions} specifying the DB to clean
-   */
-  @SuppressWarnings({"rawtypes", "unchecked"})
-  public static void cleanDatabaseServerViaDeletes(LoadAppOptions options) {
-    // Before disabling this check, please go and update your resume.
-    if (!DB_URL.contains("hsql"))
-      throw new BadCodeMonkeyException("Saving you from a career-changing event.");
-
-    EntityManagerFactory entityManagerFactory = createEntityManagerFactory(options);
-    EntityManager entityManager = null;
-    EntityTransaction transaction = null;
-    try {
-      entityManager = entityManagerFactory.createEntityManager();
-
-      // Determine the entity types to delete, and the order to do so in.
-      Comparator<Class<?>> entityDeletionSorter =
-          (t1, t2) -> {
-            if (t1.equals(Beneficiary.class)) return 1;
-            if (t2.equals(Beneficiary.class)) return -1;
-            if (t1.getSimpleName().endsWith("Line")) return -1;
-            if (t2.getSimpleName().endsWith("Line")) return 1;
-            return 0;
-          };
-      List<Class<?>> entityTypesInDeletionOrder =
-          entityManagerFactory.getMetamodel().getEntities().stream()
-              .map(t -> t.getJavaType())
-              .sorted(entityDeletionSorter)
-              .collect(Collectors.toList());
-
-      LOGGER.info("Deleting all resources...");
-      transaction = entityManager.getTransaction();
-      transaction.begin();
-      for (Class<?> entityClass : entityTypesInDeletionOrder) {
-        CriteriaBuilder builder = entityManager.getCriteriaBuilder();
-        CriteriaDelete query = builder.createCriteriaDelete(entityClass);
-        query.from(entityClass);
-        entityManager.createQuery(query).executeUpdate();
-      }
-      transaction.commit();
-      LOGGER.info("Deleted all resources.");
-    } finally {
-      if (transaction != null && transaction.isActive()) transaction.rollback();
-      if (entityManager != null) entityManager.close();
-    }
-  }
-
-  /**
-   * <strong>Serious Business:</strong> deletes all resources from the database server used in
-   * tests.
-   *
-   * @param options the {@link LoadAppOptions} specifying the DB to clean
-   */
-  public static void cleanDatabaseServer(LoadAppOptions options) {
-    // Before disabling this check, please go and update your resume.
-    if (!options.getDatabaseUrl().contains("hsql"))
-      throw new BadCodeMonkeyException("Saving you from a career-changing event.");
-
-    Flyway flyway = new Flyway();
-    flyway.setDataSource(RifLoader.createDataSource(options, new MetricRegistry()));
-    flyway.clean();
-  }
-
-  /**
+   * @param dataSource a {@link DataSource} for the test DB to connect to
    * @return the {@link LoadAppOptions} that should be used in tests, which specifies how to connect
    *     to the database server that tests should be run against
    */
-  public static LoadAppOptions getLoadOptions() {
+  public static LoadAppOptions getLoadOptions(DataSource dataSource) {
     return new LoadAppOptions(
         HICN_HASH_ITERATIONS,
         HICN_HASH_PEPPER,
-        DB_URL,
-        DB_USERNAME,
-        DB_PASSWORD,
+        dataSource,
         LoadAppOptions.DEFAULT_LOADER_THREADS,
         IDEMPOTENCY_REQUIRED);
-  }
-
-  /**
-   * @param options the {@link LoadAppOptions} specifying the DB to use
-   * @return a JDBC {@link DataSource} for the database server used in tests
-   */
-  public static DataSource createDataSouce(LoadAppOptions options) {
-    DataSource jdbcDataSource = RifLoader.createDataSource(options, new MetricRegistry());
-    return jdbcDataSource;
   }
 
   /**
@@ -153,7 +39,11 @@ public final class RifLoaderTestUtils {
    * @return a JPA {@link EntityManagerFactory} for the database server used in tests
    */
   public static EntityManagerFactory createEntityManagerFactory(LoadAppOptions options) {
-    DataSource jdbcDataSource = createDataSouce(options);
-    return RifLoader.createEntityManagerFactory(jdbcDataSource);
+    if (options.getDatabaseDataSource() == null) {
+      throw new IllegalStateException("DB DataSource (not URLs) must be used in tests.");
+    }
+
+    DataSource dataSource = options.getDatabaseDataSource();
+    return RifLoader.createEntityManagerFactory(dataSource);
   }
 }

--- a/apps/bfd-pipeline/bfd-pipeline-rif-load/src/test/java/gov/cms/bfd/pipeline/rif/load/RifLoaderTest.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rif-load/src/test/java/gov/cms/bfd/pipeline/rif/load/RifLoaderTest.java
@@ -1,5 +1,6 @@
 package gov.cms.bfd.pipeline.rif.load;
 
+import gov.cms.bfd.model.rif.schema.DatabaseTestHelper;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import javax.crypto.SecretKeyFactory;
@@ -19,7 +20,8 @@ public final class RifLoaderTest {
    */
   @Test
   public void computeHicnHash() {
-    LoadAppOptions options = RifLoaderTestUtils.getLoadOptions();
+    LoadAppOptions options =
+        RifLoaderTestUtils.getLoadOptions(DatabaseTestHelper.getTestDatabase());
     options =
         new LoadAppOptions(
             1000,

--- a/apps/bfd-server/bfd-server-war/pom.xml
+++ b/apps/bfd-server/bfd-server-war/pom.xml
@@ -21,10 +21,8 @@
 
 		<!-- Configure the BFD Server, as it will be run via the exec
 			plugin. These settings are pulled out as POM properties so that they can
-			be adjusted via profiles. Note that the specific DB URL here is special-cased
-			by SpringConfiguration, which will launch an embedded HSQL DB to host it. -->
+			be adjusted via profiles. -->
 		<its.bfdServer.jvmargs>-Xmx4g</its.bfdServer.jvmargs>
-		<its.bfdServer.db.url>jdbc:bfd-test:hsqldb:mem</its.bfdServer.db.url>
 
 		<!-- Should work out of the box on Linux, but likely needs to be customized
 			(in settings.xml) for Windows dev environments. Seedev/devenv-readme.md
@@ -319,7 +317,7 @@
 								<argument>-t</argument>
 								<argument>${project.build.directory}</argument>
 								<argument>-u</argument>
-								<argument>${its.bfdServer.db.url}</argument>
+								<argument>${its.db.url}</argument>
 							</arguments>
 
 							<!-- Don't start/stop the server if the ITs are being skipped. -->

--- a/apps/bfd-server/bfd-server-war/src/main/config/server-start.sh
+++ b/apps/bfd-server/bfd-server-war/src/main/config/server-start.sh
@@ -168,6 +168,7 @@ BFD_PORT="${serverPortHttps}" \
 	"-DbfdServer.db.url=${dbUrl}" \
 	"-DbfdServer.db.username=" \
 	"-DbfdServer.db.password=" \
+	"-DbfdServer.db.schema.apply=true" \
 	-jar "${serverLauncher}" \
 	>"${serverLog}" 2>&1 \
 	&

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/ServerTestUtils.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/ServerTestUtils.java
@@ -289,6 +289,13 @@ public final class ServerTestUtils {
         query.from(entityClass);
         entityManager.createQuery(query).executeUpdate();
       }
+
+      /*
+       * To be complete, we should also be resetting our sequences here. However, there isn't a
+       * simple way to do that without hardcoding the sequence names, so I'm going to lean into my
+       * laziness and not implement it: it's unlikely to cause issues with our tests.
+       */
+
       transaction.commit();
       LOGGER.info("Deleted all resources.");
     } finally {

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/ServerTestUtils.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/ServerTestUtils.java
@@ -9,7 +9,7 @@ import gov.cms.bfd.model.rif.RifFileEvent;
 import gov.cms.bfd.model.rif.RifFileRecords;
 import gov.cms.bfd.model.rif.RifFilesEvent;
 import gov.cms.bfd.model.rif.samples.StaticRifResource;
-import gov.cms.bfd.model.rif.schema.DatabaseSchemaManager;
+import gov.cms.bfd.model.rif.schema.DatabaseTestHelper;
 import gov.cms.bfd.pipeline.rif.extract.RifFilesProcessor;
 import gov.cms.bfd.pipeline.rif.load.LoadAppOptions;
 import gov.cms.bfd.pipeline.rif.load.RifLoader;
@@ -30,6 +30,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
@@ -39,6 +40,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.management.MBeanServer;
 import javax.net.ssl.SSLContext;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.EntityTransaction;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaDelete;
+import javax.sql.DataSource;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.config.RegistryBuilder;
@@ -194,12 +201,6 @@ public final class ServerTestUtils {
     return trustStorePath;
   }
 
-  /** Ensures that the database used in tests has the correct database schema. */
-  public static void createDatabaseSchema() {
-    LoadAppOptions options = createRifLoaderOptions();
-    DatabaseSchemaManager.createOrUpdateSchema(RifLoaderTestUtils.createDataSouce(options));
-  }
-
   /**
    * @param sampleResources the sample RIF resources to parse
    * @return the {@link List} of RIF records that were parsed (e.g. {@link Beneficiary}s, etc.)
@@ -233,44 +234,112 @@ public final class ServerTestUtils {
     // Create the processors that will handle each stage of the pipeline.
     MetricRegistry loadAppMetrics = new MetricRegistry();
     RifFilesProcessor processor = new RifFilesProcessor();
-    RifLoader loader = new RifLoader(loadAppMetrics, loadOptions);
 
-    // Link up the pipeline and run it.
-    LOGGER.info("Loading RIF records...");
-    List<Object> recordsLoaded = new ArrayList<>();
-    for (RifFileEvent rifFileEvent : rifFilesEvent.getFileEvents()) {
-      RifFileRecords rifFileRecords = processor.produceRecords(rifFileEvent);
-      loader.process(
-          rifFileRecords,
-          error -> {
-            LOGGER.warn("Record(s) failed to load.", error);
-          },
-          result -> {
-            recordsLoaded.add(result.getRifRecordEvent().getRecord());
-          });
+    try (RifLoader loader = new RifLoader(loadAppMetrics, loadOptions); ) {
+      // Link up the pipeline and run it.
+      LOGGER.info("Loading RIF records...");
+      List<Object> recordsLoaded = new ArrayList<>();
+      for (RifFileEvent rifFileEvent : rifFilesEvent.getFileEvents()) {
+        RifFileRecords rifFileRecords = processor.produceRecords(rifFileEvent);
+        loader.process(
+            rifFileRecords,
+            error -> {
+              LOGGER.warn("Record(s) failed to load.", error);
+            },
+            result -> {
+              recordsLoaded.add(result.getRifRecordEvent().getRecord());
+            });
+      }
+      LOGGER.info("Loaded RIF records: '{}'.");
+      return recordsLoaded;
     }
-    LOGGER.info("Loaded RIF records: '{}'.");
-    return recordsLoaded;
   }
 
-  /** Calls {@link RifLoaderTestUtils#cleanDatabaseServer(LoadAppOptions)}. */
+  /** Cleans the test DB by running a bunch of <cod. */
+  @SuppressWarnings({"rawtypes", "unchecked"})
   public static void cleanDatabaseServer() {
-    RifLoaderTestUtils.cleanDatabaseServerViaDeletes(createRifLoaderOptions());
+    EntityManagerFactory entityManagerFactory = null;
+    EntityManager entityManager = null;
+    EntityTransaction transaction = null;
+    try {
+      entityManagerFactory = createEntityManagerFactory();
+      entityManager = entityManagerFactory.createEntityManager();
+
+      // Determine the entity types to delete, and the order to do so in.
+      Comparator<Class<?>> entityDeletionSorter =
+          (t1, t2) -> {
+            if (t1.equals(Beneficiary.class)) return 1;
+            if (t2.equals(Beneficiary.class)) return -1;
+            if (t1.getSimpleName().endsWith("Line")) return -1;
+            if (t2.getSimpleName().endsWith("Line")) return 1;
+            return 0;
+          };
+      List<Class<?>> entityTypesInDeletionOrder =
+          entityManagerFactory.getMetamodel().getEntities().stream()
+              .map(t -> t.getJavaType())
+              .sorted(entityDeletionSorter)
+              .collect(Collectors.toList());
+
+      LOGGER.info("Deleting all resources...");
+      transaction = entityManager.getTransaction();
+      transaction.begin();
+      for (Class<?> entityClass : entityTypesInDeletionOrder) {
+        CriteriaBuilder builder = entityManager.getCriteriaBuilder();
+        CriteriaDelete query = builder.createCriteriaDelete(entityClass);
+        query.from(entityClass);
+        entityManager.createQuery(query).executeUpdate();
+      }
+      transaction.commit();
+      LOGGER.info("Deleted all resources.");
+    } finally {
+      if (transaction != null && transaction.isActive()) transaction.rollback();
+      if (entityManager != null) entityManager.close();
+      if (entityManagerFactory != null) entityManagerFactory.close();
+    }
+  }
+
+  /** @return a {@link DataSource} for the test DB */
+  private static final DataSource createDataSource() {
+    String jdbcUrl, jdbcUsername, jdbcPassword;
+
+    /*
+     * In our tests, we either get the DB connection details from the system properties (for a
+     * "normal" DB that was created outside of the tests), or from the test Properties file that was
+     * created by the WAR when it launched (for HSQL DBs).
+     */
+
+    Properties testDbProps = readTestDatabaseProperties();
+    if (testDbProps != null) {
+      jdbcUrl = testDbProps.getProperty(SpringConfiguration.PROP_DB_URL);
+      jdbcUsername = testDbProps.getProperty(SpringConfiguration.PROP_DB_USERNAME, null);
+      jdbcPassword = testDbProps.getProperty(SpringConfiguration.PROP_DB_PASSWORD, null);
+    } else {
+      jdbcUrl = System.getProperty("its.db.url", null);
+      jdbcUsername = System.getProperty("its.db.username", null);
+      jdbcPassword = System.getProperty("its.db.password", null);
+    }
+
+    if (jdbcUsername != null && jdbcUsername.isEmpty()) jdbcUsername = null;
+    if (jdbcPassword != null && jdbcPassword.isEmpty()) jdbcPassword = null;
+
+    DataSource dataSource = DatabaseTestHelper.getTestDatabase(jdbcUrl, jdbcUsername, jdbcPassword);
+
+    return dataSource;
+  }
+
+  /** @return an {@link EntityManagerFactory} for the test DB */
+  private static EntityManagerFactory createEntityManagerFactory() {
+    DataSource dataSource = createDataSource();
+    return RifLoader.createEntityManagerFactory(dataSource);
   }
 
   /** @return the {@link LoadAppOptions} to use with {@link RifLoader} in integration tests */
   public static LoadAppOptions createRifLoaderOptions() {
-    Properties testDbProps = readTestDatabaseProperties();
-    String jdbcUrl = testDbProps.getProperty(SpringConfiguration.PROP_DB_URL);
-    String jdbcUsername = testDbProps.getProperty(SpringConfiguration.PROP_DB_USERNAME);
-    String jdbcPassword = testDbProps.getProperty(SpringConfiguration.PROP_DB_PASSWORD);
-
+    DataSource dataSource = createDataSource();
     return new LoadAppOptions(
         RifLoaderTestUtils.HICN_HASH_ITERATIONS,
         RifLoaderTestUtils.HICN_HASH_PEPPER,
-        jdbcUrl,
-        jdbcUsername,
-        jdbcPassword.toCharArray(),
+        dataSource,
         LoadAppOptions.DEFAULT_LOADER_THREADS,
         RifLoaderTestUtils.IDEMPOTENCY_REQUIRED);
   }
@@ -301,19 +370,21 @@ public final class ServerTestUtils {
   }
 
   /**
-   * @return the {@link Properties} from the {@link
-   *     gov.cms.bfd.server.war.SpringConfiguration#findTestDatabaseProperties()} file that should
-   *     have been written out by {@link gov.cms.bfd.server.war.SpringConfiguration} when it created
-   *     the test database
+   * @return the {@link Properties} file created by {@link
+   *     gov.cms.bfd.server.war.SpringConfiguration#findTestDatabaseProperties()}, or <code>null
+   *     </code> if it's not present (indicating that just a regular DB connection is being used)
    */
   private static Properties readTestDatabaseProperties() {
-    Properties testDbProps = new Properties();
+    Path testDatabasePropertiesPath = SpringConfiguration.findTestDatabaseProperties();
+    if (!Files.isRegularFile(testDatabasePropertiesPath)) return null;
+
     try {
-      testDbProps.load(new FileReader(SpringConfiguration.findTestDatabaseProperties().toFile()));
+      Properties testDbProps = new Properties();
+      testDbProps.load(new FileReader(testDatabasePropertiesPath.toFile()));
+      return testDbProps;
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }
-    return testDbProps;
   }
 
   /**

--- a/apps/dev/docker-compose.yml
+++ b/apps/dev/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.7'
+
+services:
+
+  postgresql:
+    image: postgres:9.6
+    ports:
+      - "127.0.0.1::5432"
+    restart: always
+    environment:
+      POSTGRES_DB: bfd
+      POSTGRES_USER: bfd
+      POSTGRES_PASSWORD: InsecureLocalDev

--- a/apps/pom.xml
+++ b/apps/pom.xml
@@ -84,6 +84,13 @@
 
 		<metrics.version>3.1.2</metrics.version>
 		<hibernate.version>5.2.10.Final</hibernate.version>
+		
+		<!-- The default DB that will be used in integration tests. -->
+		<!-- Note: See gov.cms.bfd.model.rif.schema.DatabaseTestHelper for details
+			on the default 'jdbc:bfd-test:' URL here. -->
+		<its.db.url>jdbc:bfd-test:hsqldb:mem</its.db.url>
+		<its.db.username></its.db.username>
+		<its.db.password></its.db.password>
 	</properties>
 
 	<dependencyManagement>
@@ -368,6 +375,11 @@ checkJavaFormat
 							might want to configure the max heap size and/or proxy server settings for
 							tests run on a system. -->
 						<argLine>${maven-test.jvm-args.env-specific}</argLine>
+						<systemPropertyVariables>
+							<its.db.url>${its.db.url}</its.db.url>
+							<its.db.username>${its.db.username}</its.db.username>
+							<its.db.password>${its.db.password}</its.db.password>
+						</systemPropertyVariables>
 					</configuration>
 				</plugin>
 				<plugin>


### PR DESCRIPTION
Added support for running ITs against PostgreSQL.

As part of this, had to do a bunch of stuff:

* Refactor a lot of tests to use the new `DatabaseTestHelper`.
* Make `RifLoader` `AutoCloseable`, to avoid connection leaks that were causing test failures (when run against PostgreSQL).
* Add properties to the root POM that specify which DB to run ITs against.
* Add a configuration option to the BFD Server that causes it to run DB schema migrations (disabled by default).
* Add a `docker-compose.yml` descriptor that can be used to standup a temporary PostgreSQL DB, for use in local development and testing.
* Updated the `devenv-readme.md` file a bit, and added instructions on testing against PostgreSQL.
* Set the PostgreSQL connection's `application_name` option for the BFD Server.
    * Needed this to debug something, but it's useful in general.

https://jira.cms.gov/browse/BLUEBUTTON-1379