### PR TITLE
BLUEBUTTON-1361: Fix pipeline data set move

### DIFF
--- a/ops/terraform/modules/resources/bfd_pipeline/main.tf
+++ b/ops/terraform/modules/resources/bfd_pipeline/main.tf
@@ -57,7 +57,13 @@ resource "aws_iam_policy" "bfd_pipeline_rif" {
   "Statement": [
     {
       "Sid": "BFDPipelineRWS3RIFKMS",
-      "Action": ["kms:Decrypt"],
+      "Action": [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey"
+      ],
       "Effect": "Allow",
       "Resource": ["${data.aws_kms_key.master_key.arn}"]
     },


### PR DESCRIPTION
I enabled debug logging on the pipeline this weekend, and noticed that the DataSetMoveTask was getting kicked off properly, but appeared to fail after the first copy operation, as no further debug logs in that task appeared.  Through some testing of the AWS CLI I noticed the following error when copying objects:

```
An error occurred (AccessDenied) when calling the CopyObject operation: Access Denied
```

This was strange because there is no CopyObject IAM permission itself.  Research dug up this very helpful article: https://aws.amazon.com/premiumsupport/knowledge-center/s3-troubleshoot-copy-between-buckets/

This helped establish that our bucket permissions were ok, but we were not granting enough KMS access to the pipeline role.  I've tested this by manually editing the policy permissions and my AWS CLI tests became successful.