### PR TITLE
BLUEBUTTON-1361: Improve BFD Pipeline's async error handling

### DIFF
--- a/apps/bfd-pipeline/bfd-pipeline-app/src/main/java/gov/cms/bfd/pipeline/app/S3ToDatabaseLoadApp.java
+++ b/apps/bfd-pipeline/bfd-pipeline-app/src/main/java/gov/cms/bfd/pipeline/app/S3ToDatabaseLoadApp.java
@@ -241,12 +241,6 @@ public final class S3ToDatabaseLoadApp {
         new UncaughtExceptionHandler() {
           @Override
           public void uncaughtException(Thread t, Throwable e) {
-            /*
-             * FIXME Just a note on something that I found a bit surprising: this won't be triggered
-             * for errors that occur in the DataSetMonitorWorker, as the ScheduledExecutorService
-             * swallows those exceptions.
-             */
-
             handleUncaughtException(e);
           }
         });

--- a/apps/bfd-pipeline/bfd-pipeline-app/src/main/java/gov/cms/bfd/pipeline/app/S3ToDatabaseLoadApp.java
+++ b/apps/bfd-pipeline/bfd-pipeline-app/src/main/java/gov/cms/bfd/pipeline/app/S3ToDatabaseLoadApp.java
@@ -1,5 +1,6 @@
 package gov.cms.bfd.pipeline.app;
 
+import ch.qos.logback.classic.LoggerContext;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Slf4jReporter;
 import com.codahale.metrics.Timer;
@@ -219,6 +220,14 @@ public final class S3ToDatabaseLoadApp {
                     Slf4jReporter.forRegistry(metrics).outputTo(LOGGER).build().report();
 
                     LOGGER.info("Application has finished shutting down.");
+
+                    /*
+                     * We have to do this ourselves (rather than use Logback's DelayingShutdownHook)
+                     * to ensure that the logger isn't closed before the above logging.
+                     */
+                    LoggerContext logbackContext =
+                        (LoggerContext) LoggerFactory.getILoggerFactory();
+                    logbackContext.stop();
                   }
                 }));
   }

--- a/apps/bfd-pipeline/bfd-pipeline-rif-extract/src/main/java/gov/cms/bfd/pipeline/rif/extract/s3/DataSetMonitor.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rif-extract/src/main/java/gov/cms/bfd/pipeline/rif/extract/s3/DataSetMonitor.java
@@ -155,11 +155,12 @@ public final class DataSetMonitor {
      * Signal the scheduler to stop after the current DataSetMonitorWorker
      * execution (if any), then wait for that to happen.
      */
+    dataSetWatcherExecutor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
+    dataSetWatcherExecutor.shutdown();
     dataSetWatcherFuture.cancel(false);
     waitForStop();
 
     // Clean house.
-    dataSetWatcherExecutor.shutdown();
     s3TaskManager.shutdownSafely();
 
     LOGGER.debug("Stopped.");

--- a/apps/bfd-pipeline/bfd-pipeline-rif-extract/src/main/java/gov/cms/bfd/pipeline/rif/extract/s3/DataSetMonitor.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rif-extract/src/main/java/gov/cms/bfd/pipeline/rif/extract/s3/DataSetMonitor.java
@@ -108,7 +108,7 @@ public final class DataSetMonitor {
     if (this.dataSetWatcherExecutor != null || this.dataSetWatcherFuture != null)
       throw new IllegalStateException();
 
-    this.dataSetWatcherExecutor = new TaskExecutor(1);
+    this.dataSetWatcherExecutor = new TaskExecutor("Data Set Watcher Executor", 1);
     this.s3TaskManager = new S3TaskManager(appMetrics, options);
     this.dataSetWatcher = new DataSetMonitorWorker(appMetrics, options, s3TaskManager, listener);
     Runnable errorNotifyingDataSetWatcher =

--- a/apps/bfd-pipeline/bfd-pipeline-rif-extract/src/main/java/gov/cms/bfd/pipeline/rif/extract/s3/DataSetMonitorWorker.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rif-extract/src/main/java/gov/cms/bfd/pipeline/rif/extract/s3/DataSetMonitorWorker.java
@@ -86,14 +86,18 @@ public final class DataSetMonitorWorker implements Runnable {
    *
    * @param appMetrics the {@link MetricRegistry} for the overall application
    * @param options the {@link ExtractionOptions} to use
+   * @param s3TaskManager the {@link S3TaskManager} to use
    * @param listener the {@link DataSetMonitorListener} to send events to
    */
   public DataSetMonitorWorker(
-      MetricRegistry appMetrics, ExtractionOptions options, DataSetMonitorListener listener) {
+      MetricRegistry appMetrics,
+      ExtractionOptions options,
+      S3TaskManager s3TaskManager,
+      DataSetMonitorListener listener) {
     this.appMetrics = appMetrics;
     this.options = options;
     this.listener = listener;
-    this.s3TaskManager = new S3TaskManager(appMetrics, options);
+    this.s3TaskManager = s3TaskManager;
 
     this.dataSetQueue = new DataSetQueue(appMetrics, options, s3TaskManager);
   }
@@ -265,17 +269,5 @@ public final class DataSetMonitorWorker implements Runnable {
     }
 
     return true;
-  }
-
-  /**
-   * Cleans up all resources in use by this {@link DataSetMonitorWorker}, in preparation for
-   * application shutdown.
-   */
-  public void cleanup() {
-    /*
-     * Stop accepting new S3 tasks, cancel those tasks that can be canceled
-     * safely, and wait for the rest to complete.
-     */
-    s3TaskManager.shutdownSafely();
   }
 }

--- a/apps/bfd-pipeline/bfd-pipeline-rif-extract/src/main/java/gov/cms/bfd/pipeline/rif/extract/s3/S3RifFile.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rif-extract/src/main/java/gov/cms/bfd/pipeline/rif/extract/s3/S3RifFile.java
@@ -145,11 +145,12 @@ public final class S3RifFile implements RifFile {
    */
   public void cleanupTempFile() {
     LOGGER.debug("Cleaning up '{}'...", this);
-    if (!manifestEntryDownload.isDone()) {
-      manifestEntryDownload.cancel(false);
-      return;
-    }
 
+    /*
+     * We need to either cancel the download or wait for it to complete and then clean up the file.
+     * However, canceling isn't a thread-safe operation (which is bonkers, but true), so we'll just
+     * wait for completion.
+     */
     try {
       ManifestEntryDownloadResult fileDownloadResult = waitForDownload();
       Files.deleteIfExists(fileDownloadResult.getLocalDownload());

--- a/apps/bfd-pipeline/bfd-pipeline-rif-extract/src/main/java/gov/cms/bfd/pipeline/rif/extract/s3/TaskExecutor.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rif-extract/src/main/java/gov/cms/bfd/pipeline/rif/extract/s3/TaskExecutor.java
@@ -1,11 +1,14 @@
 package gov.cms.bfd.pipeline.rif.extract.s3;
 
+import java.lang.reflect.Field;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A {@link ScheduledThreadPoolExecutor} that can be used to run asynchronous tasks. Why this
@@ -14,15 +17,21 @@ import java.util.concurrent.TimeUnit;
  * shutdown when things go boom.
  */
 public final class TaskExecutor extends ScheduledThreadPoolExecutor {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TaskExecutor.class);
+
+  private final String name;
+
   /**
    * Constructs a new {@link TaskExecutor} instance.
    *
    * @param threadPoolSize the number of threads to maintain in the thread pool
    */
-  public TaskExecutor(int threadPoolSize) {
+  public TaskExecutor(String name, int threadPoolSize) {
     super(threadPoolSize);
     setKeepAliveTime(100L, TimeUnit.MILLISECONDS);
     allowCoreThreadTimeOut(true);
+
+    this.name = name;
   }
 
   /**
@@ -34,8 +43,9 @@ public final class TaskExecutor extends ScheduledThreadPoolExecutor {
     super.afterExecute(runnable, throwable);
 
     /*
-     * We need to ensure that failed tasks at least get logged, so that those failures can be
-     * investigated.
+     * We need to ensure that failure of asynchronous tasks cause exceptions to get thrown on this
+     * thread, which should ultimately bubble up to something that the application can handle, e.g.
+     * in an uncaught exception handler.
      */
 
     if (throwable == null && runnable instanceof Future<?>) {
@@ -58,7 +68,54 @@ public final class TaskExecutor extends ScheduledThreadPoolExecutor {
      * error, via the thread's uncaught exception handler.
      */
     if (throwable != null) {
-      throw new RuntimeException("Asynchronous task failed.", throwable);
+      if (throwable instanceof CancellationException) {
+        // Don't bubble up cancellations, as they're not "real" errors.
+        LOGGER.trace(
+            String.format(
+                "Asynchronous task '%s' on the '%s' executor was cancelled.",
+                getTaskId(runnable), this.name),
+            throwable);
+      } else {
+        throw new RuntimeException(
+            String.format(
+                "Asynchronous task '%s' on the '%s' executor failed.",
+                getTaskId(runnable), this.name),
+            throwable);
+      }
+    }
+  }
+
+  /**
+   * Returns an identifying {@link String} for the specified task object, e.g. a {@link Runnable},
+   * {@link Future}, etc. Only suitable for use in debugging.
+   *
+   * @param task the task object (e.g. {@link Runnable}, {@link Future}) to try and get an
+   *     identifying {@link String} for
+   */
+  public static String getTaskId(Object task) {
+    /*
+     * The JDK executors really don't provide much monitoring or other metadata, which makes them a
+     * pain to debug. This isn't much, but it does help somewhat when trying to track down problems.
+     */
+
+    try {
+      if (task.getClass().getName().contains("ScheduledFutureTask")) {
+        /*
+         * Tasks submitted to TaskExecutor get wrapped in a ScheduledFutureTask, which this branch
+         * covers.
+         */
+
+        Field timeField = task.getClass().getDeclaredField("time");
+        timeField.setAccessible(true);
+        return "" + timeField.get(task);
+      } else {
+        return String.format("(unknown: %s)", task);
+      }
+    } catch (NoSuchFieldException
+        | SecurityException
+        | IllegalArgumentException
+        | IllegalAccessException e) {
+      return String.format("(unknown: %s)", task);
     }
   }
 }

--- a/apps/bfd-pipeline/bfd-pipeline-rif-extract/src/main/java/gov/cms/bfd/pipeline/rif/extract/s3/TaskExecutor.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rif-extract/src/main/java/gov/cms/bfd/pipeline/rif/extract/s3/TaskExecutor.java
@@ -1,0 +1,64 @@
+package gov.cms.bfd.pipeline.rif.extract.s3;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A {@link ScheduledThreadPoolExecutor} that can be used to run asynchronous tasks. Why this
+ * instead of something from {@link Executors}? Because this will properly "bubble up" task failures
+ * to the {@link Thread} and its uncaught exception handler, allowing our application to gracefully
+ * shutdown when things go boom.
+ */
+public final class TaskExecutor extends ScheduledThreadPoolExecutor {
+  /**
+   * Constructs a new {@link TaskExecutor} instance.
+   *
+   * @param threadPoolSize the number of threads to maintain in the thread pool
+   */
+  public TaskExecutor(int threadPoolSize) {
+    super(threadPoolSize);
+    setKeepAliveTime(100L, TimeUnit.MILLISECONDS);
+    allowCoreThreadTimeOut(true);
+  }
+
+  /**
+   * @see java.util.concurrent.ThreadPoolExecutor#afterExecute(java.lang.Runnable,
+   *     java.lang.Throwable)
+   */
+  @Override
+  protected void afterExecute(Runnable runnable, Throwable throwable) {
+    super.afterExecute(runnable, throwable);
+
+    /*
+     * We need to ensure that failed tasks at least get logged, so that those failures can be
+     * investigated.
+     */
+
+    if (throwable == null && runnable instanceof Future<?>) {
+      try {
+        Future<?> future = (Future<?>) runnable;
+        if (future.isDone()) {
+          future.get();
+        }
+      } catch (CancellationException ce) {
+        throwable = ce;
+      } catch (ExecutionException ee) {
+        throwable = ee.getCause();
+      } catch (InterruptedException ie) {
+        Thread.currentThread().interrupt();
+      }
+    }
+
+    /*
+     * Wrap and rethrow: Ensure that the (outer) application gets a chance to respond to this
+     * error, via the thread's uncaught exception handler.
+     */
+    if (throwable != null) {
+      throw new RuntimeException("Asynchronous task failed.", throwable);
+    }
+  }
+}

--- a/apps/bfd-pipeline/bfd-pipeline-rif-extract/src/main/java/gov/cms/bfd/pipeline/rif/extract/s3/task/DataSetMoveTask.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rif-extract/src/main/java/gov/cms/bfd/pipeline/rif/extract/s3/task/DataSetMoveTask.java
@@ -1,11 +1,12 @@
 package gov.cms.bfd.pipeline.rif.extract.s3.task;
 
 import com.amazonaws.services.s3.model.CopyObjectRequest;
-import com.amazonaws.services.s3.model.DeleteObjectsRequest;
-import com.amazonaws.services.s3.model.DeleteObjectsRequest.KeyVersion;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
 import com.amazonaws.services.s3.transfer.Copy;
+import com.amazonaws.waiters.WaiterParameters;
 import com.justdavis.karl.misc.exceptions.BadCodeMonkeyException;
 import gov.cms.bfd.pipeline.rif.extract.ExtractionOptions;
 import gov.cms.bfd.pipeline.rif.extract.s3.DataSetManifest;
@@ -92,19 +93,39 @@ public final class DataSetMoveTask implements Callable<Void> {
       Copy copyOperation = s3TaskManager.getS3TransferManager().copy(copyRequest);
       try {
         copyOperation.waitForCopyResult();
+        s3TaskManager
+            .getS3Client()
+            .waiters()
+            .objectExists()
+            .run(
+                new WaiterParameters<GetObjectMetadataRequest>(
+                    new GetObjectMetadataRequest(options.getS3BucketName(), targetKey)));
       } catch (InterruptedException e) {
         throw new BadCodeMonkeyException(e);
       }
     }
     LOGGER.debug("Data set copied in S3 (step 1 of move).");
 
-    DeleteObjectsRequest deleteObjectsRequest = new DeleteObjectsRequest(options.getS3BucketName());
-    deleteObjectsRequest.setKeys(
-        s3KeySuffixesToMove.stream()
-            .map(k -> String.format("%s/%s", DataSetMonitorWorker.S3_PREFIX_PENDING_DATA_SETS, k))
-            .map(k -> new KeyVersion(k))
-            .collect(Collectors.toList()));
-    s3TaskManager.getS3Client().deleteObjects(deleteObjectsRequest);
+    /*
+     * After everything's been copied, loop over it all again and delete it the source objects. (We
+     * could do it all in the same loop, but this is a bit easier to clean up from if it goes
+     * sideways.)
+     */
+    for (String s3KeySuffixToMove : s3KeySuffixesToMove) {
+      String sourceKey =
+          String.format(
+              "%s/%s", DataSetMonitorWorker.S3_PREFIX_PENDING_DATA_SETS, s3KeySuffixToMove);
+      DeleteObjectRequest deleteObjectRequest =
+          new DeleteObjectRequest(options.getS3BucketName(), sourceKey);
+      s3TaskManager.getS3Client().deleteObject(deleteObjectRequest);
+      s3TaskManager
+          .getS3Client()
+          .waiters()
+          .objectNotExists()
+          .run(
+              new WaiterParameters<GetObjectMetadataRequest>(
+                  new GetObjectMetadataRequest(options.getS3BucketName(), sourceKey)));
+    }
     LOGGER.debug("Data set deleted in S3 (step 2 of move).");
 
     LOGGER.debug("Renamed data set '{}' in S3, now that processing is complete.", manifest);

--- a/apps/bfd-pipeline/bfd-pipeline-rif-extract/src/main/java/gov/cms/bfd/pipeline/rif/extract/s3/task/S3TaskManager.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rif-extract/src/main/java/gov/cms/bfd/pipeline/rif/extract/s3/task/S3TaskManager.java
@@ -124,10 +124,9 @@ public final class S3TaskManager {
     this.moveTasksExecutor.shutdown();
 
     /*
-     * Prevent any new download tasks from being submitted and cancel those
-     * that are queued.
+     * Prevent any new download tasks from being submitted.
      */
-    this.downloadTasksExecutor.shutdownNow();
+    this.downloadTasksExecutor.shutdown();
 
     try {
       if (!this.moveTasksExecutor.isTerminated()) {

--- a/apps/bfd-pipeline/bfd-pipeline-rif-extract/src/test/java/gov/cms/bfd/pipeline/rif/extract/s3/DataSetMonitorWorkerIT.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rif-extract/src/test/java/gov/cms/bfd/pipeline/rif/extract/s3/DataSetMonitorWorkerIT.java
@@ -7,6 +7,7 @@ import gov.cms.bfd.model.rif.RifFileType;
 import gov.cms.bfd.model.rif.samples.StaticRifResource;
 import gov.cms.bfd.pipeline.rif.extract.ExtractionOptions;
 import gov.cms.bfd.pipeline.rif.extract.s3.DataSetManifest.DataSetManifestEntry;
+import gov.cms.bfd.pipeline.rif.extract.s3.task.S3TaskManager;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import org.junit.Assert;
@@ -37,8 +38,9 @@ public final class DataSetMonitorWorkerIT {
 
       // Run the worker.
       MockDataSetMonitorListener listener = new MockDataSetMonitorListener();
+      S3TaskManager s3TaskManager = new S3TaskManager(new MetricRegistry(), options);
       DataSetMonitorWorker monitorWorker =
-          new DataSetMonitorWorker(new MetricRegistry(), options, listener);
+          new DataSetMonitorWorker(new MetricRegistry(), options, s3TaskManager, listener);
       monitorWorker.run();
 
       // Verify that no data sets were generated.
@@ -91,8 +93,9 @@ public final class DataSetMonitorWorkerIT {
 
       // Run the worker.
       MockDataSetMonitorListener listener = new MockDataSetMonitorListener();
+      S3TaskManager s3TaskManager = new S3TaskManager(new MetricRegistry(), options);
       DataSetMonitorWorker monitorWorker =
-          new DataSetMonitorWorker(new MetricRegistry(), options, listener);
+          new DataSetMonitorWorker(new MetricRegistry(), options, s3TaskManager, listener);
       monitorWorker.run();
 
       // Verify what was handed off to the DataSetMonitorListener.
@@ -177,8 +180,9 @@ public final class DataSetMonitorWorkerIT {
 
       // Run the worker.
       MockDataSetMonitorListener listener = new MockDataSetMonitorListener();
+      S3TaskManager s3TaskManager = new S3TaskManager(new MetricRegistry(), options);
       DataSetMonitorWorker monitorWorker =
-          new DataSetMonitorWorker(new MetricRegistry(), options, listener);
+          new DataSetMonitorWorker(new MetricRegistry(), options, s3TaskManager, listener);
       monitorWorker.run();
 
       // Verify what was handed off to the DataSetMonitorListener.
@@ -252,8 +256,9 @@ public final class DataSetMonitorWorkerIT {
 
       // Run the worker.
       MockDataSetMonitorListener listener = new MockDataSetMonitorListener();
+      S3TaskManager s3TaskManager = new S3TaskManager(new MetricRegistry(), options);
       DataSetMonitorWorker monitorWorker =
-          new DataSetMonitorWorker(new MetricRegistry(), options, listener);
+          new DataSetMonitorWorker(new MetricRegistry(), options, s3TaskManager, listener);
       monitorWorker.run();
 
       // Verify what was handed off to the DataSetMonitorListener.


### PR DESCRIPTION
Ensure that exceptions in executors are bubbled up to threads, so that the threads' uncaught exception handlers can do their thing.

Also: update the uncaught exception handlers to use the graceful shutdown routines that were already being used elsewhere.

https://jira.cms.gov/browse/BLUEBUTTON-1361