### PR TITLE
BLUEBUTTON-1531: Add metrics and alarms for pipeline errors

### DIFF
--- a/ops/terraform/modules/resources/bfd_pipeline/variables.tf
+++ b/ops/terraform/modules/resources/bfd_pipeline/variables.tf
@@ -20,3 +20,15 @@ variable "mgmt_config" {
 variable "launch_config" {
   type        = object({ami_id=string, account_id=string, ssh_key_name=string, git_branch=string, git_commit=string})
 }
+
+variable "alarm_notification_arn" {
+  description = "The CloudWatch Alarm notification ARN."
+  type        = "string"
+  default     = null
+}
+
+variable "ok_notification_arn" {
+  description = "The CloudWatch OK notification ARN."
+  type        = "string"
+  default     = null
+}

--- a/ops/terraform/modules/stateless/main.tf
+++ b/ops/terraform/modules/stateless/main.tf
@@ -275,6 +275,9 @@ module "bfd_pipeline" {
     remote_sg     = data.aws_security_group.remote.id
     ci_cidrs      = [data.aws_vpc.mgmt.cidr_block]
   }
+
+  alarm_notification_arn = data.aws_sns_topic.cloudwatch_alarms.arn
+  ok_notification_arn    = data.aws_sns_topic.cloudwatch_ok.arn
 }
 
 # Cloudwatch Log Metric Filters
@@ -292,7 +295,6 @@ module "cw_metric_alarms" {
   app                           = "bfd"
   alarm_notification_arn        = data.aws_sns_topic.cloudwatch_alarms.arn
   ok_notification_arn           = data.aws_sns_topic.cloudwatch_ok.arn
-
 }
 
 


### PR DESCRIPTION
By design, the pipeline treats any unhandled exception as an error log and shutdown event.  We want to make sure we are tracking these errors, but only page in prod as that is currently the only environment where the pipeline is doing anything.