### PR TITLE
BLUEBUTTON-1615: Use latest gold image

### DIFF
--- a/ops/deploy-ccs.groovy
+++ b/ops/deploy-ccs.groovy
@@ -90,7 +90,7 @@ def buildPlatinumAmi(AmiIds amiIds) {
 		def goldAmi = sh(
 			returnStdout: true,
 			script: "/usr/local/bin/aws ec2 describe-images --filters \
-			'Name=name,Values=\"EAST-RH 7-6 Gold Image V.1.10 (HVM) ??-??-??\"' \
+			'Name=name,Values=\"EAST-RH 7-? Gold Image V.1.?? (HVM) ??-??-??\"' \
 			'Name=state,Values=available' --region us-east-1 --output json | \
 			jq -r '.Images | sort_by(.CreationDate) | last(.[]).ImageId'"
 			).trim()


### PR DESCRIPTION
We need to update our deployments to use the latest gold image ASAP to comply with the audit.  I've tested this filter expression locally to ensure it finds the latest gold image available using RedHat 7.