### PR TITLE
Allow local server port to be set via env var

### DIFF
--- a/apps/bfd-server/bfd-server-war/src/main/config/server-start.sh
+++ b/apps/bfd-server/bfd-server-war/src/main/config/server-start.sh
@@ -136,7 +136,7 @@ if [[ "${cygwin}" = true ]]; then keyStore=$(cygpath --mixed "${keyStore}"); fi
 if [[ "${cygwin}" = true ]]; then trustStore=$(cygpath --mixed "${trustStore}"); fi
 
 # Read the server port to be used from the ports file.
-serverPortHttps=$(grep "^server.port.https=" "${serverPortsFile}" | tr -d '\r' | cut -d'=' -f2 )
+serverPortHttps=${BFD_PORT?$(grep "^server.port.https=" "${serverPortsFile}" | tr -d '\r' | cut -d'=' -f2 )}
 if [[ -z "${serverPortHttps}" ]]; then >&2 echo "Server HTTPS port not specified in '${serverPortsFile}'."; exit 1; fi
 echo "Configured server to run on HTTPS port '${serverPortHttps}'."
 


### PR DESCRIPTION
# Why
To allow developers to run the BFD web server on a specific port. This makes possible things like consistent port forwarding in virtualized environments, and a lower barrier to entry for local development.

# Changes
- propagate the `BFD_PORT` environment variable through the `server-start.sh` script.