### PR TITLE
BLUEBUTTON-1616: Remove VictorOps URL from hardcoded location

### DIFF
--- a/ops/terraform/env/prod-sbx/stateful/main.tf
+++ b/ops/terraform/env/prod-sbx/stateful/main.tf
@@ -26,5 +26,7 @@ module "stateful" {
   env_config = {
     env               = "prod-sbx"
     tags              = {application="bfd", business="oeda", stack="prod-sbx", Environment="prod-sbx"}
-  }  
+  }
+
+  victor_ops_url      = var.victor_ops_url
 }

--- a/ops/terraform/env/prod-sbx/stateful/variables.tf
+++ b/ops/terraform/env/prod-sbx/stateful/variables.tf
@@ -1,0 +1,4 @@
+variable "victor_ops_url" {
+  description       = "VictorOps CloudWatch integration URL"
+  type              = string
+}

--- a/ops/terraform/env/prod/stateful/main.tf
+++ b/ops/terraform/env/prod/stateful/main.tf
@@ -36,4 +36,6 @@ module "stateful" {
     env               = "prod"
     tags              = {application="bfd", business="oeda", stack="prod", Environment="prod"}
   }
+
+  victor_ops_url      = var.victor_ops_url
 }

--- a/ops/terraform/env/prod/stateful/variables.tf
+++ b/ops/terraform/env/prod/stateful/variables.tf
@@ -1,0 +1,4 @@
+variable "victor_ops_url" {
+  description       = "VictorOps CloudWatch integration URL"
+  type              = string
+}

--- a/ops/terraform/env/test/stateful/main.tf
+++ b/ops/terraform/env/test/stateful/main.tf
@@ -35,5 +35,7 @@ module "stateful" {
   env_config = {
     env               = "test"
     tags              = {application="bfd", business="oeda", stack="test", Environment="test"}
-  }  
+  }
+
+  victor_ops_url      = var.victor_ops_url
 }

--- a/ops/terraform/env/test/stateful/variables.tf
+++ b/ops/terraform/env/test/stateful/variables.tf
@@ -1,0 +1,4 @@
+variable "victor_ops_url" {
+  description       = "VictorOps CloudWatch integration URL"
+  type              = string
+}

--- a/ops/terraform/modules/stateful/main.tf
+++ b/ops/terraform/modules/stateful/main.tf
@@ -8,7 +8,7 @@ locals {
   azs                   = ["us-east-1a", "us-east-1b", "us-east-1c"]
   env_config            = {env=var.env_config.env, tags=var.env_config.tags, vpc_id=data.aws_vpc.main.id, zone_id=module.local_zone.zone_id }
   is_prod               = substr(var.env_config.env, 0, 4) == "prod" 
-  victor_ops_url        = "https://alert.victorops.com/integrations/cloudwatch/20131130/alert/55e5f15e-cd33-4790-919e-1ce13a2d8299/CCS"
+  victor_ops_url        = var.victor_ops_url
   enable_victor_ops     = local.is_prod # only wake people up for prod alarms
 
   db_sgs = [

--- a/ops/terraform/modules/stateful/variables.tf
+++ b/ops/terraform/modules/stateful/variables.tf
@@ -17,3 +17,8 @@ variable "env_config" {
   description       = "All high-level info for the whole vpc"
   type              = object({env=string, tags=map(string)})
 }
+
+variable "victor_ops_url" {
+  description       = "VictorOps CloudWatch integration URL"
+  type              = string
+}


### PR DESCRIPTION
This requires the VictorOps URL to be passed as a local variable (ideally pulled from a secret store in the future) rather than hardcoded.  After this PR is deployed I will roll the new VictorOps URL out in all environments.