### PR TITLE
BLUEBUTTON-1625: Add DPC metrics

### DIFF
--- a/ops/terraform/modules/resources/bfd_server_metrics/main.tf
+++ b/ops/terraform/modules/resources/bfd_server_metrics/main.tf
@@ -7,14 +7,8 @@ locals {
     "all": "*",
     "metadata": "*/metadata*",
     "coverageAll": "*/Coverage*",
-    "coverageByPatientId": "*/Coverage*beneficiary=*",
     "patientAll": "*/Patient*",
-    "patientById": "*/Patient*_id=*",
-    "patientByIdentifier": "*/Patient*identifier=*hicnHash*",
     "eobAll": "*/ExplanationOfBenefit*",
-    "eobByPatientId": "*/ExplanationOfBenefit*patient=*",
-    "eobByPaged": "*/ExplanationOfBenefit*_count=*",
-    "eobByType":  "*/ExplanationOfBenefit*type=*",
   }
 }
 

--- a/ops/terraform/modules/stateless/main.tf
+++ b/ops/terraform/modules/stateless/main.tf
@@ -295,6 +295,17 @@ module "bfd_server_metrics_mct" {
   }
 }
 
+module "bfd_server_metrics_dpc" {
+  source = "../resources/bfd_server_metrics"
+
+  env    = var.env_config.env
+
+  metric_config = {
+    partner_name  = "dpc"
+    partner_regex = "*dpc*"
+  }
+}
+
 # FHIR server alarms, partner specific
 #
 module "bfd_server_alarm_all_500s" {


### PR DESCRIPTION
This adds request metrics tracking for DPC requests.  It also removes metrics tracking for specific types of searches due to CloudWatch limitations.  Ultimately this shouldn't be a huge issue due to the fact that 1) most partners only send one type of parameterized request per endpoint 2) CloudWatch lacks the charting ability to make good use of endpoint parameter breakdown metrics