### PR TITLE
BLUEBUTTON-1579: Increase instance size to c5.xlarge

### DIFF
--- a/ops/terraform/modules/mgmt_stateless/variables.tf
+++ b/ops/terraform/modules/mgmt_stateless/variables.tf
@@ -21,7 +21,7 @@ variable "jenkins_key_name" {
 variable "instance_size" {
   type              = string
   description       = "The EC2 instance size to use"
-  default           = "m5.xlarge"
+  default           = "c5.xlarge"
 }
 
 variable "mgmt_network_ci_cidrs" {

--- a/ops/terraform/modules/stateless/main.tf
+++ b/ops/terraform/modules/stateless/main.tf
@@ -175,7 +175,7 @@ module "fhir_lb" {
 
   ingress = {
     description   = "From VPC peerings, the MGMT VPC, and self"
-    port          = 443
+    port          = 7443
     cidr_blocks   = concat(data.aws_vpc_peering_connection.peers[*].peer_cidr_block, [data.aws_vpc.mgmt.cidr_block, data.aws_vpc.main.cidr_block])
   }
 


### PR DESCRIPTION
This PR bumps the jenkins instance size to the c5 class to test performance gains during app builds. 