### PR TITLE
BLUEBUTTON-1579: Jenkins, revert back to m5 instance

### DIFF
--- a/ops/terraform/modules/mgmt_stateless/variables.tf
+++ b/ops/terraform/modules/mgmt_stateless/variables.tf
@@ -21,7 +21,7 @@ variable "jenkins_key_name" {
 variable "instance_size" {
   type              = string
   description       = "The EC2 instance size to use"
-  default           = "c5.xlarge"
+  default           = "m5.xlarge"
 }
 
 variable "mgmt_network_ci_cidrs" {


### PR DESCRIPTION
We saw no significant improvements with the change in instance size when building apps. 