### PR TITLE
BLUEBUTTON-1595: 1-800 medicare opt out data bucket

### DIFF
--- a/ops/terraform/env/prod-sbx/stateful/main.tf
+++ b/ops/terraform/env/prod-sbx/stateful/main.tf
@@ -29,4 +29,11 @@ module "stateful" {
   }
 
   victor_ops_url      = var.victor_ops_url
+
+  medicare_opt_out_config = {
+    # TODO: add read roles for DPC
+    read_roles        = []
+    write_roles       = ["arn:aws:iam::755619740999:role/bcda-dev-nfs-instance", "arn:aws:iam::755619740999:role/bcda-test-nfs-instance"]
+    admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9", "arn:aws:iam::577373831711:user/BYSK"]
+  }
 }

--- a/ops/terraform/env/prod-sbx/stateful/main.tf
+++ b/ops/terraform/env/prod-sbx/stateful/main.tf
@@ -31,8 +31,7 @@ module "stateful" {
   victor_ops_url      = var.victor_ops_url
 
   medicare_opt_out_config = {
-    # TODO: add read roles for DPC
-    read_roles        = []
+    read_roles        = ["arn:aws:iam::755619740999:role/dpc-dev-consent-execution-role"]
     write_roles       = ["arn:aws:iam::755619740999:role/bcda-dev-nfs-instance", "arn:aws:iam::755619740999:role/bcda-test-nfs-instance"]
     admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9", "arn:aws:iam::577373831711:user/BYSK"]
   }

--- a/ops/terraform/env/prod/stateful/main.tf
+++ b/ops/terraform/env/prod/stateful/main.tf
@@ -38,4 +38,11 @@ module "stateful" {
   }
 
   victor_ops_url      = var.victor_ops_url
+
+  medicare_opt_out_config = {
+    # TODO: add read roles for DPC
+    read_roles        = []
+    write_roles       = ["arn:aws:iam::755619740999:role/bcda-prod-nfs-instance"]
+    admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9", "arn:aws:iam::577373831711:user/BYSK"]
+  }
 }

--- a/ops/terraform/env/test/stateful/main.tf
+++ b/ops/terraform/env/test/stateful/main.tf
@@ -38,4 +38,10 @@ module "stateful" {
   }
 
   victor_ops_url      = var.victor_ops_url
+
+  medicare_opt_out_config = {
+    read_roles        = ["arn:aws:iam::AccountA:role/AccountAReader", "arn:aws:iam::AccountB:role/AccountBReader"]
+    write_roles       = ["arn:aws:iam::AccountA:role/AccountAWriter", "arn:aws:iam::AccountB:role/AccountBWriter"]
+    admin_users       = ["arn:aws:iam::577373831711:user/DS7H"]
+  }
 }

--- a/ops/terraform/env/test/stateful/main.tf
+++ b/ops/terraform/env/test/stateful/main.tf
@@ -40,8 +40,9 @@ module "stateful" {
   victor_ops_url      = var.victor_ops_url
 
   medicare_opt_out_config = {
-    read_roles        = ["arn:aws:iam::577373831711:role/bfd-test-fhir-role", "arn:aws:iam::577373831711:role/bfd-test-data-migration-role"]
-    write_roles       = ["arn:aws:iam::577373831711:role/bfd-test-bfd_pipeline-role"]
+    # TODO: add read roles for DPC
+    read_roles        = []
+    write_roles       = ["arn:aws:iam::755619740999:role/bcda-dev-nfs-instance", "arn:aws:iam::755619740999:role/bcda-test-nfs-instance"]
     admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9", "arn:aws:iam::577373831711:user/BYSK"]
   }
 }

--- a/ops/terraform/env/test/stateful/main.tf
+++ b/ops/terraform/env/test/stateful/main.tf
@@ -42,6 +42,6 @@ module "stateful" {
   medicare_opt_out_config = {
     read_roles        = ["arn:aws:iam::577373831711:role/bfd-test-fhir-role", "arn:aws:iam::577373831711:role/bfd-test-data-migration-role"]
     write_roles       = ["arn:aws:iam::577373831711:role/bfd-test-bfd_pipeline-role"]
-    admin_users       = ["arn:aws:iam::577373831711:user/DS7H"]
+    admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9", "arn:aws:iam::577373831711:user/BYSK"]
   }
 }

--- a/ops/terraform/env/test/stateful/main.tf
+++ b/ops/terraform/env/test/stateful/main.tf
@@ -40,8 +40,8 @@ module "stateful" {
   victor_ops_url      = var.victor_ops_url
 
   medicare_opt_out_config = {
-    read_roles        = ["arn:aws:iam::AccountA:role/AccountAReader", "arn:aws:iam::AccountB:role/AccountBReader"]
-    write_roles       = ["arn:aws:iam::AccountA:role/AccountAWriter", "arn:aws:iam::AccountB:role/AccountBWriter"]
+    read_roles        = ["arn:aws:iam::577373831711:role/bfd-test-fhir-role", "arn:aws:iam::577373831711:role/bfd-test-data-migration-role"]
+    write_roles       = ["arn:aws:iam::577373831711:role/bfd-test-bfd_pipeline-role"]
     admin_users       = ["arn:aws:iam::577373831711:user/DS7H"]
   }
 }

--- a/ops/terraform/env/test/stateful/main.tf
+++ b/ops/terraform/env/test/stateful/main.tf
@@ -40,8 +40,7 @@ module "stateful" {
   victor_ops_url      = var.victor_ops_url
 
   medicare_opt_out_config = {
-    # TODO: add read roles for DPC
-    read_roles        = []
+    read_roles        = ["arn:aws:iam::755619740999:role/dpc-dev-consent-execution-role"]
     write_roles       = ["arn:aws:iam::755619740999:role/bcda-dev-nfs-instance", "arn:aws:iam::755619740999:role/bcda-test-nfs-instance"]
     admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9", "arn:aws:iam::577373831711:user/BYSK"]
   }

--- a/ops/terraform/modules/resources/s3_pii/main.tf
+++ b/ops/terraform/modules/resources/s3_pii/main.tf
@@ -8,21 +8,6 @@ locals {
 
 data "aws_caller_identity" "current" {}
 
-# data "aws_iam_user" "pii_bucket_admin_users" {
-#   count     = length(var.pii_bucket_config.admin_users)
-#   user_name = var.pii_bucket_config.admin_users[count.index]
-# }
-
-# data "aws_iam_role" "pii_bucket_read_roles" {
-#   count = length(var.pii_bucket_config.read_roles)
-#   name  = var.pii_bucket_config.read_roles[count.index]
-# }
-
-# data "aws_iam_role" "pii_bucket_write_roles" {
-#   count = length(var.pii_bucket_config.write_roles)
-#   name  = var.pii_bucket_config.write_roles[count.index]
-# }
-
 resource "aws_kms_key" "pii_bucket_key" {
   description             = "bfd-${var.env_config.env}-${var.pii_bucket_config.name}-cmk"
   deletion_window_in_days = 10

--- a/ops/terraform/modules/resources/s3_pii/main.tf
+++ b/ops/terraform/modules/resources/s3_pii/main.tf
@@ -16,8 +16,8 @@ resource "aws_kms_key" "pii_bucket_key" {
   policy = templatefile("${path.module}/templates/kms-policy.json", {
     env    = var.env_config.env
     name   = var.pii_bucket_config.name
-    admins = formatlist("%s", var.pii_bucket_config.admin_users)
-    roles  = formatlist("%s", concat(var.pii_bucket_config.read_roles, var.pii_bucket_config.write_roles))
+    admins = formatlist("%s", var.pii_bucket_config.admin_arns)
+    roles  = formatlist("%s", concat(var.pii_bucket_config.read_arns, var.pii_bucket_config.write_arns))
     root   = data.aws_caller_identity.current.account_id
   })
 }
@@ -81,9 +81,9 @@ resource "aws_s3_bucket_policy" "pii_bucket_policy" {
     env         = var.env_config.env
     bucket_id   = aws_s3_bucket.pii_bucket.id
     bucket_name = var.pii_bucket_config.name
-    admins      = formatlist("%s", var.pii_bucket_config.admin_users)
-    readers     = formatlist("%s", var.pii_bucket_config.read_roles)
-    writers     = formatlist("%s", var.pii_bucket_config.write_roles)
+    admins      = formatlist("%s", var.pii_bucket_config.admin_arns)
+    readers     = formatlist("%s", var.pii_bucket_config.read_arns)
+    writers     = formatlist("%s", var.pii_bucket_config.write_arns)
     root        = data.aws_caller_identity.current.account_id
   })
 }

--- a/ops/terraform/modules/resources/s3_pii/main.tf
+++ b/ops/terraform/modules/resources/s3_pii/main.tf
@@ -1,0 +1,104 @@
+# Setup an S3 bucket intended for PII
+#
+
+locals {
+  tags    = merge({Layer="data", role=var.pii_bucket_config.name}, var.env_config.tags)
+  is_prod = substr(var.env_config.env, 0, 4) == "prod" 
+}
+
+data "aws_caller_identity" "current" {}
+
+# data "aws_iam_user" "pii_bucket_admin_users" {
+#   count     = length(var.pii_bucket_config.admin_users)
+#   user_name = var.pii_bucket_config.admin_users[count.index]
+# }
+
+# data "aws_iam_role" "pii_bucket_read_roles" {
+#   count = length(var.pii_bucket_config.read_roles)
+#   name  = var.pii_bucket_config.read_roles[count.index]
+# }
+
+# data "aws_iam_role" "pii_bucket_write_roles" {
+#   count = length(var.pii_bucket_config.write_roles)
+#   name  = var.pii_bucket_config.write_roles[count.index]
+# }
+
+resource "aws_kms_key" "pii_bucket_key" {
+  description             = "bfd-${var.env_config.env}-${var.pii_bucket_config.name}-cmk"
+  deletion_window_in_days = 10
+  enable_key_rotation     = true
+
+  policy = templatefile("${path.module}/templates/kms-policy.json", {
+    env    = var.env_config.env
+    name   = var.pii_bucket_config.name
+    admins = formatlist("%s", var.pii_bucket_config.admin_users)
+    roles  = formatlist("%s", concat(var.pii_bucket_config.read_roles, var.pii_bucket_config.write_roles))
+    root   = data.aws_caller_identity.current.account_id
+  })
+}
+
+resource "aws_kms_alias" "pii_bucket_key_alias" {
+  name          = "alias/bfd-${var.env_config.env}-${var.pii_bucket_config.name}-cmk"
+  target_key_id = aws_kms_key.pii_bucket_key.id
+}
+
+resource "aws_s3_bucket" "pii_bucket" {
+  bucket = "bfd-${var.env_config.env}-${var.pii_bucket_config.name}-${data.aws_caller_identity.current.account_id}"
+  acl    = "private"
+  tags   = local.tags
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm     = "aws:kms"
+        kms_master_key_id = aws_kms_key.pii_bucket_key.id
+      }
+    }
+  }
+
+  logging {
+    target_bucket = var.pii_bucket_config.log_bucket
+    target_prefix = "${var.pii_bucket_config.name}_s3_access_logs"
+  }
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    id      = "bfd-${var.env_config.env}-${var.pii_bucket_config.name}-versioning-rule"
+    enabled = true
+
+    noncurrent_version_transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+
+    noncurrent_version_expiration {
+      days = 60
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "pii_bucket_restrictions" {
+  bucket = aws_s3_bucket.pii_bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_policy" "pii_bucket_policy" {
+  bucket = aws_s3_bucket.pii_bucket.id
+
+  policy = templatefile("${path.module}/templates/bucket-policy.json", {
+    env         = var.env_config.env
+    bucket_id   = aws_s3_bucket.pii_bucket.id
+    bucket_name = var.pii_bucket_config.name
+    admins      = formatlist("%s", var.pii_bucket_config.admin_users)
+    readers     = formatlist("%s", var.pii_bucket_config.read_roles)
+    writers     = formatlist("%s", var.pii_bucket_config.write_roles)
+    root        = data.aws_caller_identity.current.account_id
+  })
+}

--- a/ops/terraform/modules/resources/s3_pii/templates/bucket-policy.json
+++ b/ops/terraform/modules/resources/s3_pii/templates/bucket-policy.json
@@ -32,7 +32,7 @@
       "Action": [
         "s3:GetObject"
       ],
-      "Resource": "arn:aws:s3:::${bucket_id}/*",
+      "Resource": "arn:aws:s3:::${bucket_id}/*"
     },
     {
       "Sid": "BFDPIIS3WriteBucket",
@@ -89,9 +89,9 @@
       "Action": "s3:PutObject",
       "Resource": "arn:aws:s3:::${bucket_id}/*",
       "Condition": {
-          "StringNotEquals": {
-              "s3:x-amz-server-side-encryption": "aws:kms"
-          }
+        "StringNotEquals": {
+            "s3:x-amz-server-side-encryption": "aws:kms"
+        }
       }
     }
   ]

--- a/ops/terraform/modules/resources/s3_pii/templates/bucket-policy.json
+++ b/ops/terraform/modules/resources/s3_pii/templates/bucket-policy.json
@@ -1,0 +1,98 @@
+{
+  "Version": "2012-10-17",
+  "Id": "bfd-${env}-${bucket_name}-s3-policy",
+  "Statement": [
+    {
+      "Sid": "BFDPIIS3ListBucket",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": [
+          %{ for reader in readers ~}"${reader}",%{ endfor ~}
+          %{ for writer in writers ~}"${writer}",%{ endfor ~}
+          %{ for admin in admins ~}"${admin}",%{ endfor ~}
+          "${root}"
+        ]
+      },
+      "Action": [
+        "s3:ListBucket"
+      ],
+      "Resource": "arn:aws:s3:::${bucket_id}"
+    },
+    {
+      "Sid": "BFDPIIS3ReadBucket",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": [
+          %{ for reader in readers ~}"${reader}",%{ endfor ~}
+          %{ for writer in writers ~}"${writer}",%{ endfor ~}
+          %{ for admin in admins ~}"${admin}",%{ endfor ~}
+          "${root}"
+        ]
+      },
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Resource": "arn:aws:s3:::${bucket_id}/*",
+    },
+    {
+      "Sid": "BFDPIIS3WriteBucket",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": [
+          %{ for writer in writers ~}"${writer}",%{ endfor ~}
+          %{ for admin in admins ~}"${admin}",%{ endfor ~}
+          "${root}"
+        ]
+      },
+      "Action": [
+        "s3:PutObject",
+        "s3:DeleteObject"
+      ],
+      "Resource": "arn:aws:s3:::${bucket_id}/*"
+    },
+    {
+      "Sid": "BFDPIIS3AdminBucket",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": [
+          %{ for admin in admins ~}"${admin}",%{ endfor ~}
+          "${root}"
+        ]
+      },
+      "Action": "s3:*",
+      "Resource": [
+        "arn:aws:s3:::${bucket_id}",
+        "arn:aws:s3:::${bucket_id}/*"
+      ]
+    },
+    {
+      "Sid": "BFDPIIS3DenyNonExplicitUsers",
+      "Effect": "Deny",
+      "NotPrincipal": {
+        "AWS": [
+          %{ for reader in readers ~}"${reader}",%{ endfor ~}
+          %{ for writer in writers ~}"${writer}",%{ endfor ~}
+          %{ for admin in admins ~}"${admin}",%{ endfor ~}
+          "${root}"
+        ]
+      },
+      "Action": "s3:*",
+      "Resource": [
+        "arn:aws:s3:::${bucket_id}/*",
+        "arn:aws:s3:::${bucket_id}"
+      ]
+    },
+    {
+      "Sid": "BFDPIIS3DenyUnencrypted",
+      "Effect": "Deny",
+      "Principal": "*",
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::${bucket_id}/*",
+      "Condition": {
+          "StringNotEquals": {
+              "s3:x-amz-server-side-encryption": "aws:kms"
+          }
+      }
+    }
+  ]
+}

--- a/ops/terraform/modules/resources/s3_pii/templates/kms-policy.json
+++ b/ops/terraform/modules/resources/s3_pii/templates/kms-policy.json
@@ -1,0 +1,37 @@
+{
+  "Version": "2012-10-17",
+  "Id": "bfd-${env}-${name}-kms-policy",
+  "Statement": [
+    {
+      "Sid": "Admin Permissions",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": [
+          %{ for admin in admins ~}"${admin}",%{ endfor ~}
+          "${root}"
+        ]
+      },
+      "Action": [
+        "kms:*"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "Role Permissions",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": [
+          %{ for idx, role in roles ~}"${role}"%{ if idx + 1 != length(roles) ~},%{ endif ~}%{ endfor ~}
+        ]
+      },
+      "Action": [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/ops/terraform/modules/resources/s3_pii/variables.tf
+++ b/ops/terraform/modules/resources/s3_pii/variables.tf
@@ -1,0 +1,15 @@
+variable "env_config" {
+  description = "All high-level info for the whole vpc"
+  type        = object({env=string, tags=map(string), vpc_id=string, zone_id=string})
+}
+
+variable "pii_bucket_config" {
+  description = "Config for PII S3 bucket"
+  type        = object({
+    name        = string
+    log_bucket  = string
+    read_roles  = list(string)
+    write_roles = list(string)
+    admin_users = list(string)
+  })
+}

--- a/ops/terraform/modules/resources/s3_pii/variables.tf
+++ b/ops/terraform/modules/resources/s3_pii/variables.tf
@@ -6,10 +6,10 @@ variable "env_config" {
 variable "pii_bucket_config" {
   description = "Config for PII S3 bucket"
   type        = object({
-    name        = string
-    log_bucket  = string
-    read_roles  = list(string)
-    write_roles = list(string)
-    admin_users = list(string)
+    name       = string
+    log_bucket = string
+    read_arns  = list(string)
+    write_arns = list(string)
+    admin_arns = list(string)
   })
 }

--- a/ops/terraform/modules/stateful/main.tf
+++ b/ops/terraform/modules/stateful/main.tf
@@ -502,6 +502,21 @@ resource "aws_iam_user_policy_attachment" "etl_rw_s3" {
   policy_arn = aws_iam_policy.etl_rw_s3.arn
 }
 
+# S3 bucket, policy, and KMS key for medicare opt out data
+#
+module "medicare_opt_out" {
+  source            = "../resources/s3_pii"
+  env_config        = local.env_config
+
+  pii_bucket_config = {
+    name            = "medicare-opt-out"
+    log_bucket      = module.logs.id
+    read_roles      = var.medicare_opt_out_config.read_roles
+    write_roles     = var.medicare_opt_out_config.write_roles
+    admin_users     = var.medicare_opt_out_config.admin_users
+  }
+}
+
 # CloudWatch Log Groups
 #
 resource "aws_cloudwatch_log_group" "var_log_messages" {

--- a/ops/terraform/modules/stateful/variables.tf
+++ b/ops/terraform/modules/stateful/variables.tf
@@ -22,3 +22,8 @@ variable "victor_ops_url" {
   description       = "VictorOps CloudWatch integration URL"
   type              = string
 }
+
+variable "medicare_opt_out_config" {
+  description       = "Config for medicare opt out S3 bucket"
+  type              = object({read_roles = list(string), write_roles = list(string), admin_users = list(string)})
+}


### PR DESCRIPTION
Adapted from the great work by @rnagle, this creates a PII S3 bucket module with fined grained access for readers, writers, and admins: https://github.com/CMSgov/dpc-ops/tree/master/terraform/modules/resources/s3-pii

One subject for debate is the lifecycle rule.  Should this be configurable, and should it operate on more than just object versions?

Also **do not merge** until this PR has been updated with the appropriate roles from BCDA and DPC, and test roles have been removed.