### PR TITLE
BLUEBUTTON-1679 Remove hicn-hash identifier from Patient Resource

### DIFF
--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/BeneficiaryTransformer.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/BeneficiaryTransformer.java
@@ -55,10 +55,6 @@ final class BeneficiaryTransformer {
     patient.addIdentifier(
         TransformerUtils.createIdentifier(
             CcwCodebookVariable.BENE_ID, beneficiary.getBeneficiaryId()));
-    patient
-        .addIdentifier()
-        .setSystem(TransformerConstants.CODING_BBAPI_BENE_HICN_HASH)
-        .setValue(beneficiary.getHicn());
 
     if (includeIdentifiersMode == IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS) {
       Extension currentIdentifier =

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/BeneficiaryTransformerTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/BeneficiaryTransformerTest.java
@@ -34,8 +34,17 @@ public final class BeneficiaryTransformerTest {
     Patient patient =
         BeneficiaryTransformer.transform(
             new MetricRegistry(), beneficiary, IncludeIdentifiersMode.OMIT_HICNS_AND_MBIS);
+
     assertMatches(beneficiary, patient);
-    Assert.assertEquals(2, patient.getIdentifier().size());
+
+    // Verify patient has only one identifier.
+    Assert.assertEquals(1, patient.getIdentifier().size());
+
+    // Verify the only identifier is BENE_ID and value.
+    Assert.assertEquals(
+        patient.getIdentifier().get(0).getSystem(),
+        TransformerUtils.calculateVariableReferenceUrl(CcwCodebookVariable.BENE_ID));
+    Assert.assertEquals(patient.getIdentifier().get(0).getValue(), "567834");
   }
 
   /**
@@ -51,8 +60,42 @@ public final class BeneficiaryTransformerTest {
     Patient patient =
         BeneficiaryTransformer.transform(
             new MetricRegistry(), beneficiary, IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS);
+
     assertMatches(beneficiary, patient);
-    Assert.assertEquals(7, patient.getIdentifier().size());
+
+    // Verify patient has 6 identifiers.
+    Assert.assertEquals(6, patient.getIdentifier().size());
+
+    // Verify patient identifiers and values match.
+    Assert.assertEquals(
+        patient.getIdentifier().get(0).getSystem(),
+        TransformerUtils.calculateVariableReferenceUrl(CcwCodebookVariable.BENE_ID));
+    Assert.assertEquals(patient.getIdentifier().get(0).getValue(), "567834");
+
+    Assert.assertEquals(
+        patient.getIdentifier().get(1).getSystem(),
+        TransformerConstants.CODING_BBAPI_BENE_HICN_UNHASHED);
+    Assert.assertEquals(patient.getIdentifier().get(1).getValue(), "543217066U");
+
+    Assert.assertEquals(
+        patient.getIdentifier().get(2).getSystem(),
+        TransformerConstants.CODING_BBAPI_MEDICARE_BENEFICIARY_ID_UNHASHED);
+    Assert.assertEquals(patient.getIdentifier().get(2).getValue(), "3456789");
+
+    Assert.assertEquals(
+        patient.getIdentifier().get(3).getSystem(),
+        TransformerConstants.CODING_BBAPI_BENE_HICN_UNHASHED);
+    Assert.assertEquals(patient.getIdentifier().get(3).getValue(), "543217066T");
+
+    Assert.assertEquals(
+        patient.getIdentifier().get(4).getSystem(),
+        TransformerConstants.CODING_BBAPI_BENE_HICN_UNHASHED);
+    Assert.assertEquals(patient.getIdentifier().get(4).getValue(), "543217066Z");
+
+    Assert.assertEquals(
+        patient.getIdentifier().get(5).getSystem(),
+        TransformerConstants.CODING_BBAPI_MEDICARE_BENEFICIARY_ID_UNHASHED);
+    Assert.assertEquals(patient.getIdentifier().get(5).getValue(), "9AB2WW3GR44");
   }
 
   /**

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/BeneficiaryTransformerTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/BeneficiaryTransformerTest.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender;
+import org.hl7.fhir.dstu3.model.Identifier;
 import org.hl7.fhir.dstu3.model.Patient;
 import org.junit.Assert;
 import org.junit.Test;
@@ -55,6 +56,7 @@ public final class BeneficiaryTransformerTest {
    */
   @Test
   public void transformSampleARecordWithIdentifiers() {
+
     Beneficiary beneficiary = loadSampleABeneficiary();
 
     Patient patient =
@@ -67,35 +69,45 @@ public final class BeneficiaryTransformerTest {
     Assert.assertEquals(6, patient.getIdentifier().size());
 
     // Verify patient identifiers and values match.
-    Assert.assertEquals(
-        patient.getIdentifier().get(0).getSystem(),
-        TransformerUtils.calculateVariableReferenceUrl(CcwCodebookVariable.BENE_ID));
-    Assert.assertEquals(patient.getIdentifier().get(0).getValue(), "567834");
+    assertValuesInPatientIdentifiers(
+        patient,
+        TransformerUtils.calculateVariableReferenceUrl(CcwCodebookVariable.BENE_ID),
+        "567834");
 
-    Assert.assertEquals(
-        patient.getIdentifier().get(1).getSystem(),
-        TransformerConstants.CODING_BBAPI_BENE_HICN_UNHASHED);
-    Assert.assertEquals(patient.getIdentifier().get(1).getValue(), "543217066U");
+    assertValuesInPatientIdentifiers(
+        patient, TransformerConstants.CODING_BBAPI_BENE_HICN_UNHASHED, "543217066U");
 
-    Assert.assertEquals(
-        patient.getIdentifier().get(2).getSystem(),
-        TransformerConstants.CODING_BBAPI_MEDICARE_BENEFICIARY_ID_UNHASHED);
-    Assert.assertEquals(patient.getIdentifier().get(2).getValue(), "3456789");
+    assertValuesInPatientIdentifiers(
+        patient, TransformerConstants.CODING_BBAPI_MEDICARE_BENEFICIARY_ID_UNHASHED, "3456789");
 
-    Assert.assertEquals(
-        patient.getIdentifier().get(3).getSystem(),
-        TransformerConstants.CODING_BBAPI_BENE_HICN_UNHASHED);
-    Assert.assertEquals(patient.getIdentifier().get(3).getValue(), "543217066T");
+    assertValuesInPatientIdentifiers(
+        patient, TransformerConstants.CODING_BBAPI_BENE_HICN_UNHASHED, "543217066T");
 
-    Assert.assertEquals(
-        patient.getIdentifier().get(4).getSystem(),
-        TransformerConstants.CODING_BBAPI_BENE_HICN_UNHASHED);
-    Assert.assertEquals(patient.getIdentifier().get(4).getValue(), "543217066Z");
+    assertValuesInPatientIdentifiers(
+        patient, TransformerConstants.CODING_BBAPI_BENE_HICN_UNHASHED, "543217066Z");
 
-    Assert.assertEquals(
-        patient.getIdentifier().get(5).getSystem(),
-        TransformerConstants.CODING_BBAPI_MEDICARE_BENEFICIARY_ID_UNHASHED);
-    Assert.assertEquals(patient.getIdentifier().get(5).getValue(), "9AB2WW3GR44");
+    assertValuesInPatientIdentifiers(
+        patient, TransformerConstants.CODING_BBAPI_MEDICARE_BENEFICIARY_ID_UNHASHED, "9AB2WW3GR44");
+  }
+
+  /**
+   * Verifies that the {@link Patient} identifiers contain expected values.
+   *
+   * @param Patient {@link Patient} containing identifiers
+   * @param identifierSystem value to be matched
+   * @param identifierValue value to be matched
+   */
+  private static void assertValuesInPatientIdentifiers(
+      Patient patient, String identifierSystem, String identifierValue) {
+    boolean identifierFound = false;
+
+    for (Identifier temp : patient.getIdentifier()) {
+      if (identifierSystem.equals(temp.getSystem()) && identifierValue.equals(temp.getValue())) {
+        identifierFound = true;
+        break;
+      }
+    }
+    Assert.assertEquals(identifierFound, true);
   }
 
   /**

--- a/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/patientByIdentifier.json
+++ b/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/patientByIdentifier.json
@@ -110,9 +110,6 @@
         }
       } ],
       "identifier" : [ {
-        "system" : "https://bluebutton.cms.gov/resources/identifier/hicn-hash",
-        "value" : "99f6cc85e95c4b2cec5382600478482cceadb7534d4c3f0a4f2e55d33428c169"
-      }, {
         "system" : "https://bluebutton.cms.gov/resources/variables/bene_id",
         "value" : "567834"
       } ],

--- a/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/patientByIdentifierWithIncludeIdentifiers.json
+++ b/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/patientByIdentifierWithIncludeIdentifiers.json
@@ -165,9 +165,6 @@
         "system" : "http://hl7.org/fhir/sid/us-medicare",
         "value" : "543217066Z"
       }, {
-        "system" : "https://bluebutton.cms.gov/resources/identifier/hicn-hash",
-        "value" : "99f6cc85e95c4b2cec5382600478482cceadb7534d4c3f0a4f2e55d33428c169"
-      }, {
         "system" : "https://bluebutton.cms.gov/resources/variables/bene_id",
         "value" : "567834"
       } ],

--- a/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/patientRead.json
+++ b/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/patientRead.json
@@ -97,9 +97,6 @@
     }
   } ],
   "identifier" : [ {
-    "system" : "https://bluebutton.cms.gov/resources/identifier/hicn-hash",
-    "value" : "99f6cc85e95c4b2cec5382600478482cceadb7534d4c3f0a4f2e55d33428c169"
-  }, {
     "system" : "https://bluebutton.cms.gov/resources/variables/bene_id",
     "value" : "567834"
   } ],

--- a/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/patientReadWithIncludeIdentifiers.json
+++ b/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/patientReadWithIncludeIdentifiers.json
@@ -152,9 +152,6 @@
     "system" : "http://hl7.org/fhir/sid/us-medicare",
     "value" : "543217066Z"
   }, {
-    "system" : "https://bluebutton.cms.gov/resources/identifier/hicn-hash",
-    "value" : "99f6cc85e95c4b2cec5382600478482cceadb7534d4c3f0a4f2e55d33428c169"
-  }, {
     "system" : "https://bluebutton.cms.gov/resources/variables/bene_id",
     "value" : "567834"
   } ],

--- a/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/patientSearchById.json
+++ b/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/patientSearchById.json
@@ -110,9 +110,6 @@
         }
       } ],
       "identifier" : [ {
-        "system" : "https://bluebutton.cms.gov/resources/identifier/hicn-hash",
-        "value" : "99f6cc85e95c4b2cec5382600478482cceadb7534d4c3f0a4f2e55d33428c169"
-      }, {
         "system" : "https://bluebutton.cms.gov/resources/variables/bene_id",
         "value" : "567834"
       } ],

--- a/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/patientSearchByIdWithIncludeIdentifiers.json
+++ b/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/patientSearchByIdWithIncludeIdentifiers.json
@@ -165,9 +165,6 @@
         "system" : "http://hl7.org/fhir/sid/us-medicare",
         "value" : "543217066Z"
       }, {
-        "system" : "https://bluebutton.cms.gov/resources/identifier/hicn-hash",
-        "value" : "99f6cc85e95c4b2cec5382600478482cceadb7534d4c3f0a4f2e55d33428c169"
-      }, {
         "system" : "https://bluebutton.cms.gov/resources/variables/bene_id",
         "value" : "567834"
       } ],

--- a/apps/bfd-server/dev/api-changelog.md
+++ b/apps/bfd-server/dev/api-changelog.md
@@ -1,5 +1,17 @@
 # API Changelog
 
+## BLUEBUTTON-1679: Hashed HICN needs to be removed from Patient Resource
+
+The Hashed HICN identifier is removed from the Patient resource response. This is to ensure that we are in compliance for the HICN rule by January 1st. This is to leave no traces of the HICN-hash in any external facing data requests to BFD. 
+
+The following is an example of the identifier that is removed from the response:
+
+    <identifier>
+       <system value="https://bluebutton.cms.gov/resources/identifier/hicn-hash"></system>
+       <value value="96228a57f37efea543f4f370f96f1dbf01c3e3129041dba3ea4367545507c6e7"></value>
+    </identifier>
+
+
 ## BLUEBUTTON-1191: Allow Filtering of EOB Searches by type
 
 A new optional query parameter has been added to `ExplanationOfBenefit` searches that will filter the returned results by `type`.


### PR DESCRIPTION
<!--

--- PR Hygiene Checklist ---

1. Make sure the changeset can be reviewed, keep it's scope and size succinct 
2. Make sure your branch is from your fork and has a meaningful name
3. Update the PR title: `BLUEBUTTON-99999 Add Awesomeness`
4. Edit the text below - do not leave placeholders in the text.
4.1. Remove sections that you don't feel apply
5. Add any other details that will be helpful for the reviewers: details description, screenshots, etc
6. Request a review from someone/multiple someones
7. <optional> Review your changes yourself and write up any comments / concerns as if you were reviewing someone else's code.
-->

### Change Details

<!-- Add detailed discussion of changes here: -->
Summary:

This is to remove the hashed HICN identifier from the patient resource response.

The following tasks were performed:
- Removed the TransformerConstants.CODING_BBAPI_BENE_HICN_HASH identifier from the BeneficiaryTransformer .  The BeneficiaryTransformer is used by the PatientResourceProvider for the FHIR response. 
- Testing of the Patient resource using CURL is working as expected in the local docker setup. 
- Reviewed the code base for other areas that this change might affect. Not seeing BeneficiaryTransformer utilized anywhere besides PatientResourceProvider and in related tests.
- Updated the unit tests in the BeneficiaryTransformerTest class. This included transformSampleARecord() and transformSampleARecordWithIdentifiers() methods. In addition to validating the count/size for the number of identifiers, the values are also validated.
- Updated the IT tests. These are performed by the EndpointJsonResponseComparatorIT class. This utilizes JSON files under the apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses path. These files are used to validate related end-point responses.  The hicn-hash identifier was removed from 6 of these files.
- ALL TESTS ARE PASSING IN LOCAL DEV!
- Added a change entry to the apps/bfd-server/dev/api-changelog.md
<!-- This is likely a summary, or the complete contents, of your commit messages -->

### Acceptance Validation

- That the Patient resource responses DO NOT contain the hicn-hash identifier:  "https://bluebutton.cms.gov/resources/identifier/hicn-hash"

<!-- What should reviewers look for to determine completeness -->

<!-- Insert screenshots if applicable (drag images here) -->

### Feedback Requested

<!-- What type of feedback you want from your reviewers? -->

### External References

<!-- For example: replace xxx with the JIRA ticket number: -->

- [BLUEBUTTON-1679](https://jira.cms.gov/browse/BLUEBUTTON-1679)

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] altered security controls

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications
<!-- Use this to indicate you're unsure how this change may impact system security and would like to solicit the team's feedback. Optionally, provide background information regarding your questions and concerns. -->