### PR TITLE
BLUEBUTTON-1516: DB Migration for the mbiHash columns

### DIFF
--- a/apps/bfd-model/bfd-model-rif/src/main/resources/db/migration/V21__Add_MBI_hash.sql
+++ b/apps/bfd-model/bfd-model-rif/src/main/resources/db/migration/V21__Add_MBI_hash.sql
@@ -1,0 +1,9 @@
+/*
+ * The column doesn't have a default value to avoid updating the column on migration. The pipeline server
+ * will populate the column as new beneficaries are added or existing beneficaries are updated. 
+ */
+
+alter table "Beneficiaries" add column "mbiHash" varchar(64);
+
+alter table "BeneficiariesHistory" add column "mbiHash" varchar(64);
+

--- a/apps/bfd-model/bfd-model-rif/src/main/resources/db/migration/V22__Add_MBI_hash_index.sql
+++ b/apps/bfd-model/bfd-model-rif/src/main/resources/db/migration/V22__Add_MBI_hash_index.sql
@@ -1,0 +1,12 @@
+/* 
+ * Add a MedicareBeneficiaryIdentifier (MBI) hash column for mbi searches. 
+ * The search is used by partners to cross-walk to the beneficiaryId. 
+ * Since this is a frequent operation, the hash is indexed.
+ */
+
+create index ${logic.index-create-concurrently} "Beneficiaries_mbi_hash_idx"
+    on "Beneficiaries" ("mbiHash");
+
+create index ${logic.index-create-concurrently} "Beneficiaries_history_mbi_hash_idx"
+    on "BeneficiariesHistory" ("mbiHash");
+    


### PR DESCRIPTION
**Why**
For the search by MBI hash feature, we need to add a mbiHash column to our database. This change only contains a DB migration. 

**What**
Two DB migrations: 21 and 22. Two DB migrations are needed because FlyWheel wants alters and index changes in separate migrations. 

The mbiHash columns are nullable and indexed. No default is set for the column so that the column will not be updated during the alter. 

**Testing**
Deployed to locally to both HSQL and Postgres. Tests passed. 

**Future**
Other code changes will populate the hash column.

**Security Implication**

- [ ]   new software dependencies
- [ ]   altered security controls
- [x]   new data stored or transmitted
- [ ]   security checklist is completed for this change
- [ ]   requires more information or team discussion to evaluate security implications
