### PR TITLE
Return synthetic resources with negative IDs

### DIFF
--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/CoverageResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/CoverageResourceProvider.java
@@ -40,7 +40,8 @@ import org.springframework.stereotype.Component;
 @Component
 public final class CoverageResourceProvider implements IResourceProvider {
   /** A {@link Pattern} that will match the {@link Coverage#getId()}s used in this application. */
-  private static final Pattern COVERAGE_ID_PATTERN = Pattern.compile("(.*)-(\\p{Alnum}+)");
+  private static final Pattern COVERAGE_ID_PATTERN =
+      Pattern.compile("(\\p{Alnum}+-\\p{Alnum})-(-?\\p{Alnum}+)");
 
   private EntityManager entityManager;
   private MetricRegistry metricRegistry;

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/ExplanationOfBenefitResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/ExplanationOfBenefitResourceProvider.java
@@ -50,7 +50,7 @@ public final class ExplanationOfBenefitResourceProvider implements IResourceProv
    * A {@link Pattern} that will match the {@link ExplanationOfBenefit#getId()}s used in this
    * application.
    */
-  private static final Pattern EOB_ID_PATTERN = Pattern.compile("(\\p{Alpha}+)-(\\p{Alnum}+)");
+  private static final Pattern EOB_ID_PATTERN = Pattern.compile("(\\p{Alpha}+)-(-?\\p{Alnum}+)");
 
   private EntityManager entityManager;
   private MetricRegistry metricRegistry;


### PR DESCRIPTION
A regex for parsing the format of EoB and Coverage resource read requests did not successfully parse synthetic Resource read requests due to their negative IDs. The result was that no synthetic EoB or Coverage resources were found on Read requests.

This updates those regex to allow for the IDs of these Resources to be negative.