### PR TITLE
Improve Build Reliability

### DIFF
--- a/apps/bfd-server/bfd-server-launcher/src/test/java/gov/cms/bfd/server/launcher/DataServerLauncherAppIT.java
+++ b/apps/bfd-server/bfd-server-launcher/src/test/java/gov/cms/bfd/server/launcher/DataServerLauncherAppIT.java
@@ -87,6 +87,11 @@ public final class DataServerLauncherAppIT {
       }
 
       // Verify that the access log is working, as expected.
+      try {
+        TimeUnit.MILLISECONDS.sleep(
+            100); // Needed in some configurations to resolve a race condition
+      } catch (InterruptedException e) {
+      }
       Path accessLog =
           ServerTestUtils.getLauncherProjectDirectory()
               .resolve("target")

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/BeneficiaryTransformer.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/BeneficiaryTransformer.java
@@ -55,10 +55,6 @@ final class BeneficiaryTransformer {
     patient.addIdentifier(
         TransformerUtils.createIdentifier(
             CcwCodebookVariable.BENE_ID, beneficiary.getBeneficiaryId()));
-    patient
-        .addIdentifier()
-        .setSystem(TransformerConstants.CODING_BBAPI_BENE_HICN_HASH)
-        .setValue(beneficiary.getHicn());
 
     if (includeIdentifiersMode == IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS) {
       Extension currentIdentifier =

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtils.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtils.java
@@ -2688,24 +2688,22 @@ public final class TransformerUtils {
   private static Map<String, String> readNpiCodeFile() {
 
     Map<String, String> npiCodeMap = new HashMap<String, String>();
-    InputStream npiCodeDisplayStream =
-        Thread.currentThread()
-            .getContextClassLoader()
-            .getResourceAsStream("NPI_Coded_Display_Values_Tab.txt");
-
-    BufferedReader npiCodesIn = null;
-    npiCodesIn = new BufferedReader(new InputStreamReader(npiCodeDisplayStream));
-    /*
-     * We want to extract the NPI codes and display values and put in a map for easy
-     * retrieval to get the display value-- npiColumns[0] is the NPI Code,
-     * npiColumns[4] is the NPI Organization Code, npiColumns[8] is the NPI provider
-     * name prefix, npiColumns[6] is the NPI provider first name, npiColumns[7] is
-     * the NPI provider middle name, npiColumns[5] is the NPI provider last name,
-     * npiColumns[9] is the NPI provider suffix name, npiColumns[10] is the NPI
-     * provider credential.
-     */
-    String line = "";
-    try {
+    try (final InputStream npiCodeDisplayStream =
+            Thread.currentThread()
+                .getContextClassLoader()
+                .getResourceAsStream("NPI_Coded_Display_Values_Tab.txt");
+        final BufferedReader npiCodesIn =
+            new BufferedReader(new InputStreamReader(npiCodeDisplayStream))) {
+      /*
+       * We want to extract the NPI codes and display values and put in a map for easy
+       * retrieval to get the display value-- npiColumns[0] is the NPI Code,
+       * npiColumns[4] is the NPI Organization Code, npiColumns[8] is the NPI provider
+       * name prefix, npiColumns[6] is the NPI provider first name, npiColumns[7] is
+       * the NPI provider middle name, npiColumns[5] is the NPI provider last name,
+       * npiColumns[9] is the NPI provider suffix name, npiColumns[10] is the NPI
+       * provider credential.
+       */
+      String line = "";
       npiCodesIn.readLine();
       while ((line = npiCodesIn.readLine()) != null) {
         String npiColumns[] = line.split("\t");
@@ -2727,11 +2725,9 @@ public final class TransformerUtils {
           npiCodeMap.put(npiColumns[0], npiColumns[4].replace("\"", "").trim());
         }
       }
-      npiCodesIn.close();
     } catch (IOException e) {
       throw new UncheckedIOException("Unable to read NPI code data.", e);
     }
-
     return npiCodeMap;
   }
 

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtils.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtils.java
@@ -2617,20 +2617,18 @@ public final class TransformerUtils {
    * in the src/main/resources directory
    */
   private static Map<String, String> readIcdCodeFile() {
-
     Map<String, String> icdDiagnosisMap = new HashMap<String, String>();
-    InputStream icdCodeDisplayStream =
-        Thread.currentThread().getContextClassLoader().getResourceAsStream("DGNS_CD.txt");
 
-    BufferedReader icdCodesIn = null;
-    icdCodesIn = new BufferedReader(new InputStreamReader(icdCodeDisplayStream));
-    /*
-     * We want to extract the ICD Diagnosis codes and display values and put in a
-     * map for easy retrieval to get the display value icdColumns[1] is
-     * DGNS_DESC(i.e. 7840 code is HEADACHE description)
-     */
-    String line = "";
-    try {
+    try (final InputStream icdCodeDisplayStream =
+            Thread.currentThread().getContextClassLoader().getResourceAsStream("DGNS_CD.txt");
+        final BufferedReader icdCodesIn =
+            new BufferedReader(new InputStreamReader(icdCodeDisplayStream))) {
+      /*
+       * We want to extract the ICD Diagnosis codes and display values and put in a
+       * map for easy retrieval to get the display value icdColumns[1] is
+       * DGNS_DESC(i.e. 7840 code is HEADACHE description)
+       */
+      String line = "";
       icdCodesIn.readLine();
       while ((line = icdCodesIn.readLine()) != null) {
         String icdColumns[] = line.split("\t");
@@ -2776,19 +2774,16 @@ public final class TransformerUtils {
   private static Map<String, String> readProcedureCodeFile() {
 
     Map<String, String> procedureCodeMap = new HashMap<String, String>();
-    InputStream procedureCodeDisplayStream =
-        Thread.currentThread().getContextClassLoader().getResourceAsStream("PRCDR_CD.txt");
-
-    BufferedReader procedureCodesIn = null;
-    procedureCodesIn = new BufferedReader(new InputStreamReader(procedureCodeDisplayStream));
-
-    /*
-     * We want to extract the procedure codes and display values and put in a map
-     * for easy retrieval to get the display value icdColumns[0] is PRCDR_CD;
-     * icdColumns[1] is PRCDR_DESC(i.e. 8295 is INJECT TENDON OF HAND description)
-     */
-    String line = "";
-    try {
+    try (final InputStream procedureCodeDisplayStream =
+            Thread.currentThread().getContextClassLoader().getResourceAsStream("PRCDR_CD.txt");
+        final BufferedReader procedureCodesIn =
+            new BufferedReader(new InputStreamReader(procedureCodeDisplayStream))) {
+      /*
+       * We want to extract the procedure codes and display values and put in a map
+       * for easy retrieval to get the display value icdColumns[0] is PRCDR_CD;
+       * icdColumns[1] is PRCDR_DESC(i.e. 8295 is INJECT TENDON OF HAND description)
+       */
+      String line = "";
       procedureCodesIn.readLine();
       while ((line = procedureCodesIn.readLine()) != null) {
         String icdColumns[] = line.split("\t");
@@ -2856,22 +2851,19 @@ public final class TransformerUtils {
    */
   public static Map<String, String> readFDADrugCodeFile() {
     Map<String, String> ndcProductHashMap = new HashMap<String, String>();
-    InputStream ndcProductStream =
-        Thread.currentThread()
-            .getContextClassLoader()
-            .getResourceAsStream(FDADrugDataUtilityApp.FDA_PRODUCTS_RESOURCE);
-
-    BufferedReader ndcProductsIn = null;
-    ndcProductsIn = new BufferedReader(new InputStreamReader(ndcProductStream));
-
-    /*
-     * We want to extract the PRODUCTNDC and PROPRIETARYNAME/SUBSTANCENAME from the
-     * FDA Products file (fda_products_utf8.tsv is in /target/classes directory) and
-     * put in a Map for easy retrieval to get the display value which is a
-     * combination of PROPRIETARYNAME & SUBSTANCENAME
-     */
-    String line = "";
-    try {
+    try (final InputStream ndcProductStream =
+            Thread.currentThread()
+                .getContextClassLoader()
+                .getResourceAsStream(FDADrugDataUtilityApp.FDA_PRODUCTS_RESOURCE);
+        final BufferedReader ndcProductsIn =
+            new BufferedReader(new InputStreamReader(ndcProductStream))) {
+      /*
+       * We want to extract the PRODUCTNDC and PROPRIETARYNAME/SUBSTANCENAME from the
+       * FDA Products file (fda_products_utf8.tsv is in /target/classes directory) and
+       * put in a Map for easy retrieval to get the display value which is a
+       * combination of PROPRIETARYNAME & SUBSTANCENAME
+       */
+      String line = "";
       ndcProductsIn.readLine();
       while ((line = ndcProductsIn.readLine()) != null) {
         String ndcProductColumns[] = line.split("\t");
@@ -2894,7 +2886,6 @@ public final class TransformerUtils {
     } catch (IOException e) {
       throw new UncheckedIOException("Unable to read NDC code data.", e);
     }
-
     return ndcProductHashMap;
   }
 

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/BeneficiaryTransformerTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/BeneficiaryTransformerTest.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender;
+import org.hl7.fhir.dstu3.model.Identifier;
 import org.hl7.fhir.dstu3.model.Patient;
 import org.junit.Assert;
 import org.junit.Test;
@@ -34,8 +35,17 @@ public final class BeneficiaryTransformerTest {
     Patient patient =
         BeneficiaryTransformer.transform(
             new MetricRegistry(), beneficiary, IncludeIdentifiersMode.OMIT_HICNS_AND_MBIS);
+
     assertMatches(beneficiary, patient);
-    Assert.assertEquals(2, patient.getIdentifier().size());
+
+    // Verify patient has only one identifier.
+    Assert.assertEquals(1, patient.getIdentifier().size());
+
+    // Verify the only identifier is BENE_ID and value.
+    Assert.assertEquals(
+        patient.getIdentifier().get(0).getSystem(),
+        TransformerUtils.calculateVariableReferenceUrl(CcwCodebookVariable.BENE_ID));
+    Assert.assertEquals(patient.getIdentifier().get(0).getValue(), "567834");
   }
 
   /**
@@ -46,13 +56,58 @@ public final class BeneficiaryTransformerTest {
    */
   @Test
   public void transformSampleARecordWithIdentifiers() {
+
     Beneficiary beneficiary = loadSampleABeneficiary();
 
     Patient patient =
         BeneficiaryTransformer.transform(
             new MetricRegistry(), beneficiary, IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS);
+
     assertMatches(beneficiary, patient);
-    Assert.assertEquals(7, patient.getIdentifier().size());
+
+    // Verify patient has 6 identifiers.
+    Assert.assertEquals(6, patient.getIdentifier().size());
+
+    // Verify patient identifiers and values match.
+    assertValuesInPatientIdentifiers(
+        patient,
+        TransformerUtils.calculateVariableReferenceUrl(CcwCodebookVariable.BENE_ID),
+        "567834");
+
+    assertValuesInPatientIdentifiers(
+        patient, TransformerConstants.CODING_BBAPI_BENE_HICN_UNHASHED, "543217066U");
+
+    assertValuesInPatientIdentifiers(
+        patient, TransformerConstants.CODING_BBAPI_MEDICARE_BENEFICIARY_ID_UNHASHED, "3456789");
+
+    assertValuesInPatientIdentifiers(
+        patient, TransformerConstants.CODING_BBAPI_BENE_HICN_UNHASHED, "543217066T");
+
+    assertValuesInPatientIdentifiers(
+        patient, TransformerConstants.CODING_BBAPI_BENE_HICN_UNHASHED, "543217066Z");
+
+    assertValuesInPatientIdentifiers(
+        patient, TransformerConstants.CODING_BBAPI_MEDICARE_BENEFICIARY_ID_UNHASHED, "9AB2WW3GR44");
+  }
+
+  /**
+   * Verifies that the {@link Patient} identifiers contain expected values.
+   *
+   * @param Patient {@link Patient} containing identifiers
+   * @param identifierSystem value to be matched
+   * @param identifierValue value to be matched
+   */
+  private static void assertValuesInPatientIdentifiers(
+      Patient patient, String identifierSystem, String identifierValue) {
+    boolean identifierFound = false;
+
+    for (Identifier temp : patient.getIdentifier()) {
+      if (identifierSystem.equals(temp.getSystem()) && identifierValue.equals(temp.getValue())) {
+        identifierFound = true;
+        break;
+      }
+    }
+    Assert.assertEquals(identifierFound, true);
   }
 
   /**

--- a/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/patientByIdentifier.json
+++ b/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/patientByIdentifier.json
@@ -110,9 +110,6 @@
         }
       } ],
       "identifier" : [ {
-        "system" : "https://bluebutton.cms.gov/resources/identifier/hicn-hash",
-        "value" : "99f6cc85e95c4b2cec5382600478482cceadb7534d4c3f0a4f2e55d33428c169"
-      }, {
         "system" : "https://bluebutton.cms.gov/resources/variables/bene_id",
         "value" : "567834"
       } ],

--- a/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/patientByIdentifierWithIncludeIdentifiers.json
+++ b/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/patientByIdentifierWithIncludeIdentifiers.json
@@ -165,9 +165,6 @@
         "system" : "http://hl7.org/fhir/sid/us-medicare",
         "value" : "543217066Z"
       }, {
-        "system" : "https://bluebutton.cms.gov/resources/identifier/hicn-hash",
-        "value" : "99f6cc85e95c4b2cec5382600478482cceadb7534d4c3f0a4f2e55d33428c169"
-      }, {
         "system" : "https://bluebutton.cms.gov/resources/variables/bene_id",
         "value" : "567834"
       } ],

--- a/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/patientRead.json
+++ b/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/patientRead.json
@@ -97,9 +97,6 @@
     }
   } ],
   "identifier" : [ {
-    "system" : "https://bluebutton.cms.gov/resources/identifier/hicn-hash",
-    "value" : "99f6cc85e95c4b2cec5382600478482cceadb7534d4c3f0a4f2e55d33428c169"
-  }, {
     "system" : "https://bluebutton.cms.gov/resources/variables/bene_id",
     "value" : "567834"
   } ],

--- a/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/patientReadWithIncludeIdentifiers.json
+++ b/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/patientReadWithIncludeIdentifiers.json
@@ -152,9 +152,6 @@
     "system" : "http://hl7.org/fhir/sid/us-medicare",
     "value" : "543217066Z"
   }, {
-    "system" : "https://bluebutton.cms.gov/resources/identifier/hicn-hash",
-    "value" : "99f6cc85e95c4b2cec5382600478482cceadb7534d4c3f0a4f2e55d33428c169"
-  }, {
     "system" : "https://bluebutton.cms.gov/resources/variables/bene_id",
     "value" : "567834"
   } ],

--- a/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/patientSearchById.json
+++ b/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/patientSearchById.json
@@ -110,9 +110,6 @@
         }
       } ],
       "identifier" : [ {
-        "system" : "https://bluebutton.cms.gov/resources/identifier/hicn-hash",
-        "value" : "99f6cc85e95c4b2cec5382600478482cceadb7534d4c3f0a4f2e55d33428c169"
-      }, {
         "system" : "https://bluebutton.cms.gov/resources/variables/bene_id",
         "value" : "567834"
       } ],

--- a/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/patientSearchByIdWithIncludeIdentifiers.json
+++ b/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/patientSearchByIdWithIncludeIdentifiers.json
@@ -165,9 +165,6 @@
         "system" : "http://hl7.org/fhir/sid/us-medicare",
         "value" : "543217066Z"
       }, {
-        "system" : "https://bluebutton.cms.gov/resources/identifier/hicn-hash",
-        "value" : "99f6cc85e95c4b2cec5382600478482cceadb7534d4c3f0a4f2e55d33428c169"
-      }, {
         "system" : "https://bluebutton.cms.gov/resources/variables/bene_id",
         "value" : "567834"
       } ],

--- a/apps/bfd-server/dev/api-changelog.md
+++ b/apps/bfd-server/dev/api-changelog.md
@@ -1,5 +1,17 @@
 # API Changelog
 
+## BLUEBUTTON-1679: Hashed HICN needs to be removed from Patient Resource
+
+The Hashed HICN identifier is removed from the Patient resource response. This is to ensure that we are in compliance for the HICN rule by January 1st. This is to leave no traces of the HICN-hash in any external facing data requests to BFD. 
+
+The following is an example of the identifier that is removed from the response:
+
+    <identifier>
+       <system value="https://bluebutton.cms.gov/resources/identifier/hicn-hash"></system>
+       <value value="96228a57f37efea543f4f370f96f1dbf01c3e3129041dba3ea4367545507c6e7"></value>
+    </identifier>
+
+
 ## BLUEBUTTON-1191: Allow Filtering of EOB Searches by type
 
 A new optional query parameter has been added to `ExplanationOfBenefit` searches that will filter the returned results by `type`.


### PR DESCRIPTION
**Why**
Improve the reliability of local builds.

When I switched to a faster laptop, my local `mvn clean install` builds of the master branch began to fail more frequently. Often, these failures would be in the `bfd-server-launcher` project. Other times they would be associated with `NPI_Coded_Display_Values_Tab.txt`. If I restarted the builds, they would succeed, so the problems were transitory. 

**What Changed**
The test for the presence of the `access_log` was failing. Added a pause in the `DataServerLauncherAppIT` to allow the `access_log` to be written out. 

The `TransformUtils` function would read in the local resources like `NPI_Coded_Display_Values_Tab.txt`. The streams for these files were not in try-resource blocks. This is poor practice, although I don't think it was the cause of the problems with packaging `NPI_Coded_Display_Values_Tab.txt`

**Testing**
Ran mvn clean install many times successfully

**Security Impact**
None