### PR TITLE
BLUEBUTTON-1536  Extend IncludeIdentifiers header options for Patient Resource response

### DIFF
--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/BeneficiaryTransformer.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/BeneficiaryTransformer.java
@@ -6,7 +6,6 @@ import gov.cms.bfd.model.codebook.data.CcwCodebookVariable;
 import gov.cms.bfd.model.rif.Beneficiary;
 import gov.cms.bfd.model.rif.BeneficiaryHistory;
 import gov.cms.bfd.model.rif.MedicareBeneficiaryIdHistory;
-import gov.cms.bfd.server.war.stu3.providers.PatientResourceProvider.IncludeIdentifiersMode;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -23,18 +22,18 @@ final class BeneficiaryTransformer {
   /**
    * @param metricRegistry the {@link MetricRegistry} to use
    * @param beneficiary the CCW {@link Beneficiary} to transform
-   * @param includeIdentifiersMode the {@link IncludeIdentifiersMode} to use
+   * @param includeIdentifiersValues the includeIdentifiers header values to use
    * @return a FHIR {@link Patient} resource that represents the specified {@link Beneficiary}
    */
   public static Patient transform(
       MetricRegistry metricRegistry,
       Beneficiary beneficiary,
-      IncludeIdentifiersMode includeIdentifiersMode) {
+      List<String> includeIdentifiersValues) {
     Timer.Context timer =
         metricRegistry
             .timer(MetricRegistry.name(BeneficiaryTransformer.class.getSimpleName(), "transform"))
             .time();
-    Patient patient = transform(beneficiary, includeIdentifiersMode);
+    Patient patient = transform(beneficiary, includeIdentifiersValues);
     timer.stop();
 
     return patient;
@@ -42,11 +41,10 @@ final class BeneficiaryTransformer {
 
   /**
    * @param beneficiary the CCW {@link Beneficiary} to transform
-   * @param includeIdentifiersMode the {@link IncludeIdentifiersMode} to use
+   * @param includeIdentifiersValues the includeIdentifiers header values to use
    * @return a FHIR {@link Patient} resource that represents the specified {@link Beneficiary}
    */
-  private static Patient transform(
-      Beneficiary beneficiary, IncludeIdentifiersMode includeIdentifiersMode) {
+  private static Patient transform(Beneficiary beneficiary, List<String> includeIdentifiersValues) {
     Objects.requireNonNull(beneficiary);
 
     Patient patient = new Patient();
@@ -67,15 +65,15 @@ final class BeneficiaryTransformer {
           .setValue(beneficiary.getMbiHash().get());
     }
 
-    if ((IncludeIdentifiersMode.hasHICN(includeIdentifiersMode))
-        || (IncludeIdentifiersMode.hasMBI(includeIdentifiersMode))) {
+    if (PatientResourceProvider.hasHICN(includeIdentifiersValues)
+        || PatientResourceProvider.hasMBI(includeIdentifiersValues)) {
 
       Extension currentIdentifier =
           TransformerUtils.createIdentifierCurrencyExtension(CurrencyIdentifier.CURRENT);
 
       Optional<String> hicnUnhashedCurrent = beneficiary.getHicnUnhashed();
       if ((hicnUnhashedCurrent.isPresent())
-          && (IncludeIdentifiersMode.hasHICN(includeIdentifiersMode)))
+          && PatientResourceProvider.hasHICN(includeIdentifiersValues))
         addUnhashedIdentifier(
             patient,
             hicnUnhashedCurrent.get(),
@@ -84,7 +82,7 @@ final class BeneficiaryTransformer {
 
       Optional<String> mbiUnhashedCurrent = beneficiary.getMedicareBeneficiaryId();
       if ((mbiUnhashedCurrent.isPresent())
-          && (IncludeIdentifiersMode.hasMBI(includeIdentifiersMode)))
+          && PatientResourceProvider.hasMBI(includeIdentifiersValues))
         addUnhashedIdentifier(
             patient,
             mbiUnhashedCurrent.get(),
@@ -94,7 +92,7 @@ final class BeneficiaryTransformer {
       Extension historicalIdentifier =
           TransformerUtils.createIdentifierCurrencyExtension(CurrencyIdentifier.HISTORIC);
 
-      if (IncludeIdentifiersMode.hasHICN(includeIdentifiersMode)) {
+      if (PatientResourceProvider.hasHICN(includeIdentifiersValues)) {
         List<String> unhashedHicns = new ArrayList<String>();
         for (BeneficiaryHistory beneHistory : beneficiary.getBeneficiaryHistories()) {
           Optional<String> hicnUnhashedHistoric = beneHistory.getHicnUnhashed();
@@ -112,7 +110,7 @@ final class BeneficiaryTransformer {
         }
       }
 
-      if (IncludeIdentifiersMode.hasMBI(includeIdentifiersMode)) {
+      if (PatientResourceProvider.hasMBI(includeIdentifiersValues)) {
         List<String> unhashedMbis = new ArrayList<String>();
         for (MedicareBeneficiaryIdHistory mbiHistory :
             beneficiary.getMedicareBeneficiaryIdHistories()) {

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/CoverageResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/CoverageResourceProvider.java
@@ -14,7 +14,6 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import gov.cms.bfd.model.rif.Beneficiary;
 import gov.cms.bfd.model.rif.Beneficiary_;
-import gov.cms.bfd.server.war.stu3.providers.PatientResourceProvider.IncludeIdentifiersMode;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
@@ -168,10 +167,7 @@ public final class CoverageResourceProvider implements IResourceProvider {
     } finally {
       beneByIdQueryNanoSeconds = timerBeneQuery.stop();
       TransformerUtils.recordQueryInMdc(
-          String.format(
-              "bene_by_id.%s", IncludeIdentifiersMode.OMIT_HICNS_AND_MBIS.name().toLowerCase()),
-          beneByIdQueryNanoSeconds,
-          beneficiary == null ? 0 : 1);
+          "bene_by_id.include_", beneByIdQueryNanoSeconds, beneficiary == null ? 0 : 1);
     }
 
     return beneficiary;

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
@@ -131,12 +131,7 @@ public final class PatientResourceProvider implements IResourceProvider {
       TransformerUtils.recordQueryInMdc(
           String.format(
               "bene_by_id.include_%s",
-              includeIdentifiersValues
-                  .toString()
-                  .replace("[", "")
-                  .replace("]", "")
-                  .replace(",", "")
-                  .replace(" ", "_")),
+              String.join("_", includeIdentifiersValues),
           beneByIdQueryNanoSeconds,
           beneficiary == null ? 0 : 1);
     }
@@ -419,12 +414,7 @@ public final class PatientResourceProvider implements IResourceProvider {
       TransformerUtils.recordQueryInMdc(
           String.format(
               "bene_by_" + hashType + ".bene_by_" + hashType + "_or_id.include_%s",
-              includeIdentifiersValues
-                  .toString()
-                  .replace("[", "")
-                  .replace("]", "")
-                  .replace(",", "")
-                  .replace(" ", "_")),
+              String.join("_", includeIdentifiersValues),
           benesByHashOrIdQueryNanoSeconds,
           matchingBenes == null ? 0 : matchingBenes.size());
     }

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
@@ -494,11 +494,11 @@ public final class PatientResourceProvider implements IResourceProvider {
         // Still match boolean true by ignoring case
       } else if (headerValues.stream().anyMatch(x -> x.equalsIgnoreCase("true"))) {
         return INCLUDE_MBIS;
-      } else if (headerValues.contains("HICN") && headerValues.contains("MBI")) {
+      } else if (headerValues.contains("hicn") && headerValues.contains("mbi")) {
         return INCLUDE_HICNS_AND_MBIS;
-      } else if (headerValues.contains("HICN")) {
+      } else if (headerValues.contains("hicn")) {
         return INCLUDE_HICNS;
-      } else if (headerValues.contains("MBI")) {
+      } else if (headerValues.contains("mbi")) {
         return INCLUDE_MBIS;
       } else {
         // Default

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
@@ -511,7 +511,7 @@ public final class PatientResourceProvider implements IResourceProvider {
 
   /** @return Returns true if the @param includeIdentifiersValues includes unhashed hicn */
   public static boolean hasHICN(List<String> includeIdentifiersValues) {
-    return includeIdentifiersValues.contains("hicn");
+    return includeIdentifiersValues.contains("hicn") || includeIdentifiersValues.contains("true");
   }
 
   /** @return Returns true if the @param includeIdentifiersValues includes unhashed mbi */

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
@@ -486,17 +486,20 @@ public final class PatientResourceProvider implements IResourceProvider {
     static IncludeIdentifiersMode determineIncludeIdentifiersMode(RequestDetails requestDetails) {
       String includeIdentifiersValue = requestDetails.getHeader(HEADER_NAME_INCLUDE_IDENTIFIERS);
 
+      List<String> headerValues = Arrays.asList(includeIdentifiersValue.split("\\s*,\\s*"));
+
       if (includeIdentifiersValue == null) {
         // If the header was not included in the request or blank
         return OMIT_HICNS_AND_MBIS;
-      } else if (Boolean.parseBoolean(includeIdentifiersValue) == true) {
+        // Still match boolean true by ignoring case
+      } else if (headerValues.stream().anyMatch(x -> x.equalsIgnoreCase("true"))) {
         return INCLUDE_MBIS;
-      } else if (includeIdentifiersValue.equals("HICN")) {
-        return INCLUDE_HICNS;
-      } else if (includeIdentifiersValue.equals("MBI")) {
-        return INCLUDE_MBIS;
-      } else if (includeIdentifiersValue.equals("HICN_AND_MBI")) {
+      } else if (headerValues.contains("HICN") && headerValues.contains("MBI")) {
         return INCLUDE_HICNS_AND_MBIS;
+      } else if (headerValues.contains("HICN")) {
+        return INCLUDE_HICNS;
+      } else if (headerValues.contains("MBI")) {
+        return INCLUDE_MBIS;
       } else {
         // Default
         return OMIT_HICNS_AND_MBIS;

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
@@ -378,12 +378,12 @@ public final class PatientResourceProvider implements IResourceProvider {
 
     List<String> includeIdentifiersValues = returnIncludeIdentifiersValues(requestDetails);
 
-    if (hasHICN(includeIdentifiersValues) || hasMBI(includeIdentifiersValues)) {
-      // For efficiency, grab these relations in the same query.
-      // For security, only grab them when needed.
+    if (hasHICN(includeIdentifiersValues))
       beneMatchesRoot.fetch(Beneficiary_.beneficiaryHistories, JoinType.LEFT);
+
+    if (hasMBI(includeIdentifiersValues))
       beneMatchesRoot.fetch(Beneficiary_.medicareBeneficiaryIdHistories, JoinType.LEFT);
-    }
+
     beneMatches.select(beneMatchesRoot);
     Predicate beneHashMatches = builder.equal(beneMatchesRoot.get(beneficiaryHashField), hash);
     if (!matchingIdsFromBeneHistory.isEmpty()) {

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
@@ -106,12 +106,12 @@ public final class PatientResourceProvider implements IResourceProvider {
     CriteriaQuery<Beneficiary> criteria = builder.createQuery(Beneficiary.class);
     Root<Beneficiary> root = criteria.from(Beneficiary.class);
 
-    if (hasHICN(includeIdentifiersValues) || hasMBI(includeIdentifiersValues)) {
-      // For efficiency, grab these relations in the same query.
-      // For security, only grab them when needed.
+    if (hasHICN(includeIdentifiersValues))
       root.fetch(Beneficiary_.beneficiaryHistories, JoinType.LEFT);
+
+    if (hasMBI(includeIdentifiersValues))
       root.fetch(Beneficiary_.medicareBeneficiaryIdHistories, JoinType.LEFT);
-    }
+
     criteria.select(root);
     criteria.where(builder.equal(root.get(Beneficiary_.beneficiaryId), beneIdText));
 

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
@@ -483,7 +483,7 @@ public final class PatientResourceProvider implements IResourceProvider {
    * #returnIncludeIdentifiersValues(RequestDetails)} for details.
    */
   public static final List<String> VALID_HEADER_VALUES_INCLUDE_IDENTIFIERS =
-      Arrays.asList("true", "false", "hicn", "mbi");
+      Arrays.asList("true", "false", "hicn", "mbi", "");
 
   /**
    * Return a valid List of values for the IncludeIdenfifiers header

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
@@ -483,7 +483,7 @@ public final class PatientResourceProvider implements IResourceProvider {
    * #returnIncludeIdentifiersValues(RequestDetails)} for details.
    */
   public static final List<String> VALID_HEADER_VALUES_INCLUDE_IDENTIFIERS =
-      Arrays.asList("true", "false", "hicn", "mbi", "");
+      Arrays.asList("true", "false", "hicn", "mbi");
 
   /**
    * Return a valid List of values for the IncludeIdenfifiers header
@@ -496,7 +496,7 @@ public final class PatientResourceProvider implements IResourceProvider {
   public static List<String> returnIncludeIdentifiersValues(RequestDetails requestDetails) {
     String headerValues = requestDetails.getHeader(HEADER_NAME_INCLUDE_IDENTIFIERS);
 
-    if (headerValues == null) return Arrays.asList("");
+    if (headerValues == null || headerValues == "") return Arrays.asList("");
     else
       // Return values split on a comma with any whitespace, valid, distict, and sort
       return Arrays.asList(headerValues.toLowerCase().split("\\s*,\\s*")).stream()

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
@@ -504,11 +504,7 @@ public final class PatientResourceProvider implements IResourceProvider {
               c -> {
                 if (!VALID_HEADER_VALUES_INCLUDE_IDENTIFIERS.contains(c))
                   throw new InvalidRequestException(
-                      "Unsupported "
-                          + HEADER_NAME_INCLUDE_IDENTIFIERS
-                          + " header value: -"
-                          + c
-                          + "-");
+                      "Unsupported " + HEADER_NAME_INCLUDE_IDENTIFIERS + " header value: " + c);
               })
           .distinct()
           .sorted()

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
@@ -479,7 +479,7 @@ public final class PatientResourceProvider implements IResourceProvider {
   public static final String HEADER_NAME_INCLUDE_IDENTIFIERS = "IncludeIdentifiers";
 
   /**
-   * The List of valid values for the {@link HEADER_NAME_INCLUDE_IDENTIFIERS} header. See {@link
+   * The List of valid values for the {@link #HEADER_NAME_INCLUDE_IDENTIFIERS} header. See {@link
    * #returnIncludeIdentifiersValues(RequestDetails)} for details.
    */
   public static final List<String> VALID_HEADER_VALUES_INCLUDE_IDENTIFIERS =
@@ -512,7 +512,7 @@ public final class PatientResourceProvider implements IResourceProvider {
   }
 
   /**
-   * Check if HICN is in {@link HEADER_NAME_INCLUDE_IDENTIFIERS} header values.
+   * Check if HICN is in {@link #HEADER_NAME_INCLUDE_IDENTIFIERS} header values.
    *
    * @param includeIdentifiersValues a list of header values.
    * @return Returns true if includes unhashed hicn
@@ -522,7 +522,7 @@ public final class PatientResourceProvider implements IResourceProvider {
   }
 
   /**
-   * Check if MBI is in {@link HEADER_NAME_INCLUDE_IDENTIFIERS} header values.
+   * Check if MBI is in {@link #HEADER_NAME_INCLUDE_IDENTIFIERS} header values.
    *
    * @param includeIdentifiersValues a list of header values.
    * @return Returns true if includes unhashed mbi

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
@@ -87,6 +87,8 @@ public final class PatientResourceProvider implements IResourceProvider {
    *
    * @param patientId The read operation takes one parameter, which must be of type {@link IdType}
    *     and must be annotated with the {@link IdParam} annotation.
+   * @param requestDetails a {@link RequestDetails} containing the details of the request URL, used
+   *     to parse out pagination values
    * @return Returns a resource matching the specified {@link IdDt}, or <code>null</code> if none
    *     exists.
    */
@@ -483,19 +485,26 @@ public final class PatientResourceProvider implements IResourceProvider {
   }
 
   /**
-   * The header key used to determine which {@link IncludeIdentifiersValues} header should be used.
-   * See {@link #determineIncludeIdentifiersValues(RequestDetails)} for details.
+   * The header key used to determine which header should be used. See {@link
+   * #returnIncludeIdentifiersValues(RequestDetails)} for details.
    */
   public static final String HEADER_NAME_INCLUDE_IDENTIFIERS = "IncludeIdentifiers";
 
   /**
-   * The List of valid values for the {@link IncludeIdentifiersValues} header. See {@link
-   * #determineIncludeIdentifiersValues(RequestDetails)} for details.
+   * The List of valid values for the {@link HEADER_NAME_INCLUDE_IDENTIFIERS} header. See {@link
+   * #returnIncludeIdentifiersValues(RequestDetails)} for details.
    */
   public static final List<String> VALID_HEADER_VALUES_INCLUDE_IDENTIFIERS =
       Arrays.asList("true", "hicn", "mbi");
 
-  /** Return a valid List of values for the IncludeIdenfifiers header */
+  /**
+   * Return a valid List of values for the IncludeIdenfifiers header
+   *
+   * @param requestDetails a {@link RequestDetails} containing the details of the request URL, used
+   *     to parse out include identifiers values
+   * @return List of validated header values against the {@link
+   *     VALID_HEADER_VALUES_INCLUDE_IDENTIFIERS} list.
+   */
   public static List<String> returnIncludeIdentifiersValues(RequestDetails requestDetails) {
     String headerValues = requestDetails.getHeader(HEADER_NAME_INCLUDE_IDENTIFIERS);
 
@@ -509,12 +518,22 @@ public final class PatientResourceProvider implements IResourceProvider {
           .collect(Collectors.toList());
   }
 
-  /** @return Returns true if the @param includeIdentifiersValues includes unhashed hicn */
+  /**
+   * Check if HICN is in {@link HEADER_NAME_INCLUDE_IDENTIFIERS} header values.
+   *
+   * @param includeIdentifiersValues a list of header values.
+   * @return Returns true if includes unhashed hicn
+   */
   public static boolean hasHICN(List<String> includeIdentifiersValues) {
     return includeIdentifiersValues.contains("hicn") || includeIdentifiersValues.contains("true");
   }
 
-  /** @return Returns true if the @param includeIdentifiersValues includes unhashed mbi */
+  /**
+   * Check if MBI is in {@link HEADER_NAME_INCLUDE_IDENTIFIERS} header values.
+   *
+   * @param includeIdentifiersValues a list of header values.
+   * @return Returns true if includes unhashed mbi
+   */
   public static boolean hasMBI(List<String> includeIdentifiersValues) {
     return includeIdentifiersValues.contains("mbi") || includeIdentifiersValues.contains("true");
   }

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
@@ -129,9 +129,7 @@ public final class PatientResourceProvider implements IResourceProvider {
       beneByIdQueryNanoSeconds = timerBeneQuery.stop();
 
       TransformerUtils.recordQueryInMdc(
-          String.format(
-              "bene_by_id.include_%s",
-              String.join("_", includeIdentifiersValues),
+          String.format("bene_by_id.include_%s", String.join("_", includeIdentifiersValues)),
           beneByIdQueryNanoSeconds,
           beneficiary == null ? 0 : 1);
     }
@@ -414,7 +412,7 @@ public final class PatientResourceProvider implements IResourceProvider {
       TransformerUtils.recordQueryInMdc(
           String.format(
               "bene_by_" + hashType + ".bene_by_" + hashType + "_or_id.include_%s",
-              String.join("_", includeIdentifiersValues),
+              String.join("_", includeIdentifiersValues)),
           benesByHashOrIdQueryNanoSeconds,
           matchingBenes == null ? 0 : matchingBenes.size());
     }
@@ -485,7 +483,7 @@ public final class PatientResourceProvider implements IResourceProvider {
    * #returnIncludeIdentifiersValues(RequestDetails)} for details.
    */
   public static final List<String> VALID_HEADER_VALUES_INCLUDE_IDENTIFIERS =
-      Arrays.asList("true", "hicn", "mbi");
+      Arrays.asList("true", "false", "hicn", "mbi");
 
   /**
    * Return a valid List of values for the IncludeIdenfifiers header
@@ -502,7 +500,12 @@ public final class PatientResourceProvider implements IResourceProvider {
     else
       // Return values split on a comma with any whitespace, valid, distict, and sort
       return Arrays.asList(headerValues.toLowerCase().split("\\s*,\\s*")).stream()
-          .filter(c -> VALID_HEADER_VALUES_INCLUDE_IDENTIFIERS.contains(c))
+          .peek(
+              c -> {
+                if (!VALID_HEADER_VALUES_INCLUDE_IDENTIFIERS.contains(c))
+                  throw new InvalidRequestException(
+                      "Unsupported " + HEADER_NAME_INCLUDE_IDENTIFIERS + " header value: " + c);
+              })
           .distinct()
           .sorted()
           .collect(Collectors.toList());

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
@@ -504,7 +504,11 @@ public final class PatientResourceProvider implements IResourceProvider {
               c -> {
                 if (!VALID_HEADER_VALUES_INCLUDE_IDENTIFIERS.contains(c))
                   throw new InvalidRequestException(
-                      "Unsupported " + HEADER_NAME_INCLUDE_IDENTIFIERS + " header value: " + c);
+                      "Unsupported "
+                          + HEADER_NAME_INCLUDE_IDENTIFIERS
+                          + " header value: -"
+                          + c
+                          + "-");
               })
           .distinct()
           .sorted()

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/BeneficiaryTransformerTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/BeneficiaryTransformerTest.java
@@ -8,7 +8,6 @@ import gov.cms.bfd.model.rif.MedicareBeneficiaryIdHistory;
 import gov.cms.bfd.model.rif.samples.StaticRifResource;
 import gov.cms.bfd.model.rif.samples.StaticRifResourceGroup;
 import gov.cms.bfd.server.war.ServerTestUtils;
-import gov.cms.bfd.server.war.stu3.providers.PatientResourceProvider.IncludeIdentifiersMode;
 import java.sql.Date;
 import java.util.Arrays;
 import java.util.List;
@@ -33,8 +32,7 @@ public final class BeneficiaryTransformerTest {
     Beneficiary beneficiary = loadSampleABeneficiary();
 
     Patient patient =
-        BeneficiaryTransformer.transform(
-            new MetricRegistry(), beneficiary, IncludeIdentifiersMode.OMIT_HICNS_AND_MBIS);
+        BeneficiaryTransformer.transform(new MetricRegistry(), beneficiary, Arrays.asList("false"));
     assertMatches(beneficiary, patient);
 
     Assert.assertEquals("Number of identifiers should be 2", 2, patient.getIdentifier().size());
@@ -51,8 +49,8 @@ public final class BeneficiaryTransformerTest {
   /**
    * Verifies that {@link
    * gov.cms.bfd.server.war.stu3.providers.BeneficiaryTransformer#transform(Beneficiary)} works as
-   * expected when run against the {@link StaticRifResource#SAMPLE_A_BENES} {@link Beneficiary}, in
-   * the {@link IncludeIdentifiersMode#INCLUDE_HICNS_AND_MBIS} mode.
+   * expected when run against the {@link StaticRifResource#SAMPLE_A_BENES} {@link Beneficiary},
+   * with {@link IncludeIdentifiersValues} = ["hicn","mbi"].
    */
   @Test
   public void transformSampleARecordWithIdentifiers() {
@@ -60,7 +58,7 @@ public final class BeneficiaryTransformerTest {
 
     Patient patient =
         BeneficiaryTransformer.transform(
-            new MetricRegistry(), beneficiary, IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS);
+            new MetricRegistry(), beneficiary, Arrays.asList("hicn", "mbi"));
     assertMatches(beneficiary, patient);
 
     Assert.assertEquals("Number of identifiers should be 7", 7, patient.getIdentifier().size());
@@ -87,16 +85,15 @@ public final class BeneficiaryTransformerTest {
   /**
    * Verifies that {@link
    * gov.cms.bfd.server.war.stu3.providers.BeneficiaryTransformer#transform(Beneficiary)} works as
-   * expected when run against the {@link StaticRifResource#SAMPLE_A_BENES} {@link Beneficiary}, in
-   * the {@link IncludeIdentifiersMode#INCLUDE_HICNS} mode.
+   * expected when run against the {@link StaticRifResource#SAMPLE_A_BENES} {@link Beneficiary},
+   * with {@link IncludeIdentifiersValues} = ["hicn"].
    */
   @Test
   public void transformSampleARecordWithIdentifiersHicn() {
     Beneficiary beneficiary = loadSampleABeneficiary();
 
     Patient patient =
-        BeneficiaryTransformer.transform(
-            new MetricRegistry(), beneficiary, IncludeIdentifiersMode.INCLUDE_HICNS);
+        BeneficiaryTransformer.transform(new MetricRegistry(), beneficiary, Arrays.asList("hicn"));
     assertMatches(beneficiary, patient);
 
     Assert.assertEquals("Number of identifiers should be 5", 5, patient.getIdentifier().size());
@@ -119,16 +116,15 @@ public final class BeneficiaryTransformerTest {
   /**
    * Verifies that {@link
    * gov.cms.bfd.server.war.stu3.providers.BeneficiaryTransformer#transform(Beneficiary)} works as
-   * expected when run against the {@link StaticRifResource#SAMPLE_A_BENES} {@link Beneficiary}, in
-   * the {@link IncludeIdentifiersMode#INCLUDE_MBIS} mode.
+   * expected when run against the {@link StaticRifResource#SAMPLE_A_BENES} {@link Beneficiary},
+   * with {@link IncludeIdentifiersValues} = ["mbi"].
    */
   @Test
   public void transformSampleARecordWithIdentifiersMbi() {
     Beneficiary beneficiary = loadSampleABeneficiary();
 
     Patient patient =
-        BeneficiaryTransformer.transform(
-            new MetricRegistry(), beneficiary, IncludeIdentifiersMode.INCLUDE_MBIS);
+        BeneficiaryTransformer.transform(new MetricRegistry(), beneficiary, Arrays.asList("mbi"));
     assertMatches(beneficiary, patient);
 
     Assert.assertEquals("Number of identifiers should be 4", 4, patient.getIdentifier().size());
@@ -235,8 +231,7 @@ public final class BeneficiaryTransformerTest {
     TransformerTestUtils.setAllOptionalsToEmpty(beneficiary);
 
     Patient patient =
-        BeneficiaryTransformer.transform(
-            new MetricRegistry(), beneficiary, IncludeIdentifiersMode.OMIT_HICNS_AND_MBIS);
+        BeneficiaryTransformer.transform(new MetricRegistry(), beneficiary, Arrays.asList(""));
     assertMatches(beneficiary, patient);
   }
 

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/BeneficiaryTransformerTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/BeneficiaryTransformerTest.java
@@ -37,8 +37,7 @@ public final class BeneficiaryTransformerTest {
             new MetricRegistry(), beneficiary, IncludeIdentifiersMode.OMIT_HICNS_AND_MBIS);
     assertMatches(beneficiary, patient);
 
-    // Verify patient has only two identifiers.
-    Assert.assertEquals(2, patient.getIdentifier().size());
+    Assert.assertEquals("Number of identifiers should be 2", 2, patient.getIdentifier().size());
 
     // Verify identifiers and values match.
     assertValuesInPatientIdentifiers(
@@ -64,8 +63,7 @@ public final class BeneficiaryTransformerTest {
             new MetricRegistry(), beneficiary, IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS);
     assertMatches(beneficiary, patient);
 
-    // Verify patient has only 7 identifiers.
-    Assert.assertEquals(7, patient.getIdentifier().size());
+    Assert.assertEquals("Number of identifiers should be 7", 7, patient.getIdentifier().size());
 
     // Verify patient identifiers and values match.
     assertValuesInPatientIdentifiers(
@@ -101,8 +99,7 @@ public final class BeneficiaryTransformerTest {
             new MetricRegistry(), beneficiary, IncludeIdentifiersMode.INCLUDE_HICNS);
     assertMatches(beneficiary, patient);
 
-    // Verify patient has only 5 identifiers.
-    Assert.assertEquals(5, patient.getIdentifier().size());
+    Assert.assertEquals("Number of identifiers should be 5", 5, patient.getIdentifier().size());
 
     // Verify patient identifiers and values match.
     assertValuesInPatientIdentifiers(
@@ -134,8 +131,7 @@ public final class BeneficiaryTransformerTest {
             new MetricRegistry(), beneficiary, IncludeIdentifiersMode.INCLUDE_MBIS);
     assertMatches(beneficiary, patient);
 
-    // Verify patient has only 4 identifiers.
-    Assert.assertEquals(4, patient.getIdentifier().size());
+    Assert.assertEquals("Number of identifiers should be 4", 4, patient.getIdentifier().size());
 
     // Verify patient identifiers and values match.
     assertValuesInPatientIdentifiers(
@@ -167,7 +163,14 @@ public final class BeneficiaryTransformerTest {
         break;
       }
     }
-    Assert.assertEquals(identifierFound, true);
+    Assert.assertEquals(
+        "Identifier "
+            + identifierSystem
+            + " value = "
+            + identifierValue
+            + " does not match an expected value.",
+        identifierFound,
+        true);
   }
 
   /**

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/BeneficiaryTransformerTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/BeneficiaryTransformerTest.java
@@ -86,6 +86,41 @@ public final class BeneficiaryTransformerTest {
    * Verifies that {@link
    * gov.cms.bfd.server.war.stu3.providers.BeneficiaryTransformer#transform(Beneficiary)} works as
    * expected when run against the {@link StaticRifResource#SAMPLE_A_BENES} {@link Beneficiary},
+   * with {@link IncludeIdentifiersValues} = ["true"].
+   */
+  @Test
+  public void transformSampleARecordWithIdentifiersTrue() {
+    Beneficiary beneficiary = loadSampleABeneficiary();
+
+    Patient patient =
+        BeneficiaryTransformer.transform(new MetricRegistry(), beneficiary, Arrays.asList("true"));
+    assertMatches(beneficiary, patient);
+
+    Assert.assertEquals("Number of identifiers should be 7", 7, patient.getIdentifier().size());
+
+    // Verify patient identifiers and values match.
+    assertValuesInPatientIdentifiers(
+        patient,
+        TransformerUtils.calculateVariableReferenceUrl(CcwCodebookVariable.BENE_ID),
+        "567834");
+    assertValuesInPatientIdentifiers(
+        patient, TransformerConstants.CODING_BBAPI_BENE_HICN_HASH, "somehash");
+    assertValuesInPatientIdentifiers(
+        patient, TransformerConstants.CODING_BBAPI_BENE_HICN_UNHASHED, "543217066U");
+    assertValuesInPatientIdentifiers(
+        patient, TransformerConstants.CODING_BBAPI_MEDICARE_BENEFICIARY_ID_UNHASHED, "3456789");
+    assertValuesInPatientIdentifiers(
+        patient, TransformerConstants.CODING_BBAPI_BENE_HICN_UNHASHED, "543217066T");
+    assertValuesInPatientIdentifiers(
+        patient, TransformerConstants.CODING_BBAPI_BENE_HICN_UNHASHED, "543217066Z");
+    assertValuesInPatientIdentifiers(
+        patient, TransformerConstants.CODING_BBAPI_MEDICARE_BENEFICIARY_ID_UNHASHED, "9AB2WW3GR44");
+  }
+
+  /**
+   * Verifies that {@link
+   * gov.cms.bfd.server.war.stu3.providers.BeneficiaryTransformer#transform(Beneficiary)} works as
+   * expected when run against the {@link StaticRifResource#SAMPLE_A_BENES} {@link Beneficiary},
    * with {@link IncludeIdentifiersValues} = ["hicn"].
    */
   @Test

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/ExtraParamsInterceptor.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/ExtraParamsInterceptor.java
@@ -20,9 +20,21 @@ public class ExtraParamsInterceptor implements IClientInterceptor {
 
   @Override
   public void interceptRequest(IHttpRequest theRequest) {
-    if (includeIdentifiersMode == IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS)
-      theRequest.addHeader(
-          IncludeIdentifiersMode.HEADER_NAME_INCLUDE_IDENTIFIERS, Boolean.TRUE.toString());
+    String headerValue;
+    switch (includeIdentifiersMode) {
+      case INCLUDE_HICNS_AND_MBIS:
+        headerValue = "HICN_AND_MBI";
+        break;
+      case INCLUDE_HICNS:
+        headerValue = "HICN";
+        break;
+      case INCLUDE_MBIS:
+        headerValue = "MBI";
+        break;
+      default:
+        headerValue = Boolean.FALSE.toString();
+    }
+    theRequest.addHeader(IncludeIdentifiersMode.HEADER_NAME_INCLUDE_IDENTIFIERS, headerValue);
   }
 
   @Override

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/ExtraParamsInterceptor.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/ExtraParamsInterceptor.java
@@ -4,7 +4,6 @@ import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.client.api.IClientInterceptor;
 import ca.uhn.fhir.rest.client.api.IHttpRequest;
 import ca.uhn.fhir.rest.client.api.IHttpResponse;
-import gov.cms.bfd.server.war.stu3.providers.PatientResourceProvider.IncludeIdentifiersMode;
 import java.io.IOException;
 
 /**
@@ -15,26 +14,12 @@ import java.io.IOException;
  */
 public class ExtraParamsInterceptor implements IClientInterceptor {
 
-  private IncludeIdentifiersMode includeIdentifiersMode =
-      IncludeIdentifiersMode.OMIT_HICNS_AND_MBIS;
+  private String includeIdentifiersValues = "false";
 
   @Override
   public void interceptRequest(IHttpRequest theRequest) {
-    String headerValue;
-    switch (includeIdentifiersMode) {
-      case INCLUDE_HICNS_AND_MBIS:
-        headerValue = "hicn,mbi";
-        break;
-      case INCLUDE_HICNS:
-        headerValue = "hicn";
-        break;
-      case INCLUDE_MBIS:
-        headerValue = "mbi";
-        break;
-      default:
-        headerValue = Boolean.FALSE.toString();
-    }
-    theRequest.addHeader(IncludeIdentifiersMode.HEADER_NAME_INCLUDE_IDENTIFIERS, headerValue);
+    String headerValue = includeIdentifiersValues;
+    theRequest.addHeader(PatientResourceProvider.HEADER_NAME_INCLUDE_IDENTIFIERS, headerValue);
   }
 
   @Override
@@ -43,7 +28,7 @@ public class ExtraParamsInterceptor implements IClientInterceptor {
 
   }
 
-  public void setIncludeIdentifiers(IncludeIdentifiersMode includeIdentifiersMode) {
-    this.includeIdentifiersMode = includeIdentifiersMode;
+  public void setIncludeIdentifiers(String includeIdentifiersValues) {
+    this.includeIdentifiersValues = includeIdentifiersValues;
   }
 }

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/ExtraParamsInterceptor.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/ExtraParamsInterceptor.java
@@ -23,13 +23,13 @@ public class ExtraParamsInterceptor implements IClientInterceptor {
     String headerValue;
     switch (includeIdentifiersMode) {
       case INCLUDE_HICNS_AND_MBIS:
-        headerValue = "HICN_AND_MBI";
+        headerValue = "hicn,mbi";
         break;
       case INCLUDE_HICNS:
-        headerValue = "HICN";
+        headerValue = "hicn";
         break;
       case INCLUDE_MBIS:
-        headerValue = "MBI";
+        headerValue = "mbi";
         break;
       default:
         headerValue = Boolean.FALSE.toString();

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/ExtraParamsInterceptor.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/ExtraParamsInterceptor.java
@@ -14,7 +14,7 @@ import java.io.IOException;
  */
 public class ExtraParamsInterceptor implements IClientInterceptor {
 
-  private String includeIdentifiersValues = "false";
+  private String includeIdentifiersValues = "";
 
   @Override
   public void interceptRequest(IHttpRequest theRequest) {

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProviderIT.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProviderIT.java
@@ -9,7 +9,6 @@ import gov.cms.bfd.model.rif.MedicareBeneficiaryIdHistory;
 import gov.cms.bfd.model.rif.samples.StaticRifResource;
 import gov.cms.bfd.model.rif.samples.StaticRifResourceGroup;
 import gov.cms.bfd.server.war.ServerTestUtils;
-import gov.cms.bfd.server.war.stu3.providers.PatientResourceProvider.IncludeIdentifiersMode;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -60,7 +59,7 @@ public final class PatientResourceProviderIT {
         ServerTestUtils.loadData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
     IGenericClient fhirClient = ServerTestUtils.createFhirClient();
     ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
-    extraParamsInterceptor.setIncludeIdentifiers(IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS);
+    extraParamsInterceptor.setIncludeIdentifiers("hicn,mbi");
     fhirClient.registerInterceptor(extraParamsInterceptor);
 
     Beneficiary beneficiary =
@@ -107,7 +106,7 @@ public final class PatientResourceProviderIT {
         ServerTestUtils.loadData(Arrays.asList(StaticRifResource.SAMPLE_A_BENES));
     IGenericClient fhirClient = ServerTestUtils.createFhirClient();
     ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
-    extraParamsInterceptor.setIncludeIdentifiers(IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS);
+    extraParamsInterceptor.setIncludeIdentifiers("hicn,mbi");
     fhirClient.registerInterceptor(extraParamsInterceptor);
 
     Beneficiary beneficiary =
@@ -153,7 +152,7 @@ public final class PatientResourceProviderIT {
         ServerTestUtils.loadData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
     IGenericClient fhirClient = ServerTestUtils.createFhirClient();
     ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
-    extraParamsInterceptor.setIncludeIdentifiers(IncludeIdentifiersMode.OMIT_HICNS_AND_MBIS);
+    extraParamsInterceptor.setIncludeIdentifiers("false");
     fhirClient.registerInterceptor(extraParamsInterceptor);
 
     Beneficiary beneficiary =
@@ -254,7 +253,7 @@ public final class PatientResourceProviderIT {
         ServerTestUtils.loadData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
     IGenericClient fhirClient = ServerTestUtils.createFhirClient();
     ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
-    extraParamsInterceptor.setIncludeIdentifiers(IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS);
+    extraParamsInterceptor.setIncludeIdentifiers("hicn,mbi");
     fhirClient.registerInterceptor(extraParamsInterceptor);
 
     Beneficiary beneficiary =
@@ -307,7 +306,7 @@ public final class PatientResourceProviderIT {
         ServerTestUtils.loadData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
     IGenericClient fhirClient = ServerTestUtils.createFhirClient();
     ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
-    extraParamsInterceptor.setIncludeIdentifiers(IncludeIdentifiersMode.OMIT_HICNS_AND_MBIS);
+    extraParamsInterceptor.setIncludeIdentifiers("false");
     fhirClient.registerInterceptor(extraParamsInterceptor);
 
     Beneficiary beneficiary =
@@ -466,7 +465,7 @@ public final class PatientResourceProviderIT {
         ServerTestUtils.loadData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
     IGenericClient fhirClient = ServerTestUtils.createFhirClient();
     ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
-    extraParamsInterceptor.setIncludeIdentifiers(IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS);
+    extraParamsInterceptor.setIncludeIdentifiers("hicn,mbi");
     fhirClient.registerInterceptor(extraParamsInterceptor);
 
     Beneficiary beneficiary =
@@ -716,7 +715,7 @@ public final class PatientResourceProviderIT {
         ServerTestUtils.loadData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
     IGenericClient fhirClient = ServerTestUtils.createFhirClient();
     ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
-    extraParamsInterceptor.setIncludeIdentifiers(IncludeIdentifiersMode.OMIT_HICNS_AND_MBIS);
+    extraParamsInterceptor.setIncludeIdentifiers("false");
     fhirClient.registerInterceptor(extraParamsInterceptor);
 
     Beneficiary beneficiary =
@@ -892,7 +891,7 @@ public final class PatientResourceProviderIT {
         ServerTestUtils.loadData(Arrays.asList(StaticRifResource.SAMPLE_A_BENES));
     IGenericClient fhirClient = ServerTestUtils.createFhirClient();
     ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
-    extraParamsInterceptor.setIncludeIdentifiers(IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS);
+    extraParamsInterceptor.setIncludeIdentifiers("hicn,mbi");
     fhirClient.registerInterceptor(extraParamsInterceptor);
 
     loadedRecords.stream()
@@ -1014,7 +1013,7 @@ public final class PatientResourceProviderIT {
         ServerTestUtils.loadData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
     IGenericClient fhirClient = ServerTestUtils.createFhirClient();
     ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
-    extraParamsInterceptor.setIncludeIdentifiers(IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS);
+    extraParamsInterceptor.setIncludeIdentifiers("hicn,mbi");
     fhirClient.registerInterceptor(extraParamsInterceptor);
 
     Beneficiary beneficiary =
@@ -1264,7 +1263,7 @@ public final class PatientResourceProviderIT {
         ServerTestUtils.loadData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
     IGenericClient fhirClient = ServerTestUtils.createFhirClient();
     ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
-    extraParamsInterceptor.setIncludeIdentifiers(IncludeIdentifiersMode.OMIT_HICNS_AND_MBIS);
+    extraParamsInterceptor.setIncludeIdentifiers("false");
     fhirClient.registerInterceptor(extraParamsInterceptor);
 
     Beneficiary beneficiary =
@@ -1444,7 +1443,7 @@ public final class PatientResourceProviderIT {
         ServerTestUtils.loadData(Arrays.asList(StaticRifResource.SAMPLE_A_BENES));
     IGenericClient fhirClient = ServerTestUtils.createFhirClient();
     ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
-    extraParamsInterceptor.setIncludeIdentifiers(IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS);
+    extraParamsInterceptor.setIncludeIdentifiers("hicn,mbi");
     fhirClient.registerInterceptor(extraParamsInterceptor);
 
     loadedRecords.stream()

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProviderIT.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProviderIT.java
@@ -51,15 +51,110 @@ public final class PatientResourceProviderIT {
   /**
    * Verifies that {@link
    * gov.cms.bfd.server.war.stu3.providers.PatientResourceProvider#read(org.hl7.fhir.dstu3.model.IdType)}
-   * works as expected for a {@link Patient} that does exist in the DB.
+   * works as expected for a {@link Patient} when include identifiers value = ["true"].
    */
   @Test
   public void readExistingPatientIncludeIdentifiersTrue() {
+    String includeIdentifiersValue = "true";
+    boolean expectingHicn = true;
+    boolean expectingMbi = true;
+
+    assertExistingPatientIncludeIdentifiersExpected(
+        includeIdentifiersValue, expectingHicn, expectingMbi);
+  }
+
+  /**
+   * Verifies that {@link
+   * gov.cms.bfd.server.war.stu3.providers.PatientResourceProvider#read(org.hl7.fhir.dstu3.model.IdType)}
+   * works as expected for a {@link Patient} when include identifiers value = ["hicn,mbi"].
+   */
+  @Test
+  public void readExistingPatientIncludeIdentifiersHicnMbi() {
+    String includeIdentifiersValue = "hicn,mbi";
+    boolean expectingHicn = true;
+    boolean expectingMbi = true;
+
+    assertExistingPatientIncludeIdentifiersExpected(
+        includeIdentifiersValue, expectingHicn, expectingMbi);
+  }
+
+  /**
+   * Verifies that {@link
+   * gov.cms.bfd.server.war.stu3.providers.PatientResourceProvider#read(org.hl7.fhir.dstu3.model.IdType)}
+   * works as expected for a {@link Patient} when include identifiers value = ["hicn"].
+   */
+  @Test
+  public void readExistingPatientIncludeIdentifiersHicn() {
+    String includeIdentifiersValue = "hicn";
+    boolean expectingHicn = true;
+    boolean expectingMbi = false;
+
+    assertExistingPatientIncludeIdentifiersExpected(
+        includeIdentifiersValue, expectingHicn, expectingMbi);
+  }
+
+  /**
+   * Verifies that {@link
+   * gov.cms.bfd.server.war.stu3.providers.PatientResourceProvider#read(org.hl7.fhir.dstu3.model.IdType)}
+   * works as expected for a {@link Patient} when include identifiers value = ["mbi"].
+   */
+  @Test
+  public void readExistingPatientIncludeIdentifiersMbi() {
+    String includeIdentifiersValue = "mbi";
+    boolean expectingHicn = false;
+    boolean expectingMbi = true;
+
+    assertExistingPatientIncludeIdentifiersExpected(
+        includeIdentifiersValue, expectingHicn, expectingMbi);
+  }
+
+  /**
+   * Verifies that {@link
+   * gov.cms.bfd.server.war.stu3.providers.PatientResourceProvider#read(org.hl7.fhir.dstu3.model.IdType)}
+   * works as expected for a {@link Patient} when include identifiers value = ["false"].
+   */
+  @Test
+  public void readExistingPatientIncludeIdentifiersFalse() {
+    String includeIdentifiersValue = "false";
+    boolean expectingHicn = false;
+    boolean expectingMbi = false;
+
+    assertExistingPatientIncludeIdentifiersExpected(
+        includeIdentifiersValue, expectingHicn, expectingMbi);
+  }
+
+  /**
+   * Verifies that {@link
+   * gov.cms.bfd.server.war.stu3.providers.PatientResourceProvider#read(org.hl7.fhir.dstu3.model.IdType)}
+   * works as expected for a {@link Patient} when include identifiers value = [""].
+   */
+  @Test
+  public void readExistingPatientIncludeIdentifiersBlank() {
+    String includeIdentifiersValue = "";
+    boolean expectingHicn = false;
+    boolean expectingMbi = false;
+
+    assertExistingPatientIncludeIdentifiersExpected(
+        includeIdentifiersValue, expectingHicn, expectingMbi);
+  }
+
+  /**
+   * Asserts that {@link
+   * gov.cms.bfd.server.war.stu3.providers.PatientResourceProvider#read(org.hl7.fhir.dstu3.model.IdType)}
+   * contains expected/present identifiers for a {@link Patient}.
+   *
+   * @param includeIdentifiersValue header value
+   * @param expectingHicn true if expecting a HICN
+   * @param expectingMbi true if expecting a MBI
+   */
+  public void assertExistingPatientIncludeIdentifiersExpected(
+      String includeIdentifiersValue, boolean expectingHicn, boolean expectingMbi) {
+
     List<Object> loadedRecords =
         ServerTestUtils.loadData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
     IGenericClient fhirClient = ServerTestUtils.createFhirClient();
     ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
-    extraParamsInterceptor.setIncludeIdentifiers("hicn,mbi");
+    extraParamsInterceptor.setIncludeIdentifiers(includeIdentifiersValue);
     fhirClient.registerInterceptor(extraParamsInterceptor);
 
     Beneficiary beneficiary =
@@ -90,15 +185,19 @@ public final class PatientResourceProviderIT {
         mbiUnhashedPresent = true;
     }
 
-    Assert.assertTrue(hicnUnhashedPresent);
-    Assert.assertTrue(mbiUnhashedPresent);
+    if (expectingHicn) Assert.assertTrue(hicnUnhashedPresent);
+    else Assert.assertFalse(hicnUnhashedPresent);
+
+    if (expectingMbi) Assert.assertTrue(mbiUnhashedPresent);
+    else Assert.assertFalse(mbiUnhashedPresent);
   }
 
   /**
    * Verifies that {@link
    * gov.cms.bfd.server.war.stu3.providers.PatientResourceProvider#read(org.hl7.fhir.dstu3.model.IdType)}
    * works as expected for a {@link Patient} that does exist in the DB but has no {@link
-   * BeneficiaryHistory} or {@link MedicareBeneficiaryIdHistory} records.
+   * BeneficiaryHistory} or {@link MedicareBeneficiaryIdHistory} records when include identifiers
+   * value = ["true"].
    */
   @Test
   public void readExistingPatientWithNoHistoryIncludeIdentifiersTrue() {
@@ -106,7 +205,7 @@ public final class PatientResourceProviderIT {
         ServerTestUtils.loadData(Arrays.asList(StaticRifResource.SAMPLE_A_BENES));
     IGenericClient fhirClient = ServerTestUtils.createFhirClient();
     ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
-    extraParamsInterceptor.setIncludeIdentifiers("hicn,mbi");
+    extraParamsInterceptor.setIncludeIdentifiers("true");
     fhirClient.registerInterceptor(extraParamsInterceptor);
 
     Beneficiary beneficiary =
@@ -139,52 +238,6 @@ public final class PatientResourceProviderIT {
 
     Assert.assertTrue(hicnUnhashedPresent);
     Assert.assertTrue(mbiUnhashedPresent);
-  }
-
-  /**
-   * Verifies that {@link
-   * gov.cms.bfd.server.war.stu3.providers.PatientResourceProvider#read(org.hl7.fhir.dstu3.model.IdType)}
-   * works as expected for a {@link Patient} that does exist in the DB.
-   */
-  @Test
-  public void readExistingPatientIncludeIdentifiersFalse() {
-    List<Object> loadedRecords =
-        ServerTestUtils.loadData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
-    IGenericClient fhirClient = ServerTestUtils.createFhirClient();
-    ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
-    extraParamsInterceptor.setIncludeIdentifiers("false");
-    fhirClient.registerInterceptor(extraParamsInterceptor);
-
-    Beneficiary beneficiary =
-        loadedRecords.stream()
-            .filter(r -> r instanceof Beneficiary)
-            .map(r -> (Beneficiary) r)
-            .findFirst()
-            .get();
-    Patient patient =
-        fhirClient.read().resource(Patient.class).withId(beneficiary.getBeneficiaryId()).execute();
-
-    Assert.assertNotNull(patient);
-    BeneficiaryTransformerTest.assertMatches(beneficiary, patient);
-
-    /*
-     * Ensure the unhashed values for HICN and MBI are *not* present.
-     */
-    Boolean hicnUnhashedPresent = false;
-    Boolean mbiUnhashedPresent = false;
-    Iterator<Identifier> identifiers = patient.getIdentifier().iterator();
-    while (identifiers.hasNext()) {
-      Identifier identifier = identifiers.next();
-      if (identifier.getSystem().equals(TransformerConstants.CODING_BBAPI_BENE_HICN_UNHASHED))
-        hicnUnhashedPresent = true;
-      if (identifier
-          .getSystem()
-          .equals(TransformerConstants.CODING_BBAPI_MEDICARE_BENEFICIARY_ID_UNHASHED))
-        mbiUnhashedPresent = true;
-    }
-
-    Assert.assertFalse(hicnUnhashedPresent);
-    Assert.assertFalse(mbiUnhashedPresent);
   }
 
   /**
@@ -253,7 +306,7 @@ public final class PatientResourceProviderIT {
         ServerTestUtils.loadData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
     IGenericClient fhirClient = ServerTestUtils.createFhirClient();
     ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
-    extraParamsInterceptor.setIncludeIdentifiers("hicn,mbi");
+    extraParamsInterceptor.setIncludeIdentifiers("true");
     fhirClient.registerInterceptor(extraParamsInterceptor);
 
     Beneficiary beneficiary =
@@ -465,7 +518,7 @@ public final class PatientResourceProviderIT {
         ServerTestUtils.loadData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
     IGenericClient fhirClient = ServerTestUtils.createFhirClient();
     ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
-    extraParamsInterceptor.setIncludeIdentifiers("hicn,mbi");
+    extraParamsInterceptor.setIncludeIdentifiers("true");
     fhirClient.registerInterceptor(extraParamsInterceptor);
 
     Beneficiary beneficiary =
@@ -891,7 +944,7 @@ public final class PatientResourceProviderIT {
         ServerTestUtils.loadData(Arrays.asList(StaticRifResource.SAMPLE_A_BENES));
     IGenericClient fhirClient = ServerTestUtils.createFhirClient();
     ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
-    extraParamsInterceptor.setIncludeIdentifiers("hicn,mbi");
+    extraParamsInterceptor.setIncludeIdentifiers("true");
     fhirClient.registerInterceptor(extraParamsInterceptor);
 
     loadedRecords.stream()
@@ -1013,7 +1066,7 @@ public final class PatientResourceProviderIT {
         ServerTestUtils.loadData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
     IGenericClient fhirClient = ServerTestUtils.createFhirClient();
     ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
-    extraParamsInterceptor.setIncludeIdentifiers("hicn,mbi");
+    extraParamsInterceptor.setIncludeIdentifiers("true");
     fhirClient.registerInterceptor(extraParamsInterceptor);
 
     Beneficiary beneficiary =
@@ -1443,7 +1496,7 @@ public final class PatientResourceProviderIT {
         ServerTestUtils.loadData(Arrays.asList(StaticRifResource.SAMPLE_A_BENES));
     IGenericClient fhirClient = ServerTestUtils.createFhirClient();
     ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
-    extraParamsInterceptor.setIncludeIdentifiers("hicn,mbi");
+    extraParamsInterceptor.setIncludeIdentifiers("true");
     fhirClient.registerInterceptor(extraParamsInterceptor);
 
     loadedRecords.stream()

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProviderIT.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProviderIT.java
@@ -2,6 +2,7 @@ package gov.cms.bfd.server.war.stu3.providers;
 
 import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import gov.cms.bfd.model.rif.Beneficiary;
 import gov.cms.bfd.model.rif.BeneficiaryHistory;
@@ -51,7 +52,7 @@ public final class PatientResourceProviderIT {
   /**
    * Verifies that {@link
    * gov.cms.bfd.server.war.stu3.providers.PatientResourceProvider#read(org.hl7.fhir.dstu3.model.IdType)}
-   * works as expected for a {@link Patient} when include identifiers value = ["true"].
+   * works as expected for a {@link Patient} when include identifiers value = "true".
    */
   @Test
   public void readExistingPatientIncludeIdentifiersTrue() {
@@ -66,7 +67,7 @@ public final class PatientResourceProviderIT {
   /**
    * Verifies that {@link
    * gov.cms.bfd.server.war.stu3.providers.PatientResourceProvider#read(org.hl7.fhir.dstu3.model.IdType)}
-   * works as expected for a {@link Patient} when include identifiers value = ["hicn,mbi"].
+   * works as expected for a {@link Patient} when include identifiers value = "hicn,mbi".
    */
   @Test
   public void readExistingPatientIncludeIdentifiersHicnMbi() {
@@ -81,7 +82,7 @@ public final class PatientResourceProviderIT {
   /**
    * Verifies that {@link
    * gov.cms.bfd.server.war.stu3.providers.PatientResourceProvider#read(org.hl7.fhir.dstu3.model.IdType)}
-   * works as expected for a {@link Patient} when include identifiers value = ["hicn"].
+   * works as expected for a {@link Patient} when include identifiers value = "hicn".
    */
   @Test
   public void readExistingPatientIncludeIdentifiersHicn() {
@@ -96,7 +97,7 @@ public final class PatientResourceProviderIT {
   /**
    * Verifies that {@link
    * gov.cms.bfd.server.war.stu3.providers.PatientResourceProvider#read(org.hl7.fhir.dstu3.model.IdType)}
-   * works as expected for a {@link Patient} when include identifiers value = ["mbi"].
+   * works as expected for a {@link Patient} when include identifiers value = "mbi".
    */
   @Test
   public void readExistingPatientIncludeIdentifiersMbi() {
@@ -111,7 +112,7 @@ public final class PatientResourceProviderIT {
   /**
    * Verifies that {@link
    * gov.cms.bfd.server.war.stu3.providers.PatientResourceProvider#read(org.hl7.fhir.dstu3.model.IdType)}
-   * works as expected for a {@link Patient} when include identifiers value = ["false"].
+   * works as expected for a {@link Patient} when include identifiers value = "false".
    */
   @Test
   public void readExistingPatientIncludeIdentifiersFalse() {
@@ -126,11 +127,43 @@ public final class PatientResourceProviderIT {
   /**
    * Verifies that {@link
    * gov.cms.bfd.server.war.stu3.providers.PatientResourceProvider#read(org.hl7.fhir.dstu3.model.IdType)}
-   * works as expected for a {@link Patient} when include identifiers value = [""].
+   * works as expected for a {@link Patient} when include identifiers value = "".
    */
   @Test
   public void readExistingPatientIncludeIdentifiersBlank() {
     String includeIdentifiersValue = "";
+    boolean expectingHicn = false;
+    boolean expectingMbi = false;
+
+    assertExistingPatientIncludeIdentifiersExpected(
+        includeIdentifiersValue, expectingHicn, expectingMbi);
+  }
+
+  /**
+   * Verifies that {@link
+   * gov.cms.bfd.server.war.stu3.providers.PatientResourceProvider#read(org.hl7.fhir.dstu3.model.IdType)}
+   * works as expected for a {@link Patient} when include identifiers value =
+   * "invalid-identifier-value" and that an exception is thrown.
+   */
+  @Test(expected = InvalidRequestException.class)
+  public void readExistingPatientIncludeIdentifiersInvalid1() {
+    String includeIdentifiersValue = "invalid-identifier-value";
+    boolean expectingHicn = false;
+    boolean expectingMbi = false;
+
+    assertExistingPatientIncludeIdentifiersExpected(
+        includeIdentifiersValue, expectingHicn, expectingMbi);
+  }
+
+  /**
+   * Verifies that {@link
+   * gov.cms.bfd.server.war.stu3.providers.PatientResourceProvider#read(org.hl7.fhir.dstu3.model.IdType)}
+   * works as expected for a {@link Patient} when include identifiers value =
+   * ["mbi,invalid-identifier-value"] and that an exception is thrown.
+   */
+  @Test(expected = InvalidRequestException.class)
+  public void readExistingPatientIncludeIdentifiersInvalid2() {
+    String includeIdentifiersValue = "mbi,invalid-identifier-value";
     boolean expectingHicn = false;
     boolean expectingMbi = false;
 

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/utils/EndpointJsonResponseComparatorIT.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/utils/EndpointJsonResponseComparatorIT.java
@@ -26,7 +26,6 @@ import gov.cms.bfd.server.war.stu3.providers.ExplanationOfBenefitResourceProvide
 import gov.cms.bfd.server.war.stu3.providers.ExtraParamsInterceptor;
 import gov.cms.bfd.server.war.stu3.providers.MedicareSegment;
 import gov.cms.bfd.server.war.stu3.providers.PatientResourceProvider;
-import gov.cms.bfd.server.war.stu3.providers.PatientResourceProvider.IncludeIdentifiersMode;
 import gov.cms.bfd.server.war.stu3.providers.TransformerConstants;
 import gov.cms.bfd.server.war.stu3.providers.TransformerUtils;
 import java.io.File;
@@ -322,8 +321,7 @@ public final class EndpointJsonResponseComparatorIT {
   /**
    * @return the results of the {@link
    *     PatientResourceProvider#read(org.hl7.fhir.dstu3.model.IdType)} operation when {@link
-   *     ExtraParamsInterceptor#setIncludeIdentifiers(IncludeIdentifiersMode)} set to {@link
-   *     IncludeIdentifiersMode#INCLUDE_HICNS_AND_MBIS}
+   *     ExtraParamsInterceptor#setIncludeIdentifiers(IncludeIdentifiersValues)} set to "hicn,mbi"
    */
   public static String patientReadWithIncludeIdentifiers() {
     List<Object> loadedRecords =
@@ -337,7 +335,7 @@ public final class EndpointJsonResponseComparatorIT {
 
     IGenericClient fhirClient = createFhirClientAndSetEncoding();
     ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
-    extraParamsInterceptor.setIncludeIdentifiers(IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS);
+    extraParamsInterceptor.setIncludeIdentifiers("hicn,mbi");
     fhirClient.registerInterceptor(extraParamsInterceptor);
     JsonInterceptor jsonInterceptor = createAndRegisterJsonInterceptor(fhirClient);
 
@@ -374,8 +372,8 @@ public final class EndpointJsonResponseComparatorIT {
   /**
    * @return the results of the {@link
    *     PatientResourceProvider#searchByLogicalId(ca.uhn.fhir.rest.param.TokenParam)} operation
-   *     when {@link ExtraParamsInterceptor#setIncludeIdentifiers(IncludeIdentifiersMode)} set to
-   *     {@link IncludeIdentifiersMode#INCLUDE_HICNS_AND_MBIS}
+   *     when {@link ExtraParamsInterceptor#setIncludeIdentifiers(IncludeIdentifiersValues)} set to
+   *     "hicn, mbi"
    */
   public static String patientSearchByIdWithIncludeIdentifiers() {
     List<Object> loadedRecords =
@@ -389,7 +387,7 @@ public final class EndpointJsonResponseComparatorIT {
 
     IGenericClient fhirClient = createFhirClientAndSetEncoding();
     ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
-    extraParamsInterceptor.setIncludeIdentifiers(IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS);
+    extraParamsInterceptor.setIncludeIdentifiers("hicn,mbi");
     fhirClient.registerInterceptor(extraParamsInterceptor);
     JsonInterceptor jsonInterceptor = createAndRegisterJsonInterceptor(fhirClient);
 
@@ -435,8 +433,8 @@ public final class EndpointJsonResponseComparatorIT {
   /**
    * @return the results of the {@link
    *     PatientResourceProvider#searchByIdentifier(ca.uhn.fhir.rest.param.TokenParam)} operation
-   *     when {@link ExtraParamsInterceptor#setIncludeIdentifiers(IncludeIdentifiersMode)} set to
-   *     {@link IncludeIdentifiersMode#INCLUDE_HICNS_AND_MBIS}
+   *     when {@link ExtraParamsInterceptor#setIncludeIdentifiers(IncludeIdentifiersValues)} set to
+   *     "hicn,mbi"
    */
   public static String patientByIdentifierWithIncludeIdentifiers() {
     List<Object> loadedRecords =
@@ -450,7 +448,7 @@ public final class EndpointJsonResponseComparatorIT {
 
     IGenericClient fhirClient = createFhirClientAndSetEncoding();
     ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
-    extraParamsInterceptor.setIncludeIdentifiers(IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS);
+    extraParamsInterceptor.setIncludeIdentifiers("hicn,mbi");
     fhirClient.registerInterceptor(extraParamsInterceptor);
     JsonInterceptor jsonInterceptor = createAndRegisterJsonInterceptor(fhirClient);
 

--- a/apps/bfd-server/dev/api-changelog.md
+++ b/apps/bfd-server/dev/api-changelog.md
@@ -1,5 +1,27 @@
 # API Changelog
 
+## BLUEBUTTON-1536: Extend `IncludeIdentifiers` header options for the Patient Resource
+
+The `IncludeIdentifiers` header has been extended to handle values of [ "true", "hicn", "mbi' ]. 
+
+To enable this, set an "`IncludeIdentifiers: <value>`" HTTP header in the `/Patient` request.
+
+Multiple values can be seperated by a comma (","). For example, "`IncludeIdentifiers: hicn,mbi`" .
+
+The following table describes the response behaviors:
+
+
+HEADER: IncludeIdentifier | Response Behavior
+--- | ---
+\<blank\> | omit HICN and MBI
+false | omit HICN and MBI
+true | include HICN and MBI
+hicn | include HICN
+mbi | include MBI
+hicn,mbi or mbi,hicn | include HICN and MBI
+\<any\> | omit HICN and MBI
+
+
 ## BLUEBUTTON-1516: Support searching the Patient resource by hashed MBI
 
 The Patient resource supports searching by a hashed MBI identifier:


### PR DESCRIPTION
### Change Details

Summary:

This PR extends the `IncludeIdentifiers` request header values for returning just "mbi" or "hicn" behaviors in the Patient Resource, and retains the default "true" behavior to return mbi and hicn.

NOTE: The code was refactored to replace the `PatientResourceProvider.IncludeIdentifiersMode` ENUM that had two states:  `INCLUDE_HICNS_AND_MBIS` and `OMIT_HICNS_AND_MBIS`. This was change to utilize a List `includeIdentifiersValues` instead that has valid values:  [ "true", "hicn", "mbi' ]. This was done to make the code more readable and simplify the logic.

The following tasks were performed:

* Created a `PatientResourceProvider.returnIncludeIdentifiersValues()` method to return a `List<String>` of validated request header values from   [ "true", "hicn", "mbi' ].
* Added  `hasMBI()` and `hasHICN` methods to `PatientResourceProvider` class that provide decision logic that is more readable.
* Updated the `PatientResourceProvider.read()` method to utilize `PatientResourceProvider`  `hasMBI()` and `hasHICN()` methods for the include identifiers related logic.
* Updated the `BeneficiaryTransformer.transform()` method to use `PatientResourceProvider`   `hasMBI()` and `hasHICN()` methods for controlling which identifiers are returned in the transformation.
* Updated the `BeneficiaryTransformerTest` class to test include identifiers behaviors and to verify the transformed identifier counts and values.
* Updated the `ExtraParamsInterceptor.interceptRequest()` to add header values in support of IT testing.
* Added messages to asserts in `BeneficiaryTransformerTest` class.
* Changed expected request header values to lower case to be more standard.
* Updated to simplify the logic by allowing multiple `IncludeIdentifiers` header values. For example, "hicn,mbi" for returning both hicn & mbi. This follows  https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2 that describes the spec for handling headers that contain multiple values.  However, `ca.uhn.fhir.rest.api.server.RequestDetails.getHeader()` does not support the case with multiple  `IncludeIdentifiers` header entries. It will return the first instance of the header and it's value.
* Added a change entry to the apps/bfd-server/dev/api-changelog.md
* Update IT tests in the `PatientResourceProviderIT` class.
* Updated to throw a InvalidRequest exception (400) for invalid header values.


### `IncludeIdentifiers` Header Values:

HEADER: IncludeIdentifier | Response Behavior
-- | --
\<header not included\> | omit HICN and MBI
\<blank\> | omit HICN and MBI
false | omit HICN and MBI
true | include HICN and MBI
hicn | include HICN
mbi | include MBI
hicn,mbi or mbi,hicn | include HICN and MBI
\<any invalid value\> | Throws a InvalidRequest exception (400)



### Acceptance Validation

* Patient resource requests with the `IncludeIdentifiers` "true" header value should return both MBI and HICN (the current behavior). Another PR will be created for the new behavior.
* Patient resource requests with the `IncludeIdentifiers` header matching valid values (see confluence table) return the correct results.

### Feedback Requested

* Can the naming of things be improved?
* Can the code be more readable?

### Remaining Work

### External References

* [BLUEBUTTON-1536](https://jira.cms.gov/browse/BLUEBUTTON-1536)
* `IncludeIdentifiers` header values table:  https://confluence.cms.gov/display/BB/Blue+Button+Identifier+Options
