### PR TITLE
BLUEBUTTON-1727-Revert-Dev-Migration

### DIFF
--- a/apps/bfd-model/bfd-model-rif/src/main/resources/db/scripts/Flyway_revert_v21_Add_lastUpdated.sql
+++ b/apps/bfd-model/bfd-model-rif/src/main/resources/db/scripts/Flyway_revert_v21_Add_lastUpdated.sql
@@ -1,6 +1,8 @@
 /*
+ * APPLY ONLY TO THE TEST DATABASE
+ *
  * Reverts the original version of the V21 migration, which was done in a developer
- * experimental branch, but didn't get into the master branch.
+ * experimental branch, but didn't get into the master branch. 
  *
  * Note: In general, this is a bad idea, but another V21 migration made it into
  * production, so removing this migration was thought as the best fix. See the v19 goof

--- a/apps/bfd-model/bfd-model-rif/src/main/resources/db/scripts/Flyway_revert_v21_Add_lastUpdated.sql
+++ b/apps/bfd-model/bfd-model-rif/src/main/resources/db/scripts/Flyway_revert_v21_Add_lastUpdated.sql
@@ -1,0 +1,38 @@
+/*
+ * Reverts the original version of the V21 migration, which was done in a developer
+ * experimental branch, but didn't get into the master branch.
+ *
+ * Note: In general, this is a bad idea, but another V21 migration made it into
+ * production, so removing this migration was thought as the best fix. See the v19 goof
+ * for a similar situation.
+ *
+ * See: https://jira.cms.gov/browse/BLUEBUTTON-1727
+ */
+
+BEGIN;
+
+ALTER TABLE "Beneficiaries" DROP COLUMN "lastupdated";
+
+ALTER TABLE "BeneficiariesHistory" DROP COLUMN "lastupdated";
+
+ALTER TABLE "CarrierClaims" DROP COLUMN "lastupdated";
+
+ALTER TABLE "DMEClaims" DROP COLUMN "lastupdated";
+
+ALTER TABLE "HHAClaims" DROP COLUMN "lastupdated";
+
+ALTER TABLE "HospiceClaims" DROP COLUMN "lastupdated";
+
+ALTER TABLE "InpatientClaims" DROP COLUMN "lastupdated";
+
+ALTER TABLE "MedicareBeneficiaryIdHistory" DROP COLUMN "lastupdated";
+
+ALTER TABLE "OutpatientClaims" DROP COLUMN "lastupdated";
+
+ALTER TABLE "PartDEvents" DROP COLUMN "lastupdated";
+
+ALTER TABLE "SNFClaims" DROP COLUMN "lastupdated";
+
+DELETE FROM schema_version WHERE script = 'V21__Add_lastUpdated_columns.sql';
+
+COMMIT;

--- a/apps/bfd-model/bfd-model-rif/src/main/resources/db/scripts/Flyway_revert_v22_Add_bene_views.sql
+++ b/apps/bfd-model/bfd-model-rif/src/main/resources/db/scripts/Flyway_revert_v22_Add_bene_views.sql
@@ -1,0 +1,26 @@
+/*
+ * Reverts the original version of the V22 migration, which was done in a developer
+ * experimental branch, but didn't get into the master branch.
+ *
+ * Note: In general, this is a bad idea, but another V22 migration made it into
+ * production, so removing this migration was thought as the best fix. See the v19 goof
+ * for a similar situation.
+ *
+ * See: https://jira.cms.gov/browse/BLUEBUTTON-1727
+ */
+
+BEGIN;
+
+DROP VIEW claims_partd;
+
+DROP VIEW benes_monthly;
+
+DROP VIEW benes_mbis;
+
+DROP VIEW benes_hicns;
+
+DROP VIEW benes;
+
+DELETE FROM schema_version WHERE script = 'V22__Add_Beneficiary_and_PartD_views.sql';
+
+COMMIT;


### PR DESCRIPTION
**Why**
To fix the TEST environment.

The current TEST database has a couple of migrations from developer experimental branches applied to it that conflict with the current migration set in the master branch. 

**What**
These SQL scripts will remove the developer migrations which were non-destructive types of migrations. 

**Deployment**
Note: These scripts will only work in TEST. 
1. These scripts will be applied by hand to the TEST database.
2. Redeploy master branch to TEST

**Security**
NA