### PR TITLE
BLUEBUTTON-1516: Add feature flag for MBI fixups

### DIFF
--- a/apps/bfd-pipeline/bfd-pipeline-app/src/main/java/gov/cms/bfd/pipeline/app/AppConfiguration.java
+++ b/apps/bfd-pipeline/bfd-pipeline-app/src/main/java/gov/cms/bfd/pipeline/app/AppConfiguration.java
@@ -82,6 +82,12 @@ public final class AppConfiguration implements Serializable {
    */
   public static final String ENV_VAR_KEY_IDEMPOTENCY_REQUIRED = "IDEMPOTENCY_REQUIRED";
 
+  /**
+   * The name of the environment variable that should be used to provide the {@link
+   * #getLoadOptions()} {@link LoadAppOptions#isFixupsEnabled()} value.
+   */
+  public static final String ENV_VAR_KEY_FIXUPS_ENABLED = "FIXUPS_ENABLED";
+
   private final ExtractionOptions extractionOptions;
   private final LoadAppOptions loadOptions;
 
@@ -243,6 +249,12 @@ public final class AppConfiguration implements Serializable {
               "Invalid value for configuration environment variable '%s'.",
               ENV_VAR_KEY_IDEMPOTENCY_REQUIRED));
 
+    String fixupsEnabledText = System.getenv(ENV_VAR_KEY_FIXUPS_ENABLED);
+    boolean fixupsEnabled = false;
+    if (fixupsEnabledText != null && !fixupsEnabledText.isEmpty()) {
+      fixupsEnabled = Boolean.parseBoolean(fixupsEnabledText);
+    }
+
     /*
      * Just for convenience: make sure DefaultAWSCredentialsProviderChain
      * has whatever it needs.
@@ -272,7 +284,8 @@ public final class AppConfiguration implements Serializable {
             databaseUsername,
             databasePassword.toCharArray(),
             loaderThreads,
-            idempotencyRequired.get()));
+            idempotencyRequired.get().booleanValue(),
+            fixupsEnabled));
   }
 
   /**

--- a/apps/bfd-pipeline/bfd-pipeline-rif-load/src/main/java/gov/cms/bfd/pipeline/rif/load/LoadAppOptions.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rif-load/src/main/java/gov/cms/bfd/pipeline/rif/load/LoadAppOptions.java
@@ -28,6 +28,7 @@ public final class LoadAppOptions implements Serializable {
   private final DataSource databaseDataSource;
   private final int loaderThreads;
   private final boolean idempotencyRequired;
+  private final boolean fixupsEnabled;
 
   /**
    * Constructs a new {@link LoadAppOptions} instance.
@@ -39,6 +40,7 @@ public final class LoadAppOptions implements Serializable {
    * @param databasePassword the value to use for {@link #getDatabasePassword()}
    * @param loaderThreads the value to use for {@link #getLoaderThreads()}
    * @param idempotencyRequired the value to use for {@link #isIdempotencyRequired()}
+   * @param fixupsEnabled the value to use for {@link #isFixupsEnabled()}
    */
   public LoadAppOptions(
       int hicnHashIterations,
@@ -47,7 +49,8 @@ public final class LoadAppOptions implements Serializable {
       String databaseUsername,
       char[] databasePassword,
       int loaderThreads,
-      boolean idempotencyRequired) {
+      boolean idempotencyRequired,
+      boolean fixupsEnabled) {
     if (loaderThreads < 1) throw new IllegalArgumentException();
 
     this.hicnHashIterations = hicnHashIterations;
@@ -58,6 +61,7 @@ public final class LoadAppOptions implements Serializable {
     this.databaseDataSource = null;
     this.loaderThreads = loaderThreads;
     this.idempotencyRequired = idempotencyRequired;
+    this.fixupsEnabled = fixupsEnabled;
   }
 
   /**
@@ -68,13 +72,15 @@ public final class LoadAppOptions implements Serializable {
    * @param databaseDataSource the value to use for {@link #getDatabaseDataSource()}
    * @param loaderThreads the value to use for {@link #getLoaderThreads()}
    * @param idempotencyRequired the value to use for {@link #isIdempotencyRequired()}
+   * @param fixupsEnabled the value to use for {@link #isFixupsEnabled()}
    */
   public LoadAppOptions(
       int hicnHashIterations,
       byte[] hicnHashPepper,
       DataSource databaseDataSource,
       int loaderThreads,
-      boolean idempotencyRequired) {
+      boolean idempotencyRequired,
+      boolean fixupsEnabled) {
     if (loaderThreads < 1) throw new IllegalArgumentException();
 
     this.hicnHashIterations = hicnHashIterations;
@@ -85,6 +91,7 @@ public final class LoadAppOptions implements Serializable {
     this.databaseDataSource = databaseDataSource;
     this.loaderThreads = loaderThreads;
     this.idempotencyRequired = idempotencyRequired;
+    this.fixupsEnabled = fixupsEnabled;
   }
 
   /**
@@ -155,6 +162,15 @@ public final class LoadAppOptions implements Serializable {
     return idempotencyRequired;
   }
 
+  /**
+   * Feature flag for fixups processing
+   *
+   * @return is enabled
+   */
+  public boolean isFixupsEnabled() {
+    return fixupsEnabled;
+  }
+
   /** @see java.lang.Object#toString() */
   @Override
   public String toString() {
@@ -175,6 +191,8 @@ public final class LoadAppOptions implements Serializable {
     builder.append(loaderThreads);
     builder.append(", idempotencyRequired=");
     builder.append(idempotencyRequired);
+    builder.append(", fixupEnabled=");
+    builder.append(fixupsEnabled);
     builder.append("]");
     return builder.toString();
   }

--- a/apps/bfd-pipeline/bfd-pipeline-rif-load/src/main/java/gov/cms/bfd/pipeline/rif/load/RifLoaderTestUtils.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rif-load/src/main/java/gov/cms/bfd/pipeline/rif/load/RifLoaderTestUtils.java
@@ -20,6 +20,9 @@ public final class RifLoaderTestUtils {
   /** The value to use for {@link LoadAppOptions#isIdempotencyRequired()}. */
   public static final boolean IDEMPOTENCY_REQUIRED = true;
 
+  /** The value to use for {@link LoadAppOptions#isFixupsEnabled()} */
+  public static final boolean FIXUPS_ENABLED = true;
+
   /**
    * @param dataSource a {@link DataSource} for the test DB to connect to
    * @return the {@link LoadAppOptions} that should be used in tests, which specifies how to connect
@@ -31,7 +34,8 @@ public final class RifLoaderTestUtils {
         HICN_HASH_PEPPER,
         dataSource,
         LoadAppOptions.DEFAULT_LOADER_THREADS,
-        IDEMPOTENCY_REQUIRED);
+        IDEMPOTENCY_REQUIRED,
+        FIXUPS_ENABLED);
   }
 
   /**

--- a/apps/bfd-pipeline/bfd-pipeline-rif-load/src/test/java/gov/cms/bfd/pipeline/rif/load/RifLoaderIT.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rif-load/src/test/java/gov/cms/bfd/pipeline/rif/load/RifLoaderIT.java
@@ -430,12 +430,16 @@ public final class RifLoaderIT {
             null,
             (em, start) -> {
               for (final Beneficiary b :
-                  em.createQuery("select b from Beneficiary b", Beneficiary.class)
+                  em.createQuery(
+                          "select b from Beneficiary b where b.mbiHash is not null",
+                          Beneficiary.class)
                       .getResultList()) {
                 b.setMbiHash(Optional.empty());
               }
               for (final BeneficiaryHistory b :
-                  em.createQuery("select b from BeneficiaryHistory b", BeneficiaryHistory.class)
+                  em.createQuery(
+                          "select b from BeneficiaryHistory b where b.mbiHash is not null",
+                          BeneficiaryHistory.class)
                       .getResultList()) {
                 b.setMbiHash(Optional.empty());
               }

--- a/apps/bfd-pipeline/bfd-pipeline-rif-load/src/test/java/gov/cms/bfd/pipeline/rif/load/RifLoaderTest.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rif-load/src/test/java/gov/cms/bfd/pipeline/rif/load/RifLoaderTest.java
@@ -30,7 +30,8 @@ public final class RifLoaderTest {
             options.getDatabaseUsername(),
             options.getDatabasePassword(),
             options.getLoaderThreads(),
-            options.isIdempotencyRequired());
+            options.isIdempotencyRequired(),
+            options.isFixupsEnabled());
     LOGGER.info(
         "salt/pepper: {}", Arrays.toString("nottherealpepper".getBytes(StandardCharsets.UTF_8)));
     LOGGER.info("hash iterations: {}", 1000);
@@ -65,7 +66,8 @@ public final class RifLoaderTest {
             options.getDatabaseUsername(),
             options.getDatabasePassword(),
             options.getLoaderThreads(),
-            options.isIdempotencyRequired());
+            options.isIdempotencyRequired(),
+            options.isFixupsEnabled());
     LOGGER.info(
         "salt/pepper: {}", Arrays.toString("nottherealpepper".getBytes(StandardCharsets.UTF_8)));
     LOGGER.info("hash iterations: {}", 1000);

--- a/apps/bfd-pipeline/bfd-pipeline-rif-load/src/test/resources/logback-test.xml
+++ b/apps/bfd-pipeline/bfd-pipeline-rif-load/src/test/resources/logback-test.xml
@@ -12,6 +12,9 @@
 	<!-- At 'debug', Hibernate will log SQL statements. -->
 	<logger name="org.hibernate.SQL" level="info" />
 
+  <!-- At 'debug', load a rif -->
+	<logger name="gov.cms.bfd.pipeline.rif.load" level="debug" />
+
 	<!-- At 'trace', Hibernate will log SQL parameter values. -->
 	<logger name="org.hibernate.type" level="info" />
 	

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/ServerTestUtils.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/ServerTestUtils.java
@@ -348,7 +348,8 @@ public final class ServerTestUtils {
         RifLoaderTestUtils.HICN_HASH_PEPPER,
         dataSource,
         LoadAppOptions.DEFAULT_LOADER_THREADS,
-        RifLoaderTestUtils.IDEMPOTENCY_REQUIRED);
+        RifLoaderTestUtils.IDEMPOTENCY_REQUIRED,
+        RifLoaderTestUtils.FIXUPS_ENABLED);
   }
 
   /**


### PR DESCRIPTION
**Why**
The current mbiHash fixup feature is not working in PROD (works elsewhere) and is causing errors in the PROD logs. This feature flag disables the fixup feature so the logs are clear. It also increases the debugging level to assist in debugging the problem. 

**What Changed**
Added a feature flag `FIXUPS_ENABLED` to the configuration of the pipeline application. Defaults to false. MBI hash fixups are only run if the FIXUPS_ENABLED=true. 

**Security Implications**
N/A