### PR TITLE
BLUEBUTTON-1516: Faster fixups

### DIFF
--- a/apps/bfd-pipeline/bfd-pipeline-app/src/main/java/gov/cms/bfd/pipeline/app/AppConfiguration.java
+++ b/apps/bfd-pipeline/bfd-pipeline-app/src/main/java/gov/cms/bfd/pipeline/app/AppConfiguration.java
@@ -6,6 +6,7 @@ import gov.cms.bfd.model.rif.RifFileType;
 import gov.cms.bfd.pipeline.rif.extract.ExtractionOptions;
 import gov.cms.bfd.pipeline.rif.extract.s3.DataSetManifest;
 import gov.cms.bfd.pipeline.rif.load.LoadAppOptions;
+import gov.cms.bfd.pipeline.rif.load.RifLoaderIdleTasks;
 import java.io.Serializable;
 import java.util.Optional;
 import org.apache.commons.codec.DecoderException;
@@ -87,6 +88,12 @@ public final class AppConfiguration implements Serializable {
    * #getLoadOptions()} {@link LoadAppOptions#isFixupsEnabled()} value.
    */
   public static final String ENV_VAR_KEY_FIXUPS_ENABLED = "FIXUPS_ENABLED";
+
+  /**
+   * The name of the environment variable that should be used to provide the {@link
+   * #getLoadOptions()} {@link LoadAppOptions#getFixupThreads()} value.
+   */
+  public static final String ENV_VAR_KEY_FIXUP_THREADS = "FIXUP_THREADS";
 
   private final ExtractionOptions extractionOptions;
   private final LoadAppOptions loadOptions;
@@ -255,6 +262,12 @@ public final class AppConfiguration implements Serializable {
       fixupsEnabled = Boolean.parseBoolean(fixupsEnabledText);
     }
 
+    String fixupThreadsText = System.getenv(ENV_VAR_KEY_FIXUP_THREADS);
+    int fixupThreads = RifLoaderIdleTasks.DEFAULT_PARTITION_COUNT;
+    if (fixupThreadsText != null && !fixupThreadsText.isEmpty()) {
+      fixupThreads = Integer.parseInt(fixupThreadsText);
+    }
+
     /*
      * Just for convenience: make sure DefaultAWSCredentialsProviderChain
      * has whatever it needs.
@@ -285,7 +298,8 @@ public final class AppConfiguration implements Serializable {
             databasePassword.toCharArray(),
             loaderThreads,
             idempotencyRequired.get().booleanValue(),
-            fixupsEnabled));
+            fixupsEnabled,
+            fixupThreads));
   }
 
   /**

--- a/apps/bfd-pipeline/bfd-pipeline-app/src/main/resources/logback.xml
+++ b/apps/bfd-pipeline/bfd-pipeline-app/src/main/resources/logback.xml
@@ -12,6 +12,9 @@
 	<!-- At 'debug', Hibernate will log SQL statements. -->
 	<logger name="org.hibernate.SQL" level="info" />
 
+  <!-- At 'debug', will display timing information about the idle task batches -->
+	<logger name="gov.cms.bfd.pipeline.rif.load" level="debug" />
+	
 	<!-- At 'trace', Hibernate will log SQL parameter values. -->
 	<logger name="org.hibernate.type" level="info" />
 	

--- a/apps/bfd-pipeline/bfd-pipeline-rif-load/src/main/java/gov/cms/bfd/pipeline/rif/load/LoadAppOptions.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rif-load/src/main/java/gov/cms/bfd/pipeline/rif/load/LoadAppOptions.java
@@ -29,6 +29,7 @@ public final class LoadAppOptions implements Serializable {
   private final int loaderThreads;
   private final boolean idempotencyRequired;
   private final boolean fixupsEnabled;
+  private final int fixupThreads;
 
   /**
    * Constructs a new {@link LoadAppOptions} instance.
@@ -41,6 +42,7 @@ public final class LoadAppOptions implements Serializable {
    * @param loaderThreads the value to use for {@link #getLoaderThreads()}
    * @param idempotencyRequired the value to use for {@link #isIdempotencyRequired()}
    * @param fixupsEnabled the value to use for {@link #isFixupsEnabled()}
+   * @param fixupThreads the value fot use for {@link #getFixupThreads()}
    */
   public LoadAppOptions(
       int hicnHashIterations,
@@ -50,7 +52,8 @@ public final class LoadAppOptions implements Serializable {
       char[] databasePassword,
       int loaderThreads,
       boolean idempotencyRequired,
-      boolean fixupsEnabled) {
+      boolean fixupsEnabled,
+      int fixupThreads) {
     if (loaderThreads < 1) throw new IllegalArgumentException();
 
     this.hicnHashIterations = hicnHashIterations;
@@ -62,6 +65,7 @@ public final class LoadAppOptions implements Serializable {
     this.loaderThreads = loaderThreads;
     this.idempotencyRequired = idempotencyRequired;
     this.fixupsEnabled = fixupsEnabled;
+    this.fixupThreads = fixupThreads;
   }
 
   /**
@@ -73,6 +77,7 @@ public final class LoadAppOptions implements Serializable {
    * @param loaderThreads the value to use for {@link #getLoaderThreads()}
    * @param idempotencyRequired the value to use for {@link #isIdempotencyRequired()}
    * @param fixupsEnabled the value to use for {@link #isFixupsEnabled()}
+   * @param fixupThreads the value fot use for {@link #getFixupThreads()}
    */
   public LoadAppOptions(
       int hicnHashIterations,
@@ -80,7 +85,8 @@ public final class LoadAppOptions implements Serializable {
       DataSource databaseDataSource,
       int loaderThreads,
       boolean idempotencyRequired,
-      boolean fixupsEnabled) {
+      boolean fixupsEnabled,
+      int fixupThreads) {
     if (loaderThreads < 1) throw new IllegalArgumentException();
 
     this.hicnHashIterations = hicnHashIterations;
@@ -92,6 +98,7 @@ public final class LoadAppOptions implements Serializable {
     this.loaderThreads = loaderThreads;
     this.idempotencyRequired = idempotencyRequired;
     this.fixupsEnabled = fixupsEnabled;
+    this.fixupThreads = fixupThreads;
   }
 
   /**
@@ -171,6 +178,15 @@ public final class LoadAppOptions implements Serializable {
     return fixupsEnabled;
   }
 
+  /**
+   * Feature flag for fixups processing
+   *
+   * @return is enabled
+   */
+  public int getFixupThreads() {
+    return fixupThreads;
+  }
+
   /** @see java.lang.Object#toString() */
   @Override
   public String toString() {
@@ -193,6 +209,8 @@ public final class LoadAppOptions implements Serializable {
     builder.append(idempotencyRequired);
     builder.append(", fixupEnabled=");
     builder.append(fixupsEnabled);
+    builder.append(", fixupThreads=");
+    builder.append(fixupThreads);
     builder.append("]");
     return builder.toString();
   }

--- a/apps/bfd-pipeline/bfd-pipeline-rif-load/src/main/java/gov/cms/bfd/pipeline/rif/load/RifLoaderIdleTasks.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rif-load/src/main/java/gov/cms/bfd/pipeline/rif/load/RifLoaderIdleTasks.java
@@ -1,30 +1,29 @@
-/** */
 package gov.cms.bfd.pipeline.rif.load;
 
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
-import gov.cms.bfd.model.rif.Beneficiary;
-import gov.cms.bfd.model.rif.BeneficiaryHistory;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.function.BiFunction;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import javax.crypto.SecretKeyFactory;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
-import javax.persistence.EntityTransaction;
-import org.hibernate.ScrollMode;
-import org.hibernate.ScrollableResults;
-import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.StatelessSession;
+import org.hibernate.Transaction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,42 +32,43 @@ import org.slf4j.LoggerFactory;
  * class for the RifLoader. It is expected to have a 1-to-1 relationship to a RifLoader.
  */
 public class RifLoaderIdleTasks {
-  /** Parameters for the post startup tasks. Tuned for throughput. */
+  /*
+   * Developer Notes:
+   *
+   * This class was created to fixup the mbiHash field, but with idea there may be other
+   * maintenance tasks in future.
+   *
+   * There are about a billion mbiHash fields to fill. So time was spent to come up with
+   * a fast method to fixup fields. In the end, batching large number of updates and doing these
+   * batches in parallel worked well enough.
+   *
+   * There is a hierarchy in the names and concepts used in this class.
+   *
+   *  Task - the overall state and goal of the manager.
+   *  Time Slice - A fixed amount of time that the task can execute before it must return to the main thread.
+   *    A task can take many time slices to complete.
+   *  Executor - Within a time slice, work is given to an executor.
+   *    Instead of another interface, a generic Callable interface is used.
+   *  Partition - Fixup work is divide among partitions of a table.
+   *    Partitions are numbered 0 ... PARTITION_COUNT-1;
+   *    Each partition is given its own executor.
+   *  Batch - A group of records to update in one DB transaction. All records come from a single partition.
+   */
 
   /** Time slice that a task can take before returning/yielding to the main pipeline */
-  private static final int TASK_TIME_LIMIT_MILLIS = 9800;
+  private static final int TIME_SLICE_LIMIT_MILLIS = 10000;
 
-  private static final Duration TASK_TIME_LIMIT = Duration.ofMillis(TASK_TIME_LIMIT_MILLIS);
+  private static final Duration TIME_SLICE_LIMIT = Duration.ofMillis(TIME_SLICE_LIMIT_MILLIS);
 
   /** The record count of a db update batch */
-  private static final int BATCH_COUNT = 100;
+  private static final int BATCH_COUNT = 1000;
 
-  /** One thread for each query type */
-  private static final int THREAD_COUNT = 2;
+  /** How much to partition the table. */
+  private static final int PARTITION_COUNT = 10;
 
-  /** JPQL queries */
-  private static final String SELECT_UNHASHED_BENFICIARIES =
-      "select b from Beneficiary b "
-          + "where b.mbiHash is null and b.medicareBeneficiaryId is not null and "
-          + "b.medicareBeneficiaryId is not empty";
-
-  /** JPQL query for a count */
-  private static final String COUNT_UNHASHED_BENFICIARIES =
-      "select count(b) from Beneficiary b "
-          + "where b.mbiHash is null and b.medicareBeneficiaryId is not null and "
-          + "b.medicareBeneficiaryId is not empty";
-
-  /** JPQL query for a list */
-  private static final String SELECT_UNHASHED_HISTORIES =
-      "select b from BeneficiaryHistory b "
-          + "where b.mbiHash is null and b.medicareBeneficiaryId is not null and "
-          + "b.medicareBeneficiaryId is not empty";
-
-  /** JPQL query for a count */
-  private static final String COUNT_UNHASHED_HISTORIES =
-      "select count(b) from BeneficiaryHistory b "
-          + "where b.mbiHash is null and b.medicareBeneficiaryId is not null and "
-          + "b.medicareBeneficiaryId is not empty";
+  /** An executor list that does no work and always completes */
+  private static final List<Callable<Boolean>> NULL_EXECUTORS =
+      Collections.singletonList(() -> true);
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RifLoaderIdleTasks.class);
 
@@ -77,8 +77,14 @@ public class RifLoaderIdleTasks {
     /** The initial task which is executed after startup */
     INITIAL,
 
-    /** After the initial task, this task is run. */
+    /** After the initial task, this general fixup is run. */
     POST_STARTUP,
+
+    /** A sub-task to fixup Beneficiaries table */
+    POST_STARTUP_FIXUP_BENEFICIARIES,
+
+    /** A sub-task to fixup BeneficiariesHistory table */
+    POST_STARTUP_FIXUP_BENEFICIARY_HISTORY,
 
     /** Run the normal task */
     NORMAL,
@@ -119,7 +125,7 @@ public class RifLoaderIdleTasks {
     this.beneficaryMeter = appMetrics.meter("fixups.beneficiary.rate");
     this.historyMeter = appMetrics.meter("fixups.beneficiary_history.rate");
 
-    this.executorService = Executors.newFixedThreadPool(THREAD_COUNT);
+    this.executorService = Executors.newFixedThreadPool(PARTITION_COUNT);
   }
 
   /**
@@ -137,37 +143,103 @@ public class RifLoaderIdleTasks {
    * not interfer with RIF file processing.
    */
   public void doIdleTask() {
-    boolean isTaskDone;
-    switch (currentTask) {
-      case INITIAL:
-        isTaskDone = doInitialTask();
-        break;
-      case POST_STARTUP:
-        isTaskDone = doPostStartupTask();
-        break;
-      case NORMAL:
-        isTaskDone = doNormalTask();
-        break;
-      default:
-        throw new RuntimeException("Unexpected idle task");
-    }
+    List<Callable<Boolean>> executors = getTaskExecutors(currentTask);
+    boolean isTaskDone = doExecutors(executors);
     if (isTaskDone) {
-      setNextTask();
+      currentTask = getNextTask();
     }
   }
 
-  /** Set the currentTask to the next task after current task. */
-  private void setNextTask() {
+  /**
+   * Form a list of callables to execute.
+   *
+   * @return the callables associated with the current task
+   */
+  private List<Callable<Boolean>> getTaskExecutors(Task currentTask) {
     switch (currentTask) {
       case INITIAL:
-        currentTask = Task.POST_STARTUP;
-        break;
-
+        return Collections.singletonList(this::doInitialTask);
       case POST_STARTUP:
+        return NULL_EXECUTORS;
+      case POST_STARTUP_FIXUP_BENEFICIARIES:
+        return makeExecutorsForPartitions(this::fixupBeneficiaryExecutor);
+      case POST_STARTUP_FIXUP_BENEFICIARY_HISTORY:
+        return makeExecutorsForPartitions(this::fixupHistoryExecutor);
+      case NORMAL:
+        return NULL_EXECUTORS;
+      default:
+        throw new RuntimeException("Unexpected idle task state");
+    }
+  }
+
+  /**
+   * Form a list of executors, one for each partition
+   *
+   * @param executor for a single partition
+   * @return the list of executors
+   */
+  private List<Callable<Boolean>> makeExecutorsForPartitions(Function<Integer, Boolean> executor) {
+    return IntStream.range(0, PARTITION_COUNT)
+        .mapToObj((partition) -> (Callable<Boolean>) () -> executor.apply(partition))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Execute the work in parallel threads. Wait for all executors to complete.
+   *
+   * @param executors Callables to that do the work
+   */
+  private boolean doExecutors(List<Callable<Boolean>> executors) {
+    final Instant startTime = Instant.now();
+    LOGGER.debug("Started a time slice: {}", currentTask);
+
+    List<Future<Boolean>> futures =
+        executors.stream().map(executorService::submit).collect(Collectors.toList());
+
+    final boolean isTaskDone =
+        futures.stream()
+            .map(
+                future -> {
+                  try {
+                    return future.get(2 * TIME_SLICE_LIMIT_MILLIS, TimeUnit.MILLISECONDS);
+                  } catch (TimeoutException | ExecutionException | InterruptedException ex) {
+                    LOGGER.error("Error executing in sub-task {}", getCurrentTask());
+                    LOGGER.error("Exception executing a task", ex);
+                    return false;
+                  }
+                })
+            .reduce((a, b) -> a && b)
+            .orElse(true);
+
+    LOGGER.debug(
+        "Finished a time slice: {}, {} millis",
+        currentTask,
+        startTime.until(Instant.now(), ChronoUnit.MILLIS));
+    if (isTaskDone) {
+      LOGGER.info("Finished idle task: {}", currentTask);
+    }
+    return isTaskDone;
+  }
+
+  /** Return the next task given the current task. */
+  private Task getNextTask() {
+    switch (currentTask) {
+      case INITIAL:
+        return Task.POST_STARTUP;
+      case POST_STARTUP:
+        if (options.isFixupsEnabled()) {
+          return Task.POST_STARTUP_FIXUP_BENEFICIARIES;
+        } else {
+          LOGGER.info("PostStartup fixups are not enabled.");
+          return Task.NORMAL;
+        }
+      case POST_STARTUP_FIXUP_BENEFICIARIES:
+        return Task.POST_STARTUP_FIXUP_BENEFICIARY_HISTORY;
+      case POST_STARTUP_FIXUP_BENEFICIARY_HISTORY:
+        return Task.NORMAL;
       case NORMAL:
       default:
-        currentTask = Task.NORMAL;
-        break;
+        return Task.NORMAL;
     }
   }
 
@@ -178,10 +250,18 @@ public class RifLoaderIdleTasks {
    */
   public boolean doInitialTask() {
     final EntityManager em = entityManagerFactory.createEntityManager();
+
     final Long beneficiaryCount =
-        em.createQuery(COUNT_UNHASHED_BENFICIARIES, Long.class).getSingleResult();
+        em.createQuery(
+                "select count(*) from Beneficiary where mbiHash is null and medicareBeneficiaryId is not null",
+                Long.class)
+            .getSingleResult();
+
     final Long historyCount =
-        em.createQuery(COUNT_UNHASHED_HISTORIES, Long.class).getSingleResult();
+        em.createQuery(
+                "select count(*) from BeneficiaryHistory where mbiHash is null and medicareBeneficiaryId is not null",
+                Long.class)
+            .getSingleResult();
 
     LOGGER.info(
         "Starting idle task processing with missing mbiHash for: {} Beneficaries and {} Benficiary Histories",
@@ -192,138 +272,181 @@ public class RifLoaderIdleTasks {
   }
 
   /**
-   * Run this task after the initial task. Respect the TASK_TIME_LIMIT.
+   * Executor for the Beneficiaries table.
    *
-   * @return true if done with the current task.
+   * @param partition to work on
+   * @return true if done with the work on this partition
    */
-  public boolean doPostStartupTask() {
-    // Just return done if fixups are not enabled;
-    if (!options.isFixupsEnabled()) {
-      LOGGER.info("PostStartup fixups are not enabled.");
-      return true;
-    }
-    final Instant startTime = Instant.now();
-    LOGGER.debug("Started a PostStartup time slice");
-
-    // Execute beneficiaries and histories in parallel
-    List<Future<Boolean>> batchFutures = new ArrayList<Future<Boolean>>();
-    batchFutures.add(
-        executorService.submit(() -> doTransaction(startTime, this::fixupBeneficiaryBatch)));
-    batchFutures.add(
-        executorService.submit(() -> doTransaction(startTime, this::fixupHistoryBatch)));
-
-    final boolean isDone = waitUntilDone(batchFutures);
-    LOGGER.debug("Finished a PostStartup time slice");
-    if (isDone) {
-      LOGGER.info("Finished idle startup tasks");
-    }
+  public Boolean fixupBeneficiaryExecutor(final Integer partition) {
+    LOGGER.debug("Start a Beneficiary executor: partition {}", partition);
+    final AtomicInteger counter = new AtomicInteger(0);
+    final Boolean isDone =
+        doBatches(
+            session ->
+                fixupBatch(session, "Beneficiaries", "beneficiaryId", true, partition, counter));
+    beneficaryMeter.mark(counter.get());
+    LOGGER.debug("Finished a Beneficiary executor: {}, count {}", partition, counter.get());
     return isDone;
   }
 
   /**
-   * Do the normal idle task
+   * Executor for the BeneficiariesHistory table.
    *
-   * @return true if this task is complete
+   * @param partition to work on
+   * @return true if done with the work on this partition
    */
-  public boolean doNormalTask() {
-    // Nothing to do normally
+  public Boolean fixupHistoryExecutor(final Integer partition) {
+    LOGGER.debug("Start a BeneficiariesHistory partition {}", partition);
+    final AtomicInteger counter = new AtomicInteger(0);
+    final Boolean isDone =
+        doBatches(
+            session ->
+                fixupBatch(
+                    session,
+                    "BeneficiariesHistory",
+                    "beneficiaryHistoryId",
+                    false,
+                    partition,
+                    counter));
+    historyMeter.mark(counter.get());
+    LOGGER.debug("Finished a History executor: {}, count {}", partition, counter.get());
+    return isDone;
+  }
+
+  /**
+   * Break up the work into a series of batches of record to update. Each batch is done in a
+   * transaction. After each batch, check the amount of time taken. Return after the
+   * TIME_SLICE_LIMIT is reached or the work is done.
+   *
+   * @param batchWorker does the work. Return the isDone value from the worker.
+   * @return the return value from the last batchWorker.
+   */
+  public boolean doBatches(final Function<StatelessSession, Boolean> batchWorker) {
+    // Use the stateless sessions to avoid the overhead of Hibernates caches which are not needed in
+    // this bulk update use-case
+    final Instant startTime = Instant.now();
+    final SessionFactory sf = entityManagerFactory.unwrap(SessionFactory.class);
+    final StatelessSession statelessSession = sf.openStatelessSession();
+    Transaction txn = null;
+    try {
+      boolean isDone = false;
+      while (!isDone && inPeriod(startTime, TIME_SLICE_LIMIT)) {
+        txn = statelessSession.beginTransaction();
+        isDone = batchWorker.apply(statelessSession);
+        txn.commit();
+      }
+      return isDone;
+    } finally {
+      if (statelessSession.isOpen()) {
+        if (txn != null && txn.isActive()) {
+          txn.rollback();
+        }
+        statelessSession.close();
+      }
+    }
+  }
+
+  /**
+   * Fixup a batch of records. Executed in the context of a transaction.
+   *
+   * @param session to use
+   * @param tableName to fetch from
+   * @param idName of the table
+   * @param hasTextId is true if the id is a varchar, false if the id is a bigint
+   * @param partition to fetch from
+   * @param counter to increment with the record count
+   * @return the number of records fixed up;
+   */
+  private boolean fixupBatch(
+      final StatelessSession session,
+      final String tableName,
+      final String idName,
+      final boolean hasTextId,
+      final int partition,
+      final AtomicInteger counter) {
+    List<Object[]> rows = fetchBatchRows(session, tableName, idName, hasTextId, partition);
+    if (rows.size() == 0) return true;
+    updateBatchMbiHash(session, rows, tableName, idName, hasTextId);
+    counter.addAndGet(rows.size());
     return false;
   }
 
   /**
-   * Wait until all tasks are done or time out
+   * Fetch the rows of a batch. Each row contains the tableId and a medicareBeneficiaryId.
    *
-   * @param tasks to wait on
+   * @param session to use
+   * @param tableName to fetch from
+   * @param idName of the table
+   * @param hasTextId is true if the id is a varchar, false if the id is a bigint
+   * @param partition to fetch from
+   * @return a list of rows
    */
-  private boolean waitUntilDone(List<Future<Boolean>> tasks) {
-    boolean isDone = true;
-    try {
-      // Use a 2x longer value than the expected termination.
-      for (Future<Boolean> task : tasks) {
-        isDone = task.get(2 * TASK_TIME_LIMIT_MILLIS, TimeUnit.MILLISECONDS) && isDone;
-      }
-    } catch (TimeoutException | ExecutionException | InterruptedException ex) {
-      LOGGER.error("Exception executing an idle  task", ex);
-      return false;
-    }
-    return isDone;
+  @SuppressWarnings("unchecked")
+  private List<Object[]> fetchBatchRows(
+      final StatelessSession session,
+      final String tableName,
+      final String idName,
+      final boolean hasTextId,
+      final int partition) {
+    final String p = Integer.toString(partition);
+
+    final String select =
+        "SELECT b.\""
+            + idName
+            + "\", b.\"medicareBeneficiaryId\" "
+            + "FROM \""
+            + tableName
+            + "\" b "
+            + "WHERE b.\"mbiHash\" IS NULL AND b.\"medicareBeneficiaryId\" IS NOT NULL AND "
+            + (hasTextId
+                ? "RIGHT(b.\"" + idName + "\", 1) = '" + p + "'"
+                : "MOD(b.\"" + idName + "\", 10) = " + p);
+
+    return session.createNativeQuery(select).setMaxResults(BATCH_COUNT).getResultList();
   }
 
   /**
-   * Fixup a batch of Beneficiaries. Update the beneficary metrics.
+   * Update the mbiHash field of the batch.
    *
-   * @param em a {@link EntityManager} setup for a transaction
-   * @param startTime the start of the time slice
-   * @return true if done with all fixups
+   * @param session to use
+   * @param rows rows of id and medicareBeneficiaryId tuples
+   * @param tableName to update
+   * @param idName of the table
+   * @param hasTextId is true if the id is a varchar, false if the id is a bigint
    */
-  public Boolean fixupBeneficiaryBatch(final EntityManager em, final Instant startTime) {
-    LOGGER.debug("Start fixing up a Beneficiary batch");
-    boolean isDone = true;
-    // Use a cursor, measures slightly faster than queries with a LIMIT
-    try (ScrollableResults itemCursor =
-        em.unwrap(Session.class)
-            .createQuery(SELECT_UNHASHED_BENFICIARIES)
-            .setFetchSize(BATCH_COUNT)
-            .scroll(ScrollMode.SCROLL_INSENSITIVE)) {
-      int count = 0;
-      while (inPeriod(startTime, TASK_TIME_LIMIT) && itemCursor.next()) {
-        final Beneficiary beneficiary = (Beneficiary) itemCursor.get(0);
-        beneficiary
-            .getMedicareBeneficiaryId()
-            .ifPresent(
-                mbi -> {
-                  final String mbiHash = RifLoader.computeMbiHash(options, secretKeyFactory, mbi);
-                  beneficiary.setMbiHash(Optional.of(mbiHash));
-                });
-        isDone = itemCursor.isLast();
-        // Write to the DB in batches
-        if (++count % BATCH_COUNT == 0) {
-          em.flush();
-          em.clear();
-        }
-      }
-      beneficaryMeter.mark(count);
-      LOGGER.debug("Finished fixing up a Beneficiary batch: {}", count);
-    }
-    return isDone;
-  }
+  private void updateBatchMbiHash(
+      final StatelessSession session,
+      final List<Object[]> rows,
+      String tableName,
+      String idName,
+      boolean hasTextId) {
+    final int rowSize = 100; // 64 for hash and 14 for MBI
+    StringBuilder update = new StringBuilder(rows.size() * rowSize + rowSize);
 
-  /**
-   * Fixup a batch of BeneficiaryHistory. Update the history metrics.
-   *
-   * @param em a {@link EntityManager} setup for a transaction
-   * @param startTime the start of the time slice
-   * @return true if done with all fixups
-   */
-  public Boolean fixupHistoryBatch(final EntityManager em, final Instant startTime) {
-    LOGGER.debug("Start fixing up a History batch");
-    boolean isDone = true;
-    try (ScrollableResults itemCursor =
-        em.unwrap(Session.class)
-            .createQuery(SELECT_UNHASHED_HISTORIES)
-            .setFetchSize(BATCH_COUNT)
-            .scroll(ScrollMode.SCROLL_INSENSITIVE)) {
-      int count = 0;
-      while (inPeriod(startTime, TASK_TIME_LIMIT) && itemCursor.next()) {
-        final BeneficiaryHistory beneficiary = (BeneficiaryHistory) itemCursor.get(0);
-        beneficiary
-            .getMedicareBeneficiaryId()
-            .ifPresent(
-                mbi -> {
-                  final String mbiHash = RifLoader.computeMbiHash(options, secretKeyFactory, mbi);
-                  beneficiary.setMbiHash(Optional.of(mbiHash));
-                });
-        isDone = itemCursor.isLast();
-        // Write to the DB in batches
-        if (++count % BATCH_COUNT == 0) {
-          em.flush();
-          em.clear();
-        }
-      }
-      historyMeter.mark(count);
-      LOGGER.debug("Finished fixing up a History batch: {}", count);
+    /*
+     * Developer Note:
+     * VALUES is a allows single statement update statement to update mulitple values.
+     * It's a common operator, but does not work on HSQLDB.
+     */
+    update
+        .append("UPDATE \"")
+        .append(tableName)
+        .append("\" b SET \"mbiHash\" = mbi_hash FROM (VALUES ");
+    for (int i = 0; i < rows.size(); i++) {
+      Object[] row = rows.get(i);
+      String mbi = (String) row[1];
+      String mbiHash = RifLoader.computeMbiHash(options, secretKeyFactory, mbi);
+      if (i > 0) update.append(",");
+      update
+          .append(hasTextId ? "('" : "(")
+          .append(row[0].toString())
+          .append(hasTextId ? "','" : ",'")
+          .append(mbiHash)
+          .append("')");
     }
-    return isDone;
+    update.append(") AS t(id, mbi_hash) WHERE b.\"").append(idName).append("\" = id");
+
+    session.createNativeQuery(update.toString()).executeUpdate();
   }
 
   /**
@@ -333,36 +456,8 @@ public class RifLoaderIdleTasks {
    * @param period duration
    * @return true iff current period is less than the passed in period duration;
    */
-  public static boolean inPeriod(final Instant start, final Duration period) {
+  private static boolean inPeriod(final Instant start, final Duration period) {
     Instant nowInstant = Instant.now();
-    return start.isBefore(nowInstant) && start.plus(period).isAfter(nowInstant);
-  }
-
-  /**
-   * Setup a DB transaction and call the executor to do the work.
-   *
-   * @param startTime context of the work
-   * @param executor does the work. Return the value from the executor
-   * @return the return value from the executor
-   */
-  public Boolean doTransaction(
-      final Instant startTime, final BiFunction<EntityManager, Instant, Boolean> executor) {
-    Objects.requireNonNull(executor);
-    final EntityManager em = entityManagerFactory.createEntityManager();
-    EntityTransaction txn = null;
-    try {
-      txn = em.getTransaction();
-      txn.begin();
-      final Boolean result = executor.apply(em, startTime);
-      txn.commit();
-      return result;
-    } finally {
-      if (em != null && em.isOpen()) {
-        if (txn != null && txn.isActive()) {
-          txn.rollback();
-        }
-        em.close();
-      }
-    }
+    return start.compareTo(nowInstant) <= 0 && start.plus(period).isAfter(nowInstant);
   }
 }

--- a/apps/bfd-pipeline/bfd-pipeline-rif-load/src/main/java/gov/cms/bfd/pipeline/rif/load/RifLoaderTestUtils.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rif-load/src/main/java/gov/cms/bfd/pipeline/rif/load/RifLoaderTestUtils.java
@@ -35,7 +35,8 @@ public final class RifLoaderTestUtils {
         dataSource,
         LoadAppOptions.DEFAULT_LOADER_THREADS,
         IDEMPOTENCY_REQUIRED,
-        FIXUPS_ENABLED);
+        FIXUPS_ENABLED,
+        RifLoaderIdleTasks.DEFAULT_PARTITION_COUNT);
   }
 
   /**

--- a/apps/bfd-pipeline/bfd-pipeline-rif-load/src/main/java/gov/cms/bfd/pipeline/rif/load/RifLoaderTestUtils.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rif-load/src/main/java/gov/cms/bfd/pipeline/rif/load/RifLoaderTestUtils.java
@@ -21,7 +21,7 @@ public final class RifLoaderTestUtils {
   public static final boolean IDEMPOTENCY_REQUIRED = true;
 
   /** The value to use for {@link LoadAppOptions#isFixupsEnabled()} */
-  public static final boolean FIXUPS_ENABLED = true;
+  public static final boolean FIXUPS_ENABLED = false;
 
   /**
    * @param dataSource a {@link DataSource} for the test DB to connect to

--- a/apps/bfd-pipeline/bfd-pipeline-rif-load/src/test/java/gov/cms/bfd/pipeline/rif/load/RifLoaderIT.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rif-load/src/test/java/gov/cms/bfd/pipeline/rif/load/RifLoaderIT.java
@@ -450,7 +450,8 @@ public final class RifLoaderIT {
             defaultOptions.getDatabaseDataSource(),
             defaultOptions.getLoaderThreads(),
             defaultOptions.isIdempotencyRequired(),
-            fixupsEnabled));
+            fixupsEnabled,
+            defaultOptions.getFixupThreads()));
   }
 
   /**

--- a/apps/bfd-pipeline/bfd-pipeline-rif-load/src/test/java/gov/cms/bfd/pipeline/rif/load/RifLoaderIT.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rif-load/src/test/java/gov/cms/bfd/pipeline/rif/load/RifLoaderIT.java
@@ -148,11 +148,13 @@ public final class RifLoaderIT {
     loadSample(dataSource, StaticRifResourceGroup.SAMPLE_MCT_UPDATE_3);
   }
 
-  /** Tests the RifLoaderIdleTasks class */
+  /** Tests the RifLoaderIdleTasks class with a Sample. Note: only works with Postgres. */
+  @Ignore
   @Test
   public void runIdleTasks() {
     final DataSource dataSource = DatabaseTestHelper.getTestDatabaseAfterClean();
-    final RifLoader loader = loadSample(dataSource, StaticRifResourceGroup.SAMPLE_A);
+    loadSample(dataSource, StaticRifResourceGroup.SAMPLE_A);
+    RifLoader loader = createLoader(dataSource, true);
 
     // The sample are loaded with mbiHash set, clear them for this test
     clearMbiHash(loader);
@@ -180,6 +182,20 @@ public final class RifLoaderIT {
         loader.getIdleTasks().getCurrentTask());
     loader.doIdleTask();
 
+    // Run the post startup beneficiary task
+    Assert.assertEquals(
+        "Should be running the post-startup task",
+        RifLoaderIdleTasks.Task.POST_STARTUP_FIXUP_BENEFICIARIES,
+        loader.getIdleTasks().getCurrentTask());
+    loader.doIdleTask();
+
+    // Run the post startup beneficiary history task
+    Assert.assertEquals(
+        "Should be running the post-startup task",
+        RifLoaderIdleTasks.Task.POST_STARTUP_FIXUP_BENEFICIARY_HISTORY,
+        loader.getIdleTasks().getCurrentTask());
+    loader.doIdleTask();
+
     // Should mbiHash should be set now
     Assert.assertEquals(
         "Should be running the normal task",
@@ -199,7 +215,8 @@ public final class RifLoaderIT {
   @Test
   public void runIdleTasksWithNoFixups() {
     final DataSource dataSource = DatabaseTestHelper.getTestDatabaseAfterClean();
-    final RifLoader loader = loadSample(dataSource, StaticRifResourceGroup.SAMPLE_A);
+    loadSample(dataSource, StaticRifResourceGroup.SAMPLE_A);
+    final RifLoader loader = createLoader(dataSource, false);
 
     // Should need no work
     final String selectBeneficiary = "select b from Beneficiary b where b.mbiHash is null";
@@ -237,15 +254,13 @@ public final class RifLoaderIT {
 
   /**
    * Tests the RifLoaderIdleTasks class with existing data in the database. Useful for profiling
-   * against the beneficiary data set
+   * against the beneficiary data set.
    */
   @Ignore
   @Test
   public void runExistingIdleTasks() {
     final DataSource dataSource = DatabaseTestHelper.getTestDatabase();
-    MetricRegistry appMetrics = new MetricRegistry();
-    LoadAppOptions options = RifLoaderTestUtils.getLoadOptions(dataSource);
-    RifLoader loader = new RifLoader(appMetrics, options);
+    final RifLoader loader = createLoader(dataSource, true);
 
     // The sample are loaded with mbiHash set, clear them for this test
     clearMbiHash(loader);
@@ -259,7 +274,7 @@ public final class RifLoaderIT {
 
     // Run the post startup task
     Instant startTime = Instant.now();
-    while (loader.getIdleTasks().getCurrentTask() == RifLoaderIdleTasks.Task.POST_STARTUP) {
+    while (loader.getIdleTasks().getCurrentTask() != RifLoaderIdleTasks.Task.NORMAL) {
       loader.doIdleTask();
     }
     Duration time = Duration.between(startTime, Instant.now());
@@ -280,7 +295,7 @@ public final class RifLoaderIT {
    * @param dataSource a {@link DataSource} for the test DB to use
    * @param sampleGroup the {@link StaticRifResourceGroup} to load
    */
-  private RifLoader loadSample(DataSource dataSource, StaticRifResourceGroup sampleGroup) {
+  private void loadSample(DataSource dataSource, StaticRifResourceGroup sampleGroup) {
     // Generate the sample RIF data to feed through the pipeline.
     List<StaticRifResource> sampleResources =
         Arrays.stream(sampleGroup.getResources()).collect(Collectors.toList());
@@ -348,7 +363,7 @@ public final class RifLoaderIT {
           options, entityManagerFactory, rifFileRecordsCopy.getRecords().map(r -> r.getRecord()));
     }
     LOGGER.info("All records found in DB.");
-    return loader;
+    loader.close();
   }
 
   /**
@@ -419,6 +434,26 @@ public final class RifLoaderIT {
   }
 
   /**
+   * Create a RIF loader
+   *
+   * @param dataSource to use
+   * @param fixupsEnabled option
+   */
+  private static RifLoader createLoader(DataSource dataSource, boolean fixupsEnabled) {
+    MetricRegistry appMetrics = new MetricRegistry();
+    LoadAppOptions defaultOptions = RifLoaderTestUtils.getLoadOptions(dataSource);
+    return new RifLoader(
+        appMetrics,
+        new LoadAppOptions(
+            defaultOptions.getHicnHashIterations(),
+            defaultOptions.getHicnHashPepper(),
+            defaultOptions.getDatabaseDataSource(),
+            defaultOptions.getLoaderThreads(),
+            defaultOptions.isIdempotencyRequired(),
+            fixupsEnabled));
+  }
+
+  /**
    * Clear the MBI hash fields in the db
    *
    * @param loader the loader and the db connection within
@@ -426,23 +461,10 @@ public final class RifLoaderIT {
   private static void clearMbiHash(final RifLoader loader) {
     loader
         .getIdleTasks()
-        .doTransaction(
-            null,
-            (em, start) -> {
-              for (final Beneficiary b :
-                  em.createQuery(
-                          "select b from Beneficiary b where b.mbiHash is not null",
-                          Beneficiary.class)
-                      .getResultList()) {
-                b.setMbiHash(Optional.empty());
-              }
-              for (final BeneficiaryHistory b :
-                  em.createQuery(
-                          "select b from BeneficiaryHistory b where b.mbiHash is not null",
-                          BeneficiaryHistory.class)
-                      .getResultList()) {
-                b.setMbiHash(Optional.empty());
-              }
+        .doBatches(
+            (session) -> {
+              session.createQuery("update Beneficiary set mbiHash = null").executeUpdate();
+              session.createQuery("update BeneficiaryHistory set mbiHash = null").executeUpdate();
               return true;
             });
   }

--- a/apps/bfd-pipeline/bfd-pipeline-rif-load/src/test/java/gov/cms/bfd/pipeline/rif/load/RifLoaderTest.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rif-load/src/test/java/gov/cms/bfd/pipeline/rif/load/RifLoaderTest.java
@@ -31,7 +31,8 @@ public final class RifLoaderTest {
             options.getDatabasePassword(),
             options.getLoaderThreads(),
             options.isIdempotencyRequired(),
-            options.isFixupsEnabled());
+            options.isFixupsEnabled(),
+            options.getFixupThreads());
     LOGGER.info(
         "salt/pepper: {}", Arrays.toString("nottherealpepper".getBytes(StandardCharsets.UTF_8)));
     LOGGER.info("hash iterations: {}", 1000);
@@ -67,7 +68,8 @@ public final class RifLoaderTest {
             options.getDatabasePassword(),
             options.getLoaderThreads(),
             options.isIdempotencyRequired(),
-            options.isFixupsEnabled());
+            options.isFixupsEnabled(),
+            options.getFixupThreads());
     LOGGER.info(
         "salt/pepper: {}", Arrays.toString("nottherealpepper".getBytes(StandardCharsets.UTF_8)));
     LOGGER.info("hash iterations: {}", 1000);

--- a/apps/bfd-pipeline/bfd-pipeline-rif-load/src/test/resources/logback-test.xml
+++ b/apps/bfd-pipeline/bfd-pipeline-rif-load/src/test/resources/logback-test.xml
@@ -12,8 +12,8 @@
 	<!-- At 'debug', Hibernate will log SQL statements. -->
 	<logger name="org.hibernate.SQL" level="info" />
 
-  <!-- At 'debug', load a rif -->
-	<logger name="gov.cms.bfd.pipeline.rif.load" level="debug" />
+  <!-- At 'debug', will display timing information about the idle task batches -->
+	<logger name="gov.cms.bfd.pipeline.rif.load" level="info" />
 
 	<!-- At 'trace', Hibernate will log SQL parameter values. -->
 	<logger name="org.hibernate.type" level="info" />


### PR DESCRIPTION
**Why**
This PR aims to speed up the fix-ups of the `mbiHash` field. In production, there are about 1 billion  fix-ups, which was about 10x as many fix-ups needed as expected. Using the current code, this would take about 14 days to complete. 

**What Changed**
About a 10x speed up was achieved by: 
- Bypassing Hibernate and batching updates by using native SQL. Note: This code only works for Postgres. 
- Partitioning the tables and using multiple threads
- Bigger hardware running the pipeline code.

A new configuration parameter was added. `fixup_threads`. 

The idle task code was refactored to have a clear hierarchy of names and concepts. 

**Testing Done**
Ran a bunch of tests in PROD to benchmark the code. The number of threads were varied:
```
Threads   Fix-ups Per Second
-------   --------------------
1         500
2         1040
10        3800
20        5200
40        5100
```

Increasing the size of the hardware from 4x to a 12x CPU improved the throughput to about 6000 fixups per second. 

**Security Implications**
N/A

 