### PR TITLE
BLUEBUTTON-1737: Adjust 500s alarm threshold

### DIFF
--- a/ops/terraform/modules/stateless/main.tf
+++ b/ops/terraform/modules/stateless/main.tf
@@ -321,7 +321,7 @@ module "bfd_server_alarm_all_500s" {
     period           = "300"
     statistic        = "Sum"
     ext_statistic    = null
-    threshold        = "10.0"
+    threshold        = "20.0"
     alarm_notify_arn = data.aws_sns_topic.cloudwatch_alarms.arn
     ok_notify_arn    = data.aws_sns_topic.cloudwatch_ok.arn
   }

--- a/ops/terraform/modules/stateless/main.tf
+++ b/ops/terraform/modules/stateless/main.tf
@@ -319,9 +319,9 @@ module "bfd_server_alarm_all_500s" {
     metric_prefix    = "http-requests/count-500"
     eval_periods     = "1"
     period           = "300"
-    statistic        = "Maximum"
+    statistic        = "Sum"
     ext_statistic    = null
-    threshold        = "0.0"
+    threshold        = "10.0"
     alarm_notify_arn = data.aws_sns_topic.cloudwatch_alarms.arn
     ok_notify_arn    = data.aws_sns_topic.cloudwatch_ok.arn
   }


### PR DESCRIPTION
This adjusts the required number of 500s from > 0 to > 20 before triggering a page.  The upper bound I've seen so far is 15, but it's possible a bulk partner could trigger more than this.

I welcome any additional ideas, but ideally I'd like to get this or an equivalent solution merged in soon per: https://cmsgov.slack.com/archives/CJQRH9RLG/p1579282785023700