### PR TITLE
Added the log_connections parameter to parameter group

### DIFF
--- a/ops/terraform/env/test/stateful/main.tf
+++ b/ops/terraform/env/test/stateful/main.tf
@@ -24,7 +24,8 @@ module "stateful" {
     {name="max_parallel_workers_per_gather", value="48", apply_on_reboot=false},
     {name="random_page_cost", value="1", apply_on_reboot=false},
     {name="temp_buffers", value="8192", apply_on_reboot=false},
-    {name="work_mem", value="32768", apply_on_reboot=false}
+    {name="work_mem", value="32768", apply_on_reboot=false},
+    {name="log_connections", value="1", apply_on_reboot=false}
   ]
 
   db_import_mode = {

--- a/ops/terraform/modules/stateful/main.tf
+++ b/ops/terraform/modules/stateful/main.tf
@@ -242,6 +242,11 @@ resource "aws_db_parameter_group" "import_mode" {
   parameter {
     name  = "autovacuum"
     value = "0"
+
+  parameter {
+    name = "log_connections"
+    value = "on"
+  }
   }
 
 }

--- a/ops/terraform/modules/stateful/main.tf
+++ b/ops/terraform/modules/stateful/main.tf
@@ -245,7 +245,7 @@ resource "aws_db_parameter_group" "import_mode" {
 
   parameter {
     name = "log_connections"
-    value = "on"
+    value = "1"
   }
   }
 

--- a/ops/terraform/modules/stateful/main.tf
+++ b/ops/terraform/modules/stateful/main.tf
@@ -242,11 +242,11 @@ resource "aws_db_parameter_group" "import_mode" {
   parameter {
     name  = "autovacuum"
     value = "0"
-
+  }
+  
   parameter {
     name = "log_connections"
     value = "1"
-  }
   }
 
 }


### PR DESCRIPTION
Why
To enable the logging of successful and unsuccessful logins to our RDS instances

What Changed
Added the log_connections parameter to the parameter group

Testing
None currently

Security Impact
Positive, will provide additional RDS database access data