### PR TITLE
BLUEBUTTON-1524: Update integration tests to load new synthetic data

### DIFF
--- a/apps/bfd-model/bfd-model-rif-samples/src/main/java/gov/cms/bfd/model/rif/samples/TestDataSetLocation.java
+++ b/apps/bfd-model/bfd-model-rif-samples/src/main/java/gov/cms/bfd/model/rif/samples/TestDataSetLocation.java
@@ -2,9 +2,7 @@ package gov.cms.bfd.model.rif.samples;
 
 /** Enumerates the locations of various test data sets in S3. */
 public enum TestDataSetLocation {
-  SYNTHETIC_DATA(
-      "data-synthetic/2017-11-27T00:00:00.000Z-fixed-with-negative-ids-and-enrollment-columns"),
-
+  SYNTHETIC_DATA("bfd-public-test-data", "data-synthetic/2020-1-25-mbi-with-negative-ids"),
   DUMMY_DATA_1000000_BENES("data-random/1000000-beneficiaries-2017-10-21T00:00:00.000Z"),
 
   DUMMY_DATA_100000_BENES("data-random/100000-beneficiaries-2017-10-21T00:00:00.000Z"),
@@ -27,6 +25,9 @@ public enum TestDataSetLocation {
 
   /** The S3 bucket that the project's ETL test data is stored in. */
   public static final String S3_BUCKET_TEST_DATA = "gov-hhs-cms-bluebutton-sandbox-etl-test-data";
+
+  /** The S3 bucket with synthetic data */
+  public static final String BFD_BUCKET_TEST_DATA = "bfd-public-test-data";
 
   private final String s3BucketName;
   private final String s3KeyPrefix;


### PR DESCRIPTION
**Why**
A new set of RIF files were created with MBIs and negative ids. These files were loaded into a new s3 bucket that is under the BFD AWS account. This change points our integration tests to use these new RIF files. 

**What Changed**

1. A new S3 bucket was created by hand. bfd-public-test-data
2. The full synthetic data set was uploaded to this bucket. 
3. The loadSyntheticData test was updated to load from this bucket  

Other sample RIF files did not change. 

**Testing**
Loaded the data set locally on a local Postgres instance. The data set doesn't load on HSQL. 

**Future Work**
SAMPLE_A and other sample RIF files are still in the old bucket. Eventually, they should be made to have negative bene-ids and good synthetic MBIs. 
