### PR TITLE
BLUEBUTTON-1781: Open prod-sbx to Internet traffic

### DIFF
--- a/ops/terraform/env/prod-sbx/stateless/main.tf
+++ b/ops/terraform/env/prod-sbx/stateless/main.tf
@@ -20,4 +20,5 @@ module "stateless" {
   ssh_key_name        = var.ssh_key_name
   git_branch_name     = var.git_branch_name
   git_commit_id       = var.git_commit_id
+  is_public           = true
 }

--- a/ops/terraform/modules/resources/lb/main.tf
+++ b/ops/terraform/modules/resources/lb/main.tf
@@ -6,6 +6,7 @@ locals {
   tags        = merge({Layer=var.layer, role=var.role}, var.env_config.tags)
   is_public   = contains(var.ingress.cidr_blocks, "0.0.0.0/0")
   log_prefix  = "${var.role}_elb_access_logs" 
+  is_prod     = substr(var.env_config.env, 0, 4) == "prod" 
 }
 
 ##
@@ -78,6 +79,11 @@ resource "aws_elb" "main" {
     bucket              = var.log_bucket
     bucket_prefix       = local.log_prefix
     interval            = 5   # (minutes) Match HealthApt      
+  }
+
+  lifecycle {
+    # Destroying the LB will be an outage if it has traffic. Don't do this accidentially. 
+    prevent_destroy     = local.is_prod
   }
 }
 

--- a/ops/terraform/modules/resources/lb/main.tf
+++ b/ops/terraform/modules/resources/lb/main.tf
@@ -4,6 +4,7 @@
 #
 locals {
   tags        = merge({Layer=var.layer, role=var.role}, var.env_config.tags)
+  is_public   = contains(var.ingress.cidr_blocks, "0.0.0.0/0")
   log_prefix  = "${var.role}_elb_access_logs" 
 }
 
@@ -48,7 +49,7 @@ resource "aws_elb" "main" {
   name                  = "bfd-${var.env_config.env}-${var.role}"
   tags                  = local.tags
 
-  internal              = true
+  internal              = !local.is_public
   subnets               = data.aws_subnet.app_subnets[*].id # Gives AZs and VPC association
   security_groups       = [aws_security_group.lb.id]
 

--- a/ops/terraform/modules/resources/lb/main.tf
+++ b/ops/terraform/modules/resources/lb/main.tf
@@ -6,7 +6,6 @@ locals {
   tags        = merge({Layer=var.layer, role=var.role}, var.env_config.tags)
   is_public   = contains(var.ingress.cidr_blocks, "0.0.0.0/0")
   log_prefix  = "${var.role}_elb_access_logs" 
-  is_prod     = substr(var.env_config.env, 0, 4) == "prod" 
 }
 
 ##
@@ -79,11 +78,6 @@ resource "aws_elb" "main" {
     bucket              = var.log_bucket
     bucket_prefix       = local.log_prefix
     interval            = 5   # (minutes) Match HealthApt      
-  }
-
-  lifecycle {
-    # Destroying the LB will be an outage if it has traffic. Don't do this accidentially. 
-    prevent_destroy     = local.is_prod
   }
 }
 

--- a/ops/terraform/modules/resources/lb/main.tf
+++ b/ops/terraform/modules/resources/lb/main.tf
@@ -4,7 +4,6 @@
 #
 locals {
   tags        = merge({Layer=var.layer, role=var.role}, var.env_config.tags)
-  is_public   = contains(var.ingress.cidr_blocks, "0.0.0.0/0")
   log_prefix  = "${var.role}_elb_access_logs" 
 }
 
@@ -49,7 +48,7 @@ resource "aws_elb" "main" {
   name                  = "bfd-${var.env_config.env}-${var.role}"
   tags                  = local.tags
 
-  internal              = !local.is_public
+  internal              = !var.is_public
   subnets               = data.aws_subnet.app_subnets[*].id # Gives AZs and VPC association
   security_groups       = [aws_security_group.lb.id]
 

--- a/ops/terraform/modules/resources/lb/variables.tf
+++ b/ops/terraform/modules/resources/lb/variables.tf
@@ -17,6 +17,12 @@ variable "log_bucket" {
   type        = string
 }
 
+variable "is_public" {
+  description = "If true, the LB is created as a public LB"
+  type        = bool
+  default     = false
+}
+
 variable "ingress" {
   description = "Ingress port and cidr blocks"
   type        = object({description=string, port=number, cidr_blocks=list(string)})

--- a/ops/terraform/modules/stateless/main.tf
+++ b/ops/terraform/modules/stateless/main.tf
@@ -144,9 +144,9 @@ data "aws_iam_policy" "ansible_vault_pw_ro_s3" {
   arn           = "arn:aws:iam::577373831711:policy/bfd-ansible-vault-pw-ro-s3"
 }
 
-#
+##
 # Start to build stuff
-#
+##
 
 # IAM roles
 # 
@@ -173,7 +173,11 @@ module "fhir_lb" {
   layer           = "dmz"
   log_bucket      = data.aws_s3_bucket.logs.id
 
-  ingress = {
+  ingress = var.is_public ? {
+    description   = "Public Internet access"
+    port          = 443
+    cidr_blocks   = ["0.0.0.0/0"]
+  } : {
     description   = "From VPC peerings, the MGMT VPC, and self"
     port          = 443
     cidr_blocks   = concat(data.aws_vpc_peering_connection.peers[*].peer_cidr_block, [data.aws_vpc.mgmt.cidr_block, data.aws_vpc.main.cidr_block])

--- a/ops/terraform/modules/stateless/main.tf
+++ b/ops/terraform/modules/stateless/main.tf
@@ -172,6 +172,7 @@ module "fhir_lb" {
   role            = "fhir"
   layer           = "dmz"
   log_bucket      = data.aws_s3_bucket.logs.id
+  is_public       = var.is_public
 
   ingress = var.is_public ? {
     description   = "Public Internet access"

--- a/ops/terraform/modules/stateless/variables.tf
+++ b/ops/terraform/modules/stateless/variables.tf
@@ -27,3 +27,9 @@ variable "git_commit_id" {
   description       = "git commit of beneficiary-fhir-data"
   type              = string
 }
+
+variable "is_public" {
+  description       = "If true, open the FHIR data end-point to the public Internet"
+  type              = bool
+  default           = false 
+}


### PR DESCRIPTION
**Why**
To allow developers to continue to test against the latest releases of BFD in their integration tests. See [SIA to open prod-sbx](https://confluence.cms.gov/pages/viewpage.action?spaceKey=BB&title=Update+to+SIA+to+include+request+to+open+prod-sbx+to+general+internet+access+for+developer+usage).

**Changes**
- prod-sbx ELB is replaced and made public.
- The LB security group ingress rule is changed to `0.0.0.0/0`.
- {dpc, mct, bcda, bb}.prod-sbx.bfdcloud.net points to the new ELB.
- ELBs are marked with `prevent_destroy` for safety. 
- No change in other environments

**Deployment Plan**
The change to the prod-sbx ELB cannot be made in-place; It must be destroyed and replaced. This plan deploys without down-time by using a temporary ELB to hold traffic while the main ELB is replaced. Although it may be OK to take down-time in prod-sbx, this plan will be good practice for the next time we have to replace the ELB. 

1. Test current setup while connected by VPN
```
curl --insecure --cert-type pem --cert client_data_server_local_test_env_dpr_keypair.pem  'https://bfd-prod-sbx.bfdcloud.net:443/v1/fhir/metadata?_format=application%2Fjson%2Bfhir'
``` 
2. Setup a `bfd-prod-sbx-temp` ELB by hand using the TF stateless scripts
3. Test new ELB
```
curl --insecure --cert-type pem --cert client_data_server_local_test_env_dpr_keypair.pem  'https://bfd-prod-sbx-fhir-temp-1100214705.us-east-1.elb.amazonaws.com:443/v1/fhir/metadata?_format=application%2Fjson%2Bfhir'
``` 
4. Point domains to the temp ELB by hand using the TF migration scripts
5. Test domain still work
```
curl --insecure --cert-type pem --cert client_data_server_local_test_env_dpr_keypair.pem  'https://bfd-prod-sbx.bfdcloud.net:443/v1/fhir/metadata?_format=application%2Fjson%2Bfhir'
``` 
6. Merge PR into master and deploy using Jenkins
7. Point domains to the new ELB
8. Disconnect from VPN
9. Test without a VPN connnection
```
curl --insecure --cert-type pem --cert client_data_server_local_test_env_dpr_keypair.pem  'https://bfd-prod-sbx.bfdcloud.net:443/v1/fhir/metadata?_format=application%2Fjson%2Bfhir'
``` 

**Testing**
A temp ELB was setup in prod-sbx using the PR's scripts. Connectivity was confirmed. 

**Security**
See SIA.



