### PR TITLE
BLUEBUTTON-1737 Throw ResourceNotFoundException (404) for ID multiple matches 

### DIFF
--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
@@ -26,7 +26,6 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
-import javax.persistence.NonUniqueResultException;
 import javax.persistence.PersistenceContext;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
@@ -39,6 +38,7 @@ import org.hl7.fhir.dstu3.model.IdType;
 import org.hl7.fhir.dstu3.model.Identifier;
 import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 
 /**
@@ -423,7 +423,9 @@ public final class PatientResourceProvider implements IResourceProvider {
     if (distinctBeneIds <= 0) {
       throw new NoResultException();
     } else if (distinctBeneIds > 1) {
-      throw new NonUniqueResultException();
+      MDC.put("database_query.by_hash.collision.distinct_bene_ids", Long.toString(distinctBeneIds));
+      throw new ResourceNotFoundException(
+          "By hash query found more than one distinct BENI_ID: " + Long.toString(distinctBeneIds));
     } else if (distinctBeneIds == 1) {
       beneficiary = matchingBenes.get(0);
     }

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
@@ -425,7 +425,7 @@ public final class PatientResourceProvider implements IResourceProvider {
     } else if (distinctBeneIds > 1) {
       MDC.put("database_query.by_hash.collision.distinct_bene_ids", Long.toString(distinctBeneIds));
       throw new ResourceNotFoundException(
-          "By hash query found more than one distinct BENI_ID: " + Long.toString(distinctBeneIds));
+          "By hash query found more than one distinct BENE_ID: " + Long.toString(distinctBeneIds));
     } else if (distinctBeneIds == 1) {
       beneficiary = matchingBenes.get(0);
     }


### PR DESCRIPTION
### Change Details

Summary:

This PR updates the `PatientResourceProvider.queryDatabaseByHash()` method used for HICN and MBI searches to throw a `ResourceNotFoundException` exception when multiple bene id's are found. An entry in the access.json logs (via MDC) is also made for auditing.

The ignored (using @ignore) IT tests in the `PatientResourceProviderIT` class were updated for the new behavior.

These tests are:  `searchForExistingPatientByHicnHashWithBeneDups()` and `searchForExistingPatientByMbiHashWithBeneDups()`

A new assert method `assertPatientByHashTypeMatch()` was created to be used by these tests. It combines the overlapping code from the two separate `assertPatientByHicnHashWithBeneDupsMatch()` and `assertPatientByMbiHashWithBeneDupsMatch()` methods.



### Acceptance Validation

That HICN or MBI search requests that map to multiple bene ID's will produce a `ResourceNotFoundException` exception (404 HTTP response status code). This was previously returning a `NonUniqueResultException` exception (500 HTTP response status code).


### Feedback Requested

* Does the naming of things and the text of the error/excpetion response look OK?


### External References

* [BLUEBUTTON-1737](https://jira.cms.gov/browse/BLUEBUTTON-1737)
