### PR TITLE
BLUEBUTTON-1787: GitHub Actions CI for Java and Terraform development

### DIFF
--- a/.github/workflows/ci-java.yml
+++ b/.github/workflows/ci-java.yml
@@ -1,0 +1,40 @@
+name: 'CI - Java'
+on:
+  pull_request:
+    paths:
+      - apps/**
+jobs:
+  mvn-verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Configure AWS credentials'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.GA_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.GA_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: 'Checkout repo'
+        uses: actions/checkout@v2
+      - name: 'Setup JDK'
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: 'Generate maven toolchain config'
+        run: |
+          cat << EOF > ~/.m2/toolchains.xml
+          <toolchains>
+            <toolchain>
+              <type>jdk</type>
+              <provides>
+                <version>1.8</version>
+                <vendor>OpenJDK</vendor>
+              </provides>
+              <configuration>
+                <jdkHome>$JAVA_HOME</jdkHome>
+              </configuration>
+            </toolchain>
+          </toolchains>
+          EOF
+      - name: 'Run maven verify'
+        run: mvn verify
+        working-directory: ./apps

--- a/.github/workflows/ci-java.yml
+++ b/.github/workflows/ci-java.yml
@@ -38,3 +38,31 @@ jobs:
       - name: 'Run maven verify'
         run: mvn verify
         working-directory: ./apps
+  mvn-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout repo'
+        uses: actions/checkout@v2
+      - name: 'Setup JDK'
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: 'Generate maven toolchain config'
+        run: |
+          cat << EOF > ~/.m2/toolchains.xml
+          <toolchains>
+            <toolchain>
+              <type>jdk</type>
+              <provides>
+                <version>1.8</version>
+                <vendor>OpenJDK</vendor>
+              </provides>
+              <configuration>
+                <jdkHome>$JAVA_HOME</jdkHome>
+              </configuration>
+            </toolchain>
+          </toolchains>
+          EOF
+      - name: 'Run maven lint'
+        run: mvn com.coveo:fmt-maven-plugin:check
+        working-directory: ./apps

--- a/.github/workflows/ci-java.yml
+++ b/.github/workflows/ci-java.yml
@@ -4,8 +4,12 @@ on:
     paths:
       - apps/**
 jobs:
-  mvn-verify:
+  mvn-job:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java_version: [1.8]
+        mvn_command: ['verify', 'com.coveo:fmt-maven-plugin:check']
     steps:
       - name: 'Configure AWS credentials'
         uses: aws-actions/configure-aws-credentials@v1
@@ -18,7 +22,7 @@ jobs:
       - name: 'Setup JDK'
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: ${{ matrix.java_version }}
       - name: 'Generate maven toolchain config'
         run: |
           cat << EOF > ~/.m2/toolchains.xml
@@ -26,7 +30,7 @@ jobs:
             <toolchain>
               <type>jdk</type>
               <provides>
-                <version>1.8</version>
+                <version>${{ matrix.java_version }}</version>
                 <vendor>OpenJDK</vendor>
               </provides>
               <configuration>
@@ -35,34 +39,6 @@ jobs:
             </toolchain>
           </toolchains>
           EOF
-      - name: 'Run maven verify'
-        run: mvn verify
-        working-directory: ./apps
-  mvn-lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: 'Checkout repo'
-        uses: actions/checkout@v2
-      - name: 'Setup JDK'
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-      - name: 'Generate maven toolchain config'
-        run: |
-          cat << EOF > ~/.m2/toolchains.xml
-          <toolchains>
-            <toolchain>
-              <type>jdk</type>
-              <provides>
-                <version>1.8</version>
-                <vendor>OpenJDK</vendor>
-              </provides>
-              <configuration>
-                <jdkHome>$JAVA_HOME</jdkHome>
-              </configuration>
-            </toolchain>
-          </toolchains>
-          EOF
-      - name: 'Run maven lint'
-        run: mvn com.coveo:fmt-maven-plugin:check
+      - name: 'Run maven ${{ matrix.mvn_commmand }}'
+        run: mvn ${{ matrix.mvn_command }}
         working-directory: ./apps

--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -1,0 +1,31 @@
+name: 'CI - Terraform'
+on:
+  pull_request:
+    paths:
+      - ops/terraform/**
+jobs:
+  tf-validate:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tf_version: [0.12.8]
+        tf_environment: [test, prod-sbx, prod, mgmt]
+        tf_resources: [stateless, stateful]
+    steps:
+      - name: 'Checkout repo'
+        uses: actions/checkout@v2
+      - name: 'Run terraform init'
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_version: ${{ matrix.tf_version }}
+          tf_actions_subcommand: init
+          tf_actions_working_dir: ./ops/terraform/env/${{ matrix.tf_environment }}/${{ matrix.tf_resources }}/
+          tf_actions_comment: false
+          args: '-backend=false'
+      - name: 'Run terraform validate'
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_version: ${{ matrix.tf_version }}
+          tf_actions_subcommand: validate
+          tf_actions_working_dir: ./ops/terraform/env/${{ matrix.tf_environment }}/${{ matrix.tf_resources }}/
+          tf_actions_comment: false

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .*
 !.gitignore
 !.gitattributes
+!.github
 
 # OSX system files
 .DS_Store

--- a/ops/terraform/modules/mgmt_stateful/main.tf
+++ b/ops/terraform/modules/mgmt_stateful/main.tf
@@ -206,3 +206,57 @@ resource "aws_iam_role_policy_attachment" "packer_S3" {
   role       = aws_iam_role.packer.name
   policy_arn = aws_iam_policy.packer_s3.arn
 }
+
+# IAM policy, user, and attachment to allow GitHub Actions
+# to perform app integration testing against S3
+
+resource "aws_iam_user" "github_actions" {
+  name       = "bfd-github-actions"
+}
+
+resource "aws_iam_user_policy_attachment" "github_actions_s3its" {
+  user       = aws_iam_user.github_actions.name
+  policy_arn = aws_iam_policy.github_actions_s3its.arn
+}
+
+resource "aws_iam_policy" "github_actions_s3its" {
+  name        = "bfd-github-actions-s3its"
+  description = "GitHub Actions policy for S3 integration tests"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "BFDGitHubActionsS3ITs",
+      "Action": [
+        "s3:CreateBucket",
+        "s3:ListAllMyBuckets"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Sid": "BFDGitHubActionsS3ITsBucket",
+      "Action": [
+        "s3:DeleteBucket",
+        "s3:HeadBucket",
+        "s3:ListBucket"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::bb-test-*"
+    },
+    {
+      "Sid": "BFDGitHubActionsS3ITsObject",
+      "Action": [
+        "s3:DeleteObject",
+        "s3:GetObject",
+        "s3:PutObject"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::bb-test-*/*"
+    }
+  ]
+}
+EOF
+}


### PR DESCRIPTION
This PR adds the following two GitHub Actions workflows:
- On a PR that has changes inside the apps directory, run a `mvn verify` against the parent pom of the apps directory.  This will ensure all unit and integration tests pass prior to being merged.
- On a PR that has changes inside the terraform directory, run a `terraform validate` against each independent piece of terraform state.  This will ensure terraform is syntactically valid and internally consistent prior to being merged.  

The following changes were made to the mgmt stateful module:
- Adds a user, policy, and attachment that allows the GitHub Actions runner to run S3 integration tests.

Discussion:
- What else could be added/linted without increasing the security impact?  Some of the other terraform linting tools require access to the remote state so I don't think we'd want to go down that path unless we GitHub runners in our own environment.  
- Is my current assessment that creating an AWS user for GitHub Actions to run the Java S3 integration tests is acceptable from a security standpoint?  @StewGoin 
- The `setup-java` action uses the "Zulu Community distribution of OpenJDK" which I have never heard of, and could only find specific details on in the following reddit post: https://www.reddit.com/r/java/comments/8jvv8e/what_would_be_the_reasons_to_use_the_zulu_build/?sort=top  It seems safe for our use cases but worth putting it out there in case anyone has concerns.