### PR TITLE
BLUEBUTTON-1792: Add metrics for AB2D

### DIFF
--- a/ops/terraform/modules/stateless/main.tf
+++ b/ops/terraform/modules/stateless/main.tf
@@ -311,6 +311,17 @@ module "bfd_server_metrics_dpc" {
   }
 }
 
+module "bfd_server_metrics_ab2d" {
+  source = "../resources/bfd_server_metrics"
+
+  env    = var.env_config.env
+
+  metric_config = {
+    partner_name  = "ab2d"
+    partner_regex = "*ab2d*"
+  }
+}
+
 # FHIR server alarms, partner specific
 #
 module "bfd_server_alarm_all_500s" {


### PR DESCRIPTION
This adds cloudwatch metrics for AB2D, since we still use CloudWatch as 1st line reporting/monitoring.