### PR TITLE
BLUEBUTTON-1595: Fix issues with medicare opt out rollout

### DIFF
--- a/ops/terraform/modules/resources/s3_pii/main.tf
+++ b/ops/terraform/modules/resources/s3_pii/main.tf
@@ -18,7 +18,7 @@ resource "aws_kms_key" "pii_bucket_key" {
     name   = var.pii_bucket_config.name
     admins = formatlist("%s", var.pii_bucket_config.admin_arns)
     roles  = formatlist("%s", concat(var.pii_bucket_config.read_arns, var.pii_bucket_config.write_arns))
-    root   = data.aws_caller_identity.current.account_id
+    root   = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
   })
 }
 
@@ -84,6 +84,6 @@ resource "aws_s3_bucket_policy" "pii_bucket_policy" {
     admins      = formatlist("%s", var.pii_bucket_config.admin_arns)
     readers     = formatlist("%s", var.pii_bucket_config.read_arns)
     writers     = formatlist("%s", var.pii_bucket_config.write_arns)
-    root        = data.aws_caller_identity.current.account_id
+    root        = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
   })
 }

--- a/ops/terraform/modules/stateful/main.tf
+++ b/ops/terraform/modules/stateful/main.tf
@@ -508,18 +508,8 @@ resource "aws_iam_user_policy_attachment" "etl_rw_s3" {
   policy_arn = aws_iam_policy.etl_rw_s3.arn
 }
 
-# Admin group, S3 bucket, policy, and KMS key for medicare opt out data
+# S3 bucket, policy, and KMS key for medicare opt out data
 #
-resource "aws_iam_group" "medicare_opt_out_admins" {
-  name = "bfd-${var.env_config.env}-medicare-opt-out-admins-group"
-}
-
-resource "aws_iam_group_membership" "medicare_opt_out_admins" {
-  name  = "bfd-${var.env_config.env}-medicare-opt-out-admins-membership"
-  group = aws_iam_group.medicare_opt_out_admins.name
-  users = var.medicare_opt_out_config.admin_users
-}
-
 module "medicare_opt_out" {
   source            = "../resources/s3_pii"
   env_config        = local.env_config
@@ -529,7 +519,7 @@ module "medicare_opt_out" {
     log_bucket      = module.logs.id
     read_arns       = var.medicare_opt_out_config.read_roles
     write_arns      = var.medicare_opt_out_config.write_roles
-    admin_arns      = [aws_iam_group.medicare_opt_out_admins.arn]
+    admin_arns      = var.medicare_opt_out_config.admin_users
   }
 }
 


### PR DESCRIPTION
Unfortunately I ran into a few issues applying #168 :
- The root ARN was not properly formatted
- Group ARNs cannot be used as a principal in a KMS key policy (😞) so I reverted to the previous behavior of directly passing the admin users list: https://docs.aws.amazon.com/kms/latest/developerguide/control-access-overview.html

I have already rolled this out, just need to get it merged in.