### PR TITLE
BLUEBUTTON-1536 Update api-changelog with exception (400) information

### DIFF
--- a/apps/bfd-server/dev/api-changelog.md
+++ b/apps/bfd-server/dev/api-changelog.md
@@ -42,7 +42,7 @@ true | include HICN and MBI
 hicn | include HICN
 mbi | include MBI
 hicn,mbi or mbi,hicn | include HICN and MBI
-\<any\> | omit HICN and MBI
+\<any invalid value\> | Throws an InvalidRequest exception (400 HTTP status code)
 
 
 ## BLUEBUTTON-1516: Support searching the Patient resource by hashed MBI


### PR DESCRIPTION
### Change Details

Summary:

This updates the API Change Log information for:
BLUEBUTTON-1536 Extend IncludeIdentifiers header options for Patient Resource response #177

Information related to using an invalid value throwing an InvalidRequest exception (400 HTTP status code) was missing.

**NOTE: This is a documentation change only!**

### Acceptance Validation

The API Change Log documentation is corrected.

### Feedback Requested

### Remaining Work

### External References

* [BLUEBUTTON-1536](https://jira.cms.gov/browse/BLUEBUTTON-1536)
* `IncludeIdentifiers` header values table:  https://confluence.cms.gov/display/BB/Blue+Button+Identifier+Options
