### PR TITLE
BLUEBUTTON-1843: Upgrade to HAPI 4.1.0

### DIFF
--- a/apps/bfd-server-test-functions/pom.xml
+++ b/apps/bfd-server-test-functions/pom.xml
@@ -54,7 +54,6 @@
 	</repositories>
 
 	<properties>
-		<hapi-fhir.version>1.4-SNAPSHOT</hapi-fhir.version>
 	</properties>
 
 	<dependencies>

--- a/apps/bfd-server/bfd-server-war/pom.xml
+++ b/apps/bfd-server/bfd-server-war/pom.xml
@@ -16,7 +16,6 @@
 	</description>
 
 	<properties>
-		<hapi-fhir.version>3.6</hapi-fhir.version>
 		<jersey.version>2.25.1</jersey.version>
 
 		<!-- Configure the BFD Server, as it will be run via the exec
@@ -64,19 +63,19 @@
 			<!-- At least one "structures" JAR must also be included -->
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-dstu3</artifactId>
-			<version>3.6.0</version>
+			<version>${hapi-fhir.version}</version>
 		</dependency>
 		<dependency>
 			<!-- This dependency includes the server HAPI-FHIR classes -->
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-server</artifactId>
-			<version>3.6.0</version>
+			<version>${hapi-fhir.version}</version>
 		</dependency>
 		<dependency>
 			<!-- This dependency includes the client HAPI-FHIR classes -->
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-client</artifactId>
-			<version>3.6.0</version>
+			<version>${hapi-fhir.version}</version>
 		</dependency>
 		
 		<dependency>

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/SpringConfiguration.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/SpringConfiguration.java
@@ -1,8 +1,7 @@
 package gov.cms.bfd.server.war;
 
 import ca.uhn.fhir.rest.server.IResourceProvider;
-import ca.uhn.fhir.rest.server.interceptor.IServerInterceptor;
-import ca.uhn.fhir.rest.server.interceptor.ResponseHighlighterInterceptor;
+import ca.uhn.fhir.rest.server.interceptor.*;
 import com.codahale.metrics.JmxReporter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheckRegistry;
@@ -350,15 +349,5 @@ public class SpringConfiguration {
   public HealthCheckRegistry healthCheckRegistry() {
     HealthCheckRegistry healthCheckRegistry = new HealthCheckRegistry();
     return healthCheckRegistry;
-  }
-
-  /**
-   * @return an {@link IServerInterceptor} that will add some pretty syntax highlighting in
-   *     responses when a browser is detected
-   */
-  @Bean
-  public IServerInterceptor responseHighlighterInterceptor() {
-    ResponseHighlighterInterceptor retVal = new ResponseHighlighterInterceptor();
-    return retVal;
   }
 }

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/SpringConfiguration.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/SpringConfiguration.java
@@ -1,7 +1,6 @@
 package gov.cms.bfd.server.war;
 
 import ca.uhn.fhir.rest.server.IResourceProvider;
-import ca.uhn.fhir.rest.server.interceptor.*;
 import com.codahale.metrics.JmxReporter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheckRegistry;

--- a/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/metadata.json
+++ b/apps/bfd-server/bfd-server-war/src/test/resources/endpoint-responses/metadata.json
@@ -12,7 +12,7 @@
     "description" : "gov.cms.bfd:bfd-server-war",
     "url" : "https://localhost:IGNORED_FIELD/v1/fhir"
   },
-  "fhirVersion" : "3.0.1",
+  "fhirVersion" : "3.0.2",
   "acceptUnknown" : "extensions",
   "format" : [ "application/fhir+xml", "application/fhir+json" ],
   "rest" : [ {
@@ -20,7 +20,7 @@
     "resource" : [ {
       "type" : "Coverage",
       "profile" : {
-        "reference" : "http://hl7.org/fhir/StructureDefinition/Coverage"
+        "reference" : "http://hl7.org/fhir/Profile/Coverage"
       },
       "interaction" : [ {
         "code" : "read"
@@ -43,7 +43,7 @@
     }, {
       "type" : "ExplanationOfBenefit",
       "profile" : {
-        "reference" : "http://hl7.org/fhir/StructureDefinition/ExplanationOfBenefit"
+        "reference" : "http://hl7.org/fhir/Profile/ExplanationOfBenefit"
       },
       "interaction" : [ {
         "code" : "read"
@@ -74,7 +74,7 @@
     }, {
       "type" : "OperationDefinition",
       "profile" : {
-        "reference" : "http://hl7.org/fhir/StructureDefinition/OperationDefinition"
+        "reference" : "http://hl7.org/fhir/Profile/OperationDefinition"
       },
       "interaction" : [ {
         "code" : "read"
@@ -82,7 +82,7 @@
     }, {
       "type" : "Patient",
       "profile" : {
-        "reference" : "http://hl7.org/fhir/StructureDefinition/Patient"
+        "reference" : "http://hl7.org/fhir/Profile/Patient"
       },
       "interaction" : [ {
         "code" : "read"
@@ -125,7 +125,7 @@
     }, {
       "type" : "StructureDefinition",
       "profile" : {
-        "reference" : "http://hl7.org/fhir/StructureDefinition/StructureDefinition"
+        "reference" : "http://hl7.org/fhir/Profile/StructureDefinition"
       },
       "interaction" : [ {
         "code" : "read"

--- a/apps/bfd-server/dev/api-changelog.md
+++ b/apps/bfd-server/dev/api-changelog.md
@@ -1,5 +1,20 @@
 # API Changelog
 
+## BLUEBUTTON-1843: HAPI 4.1.0 Upgrade
+
+As part of the upgrade of the HAPI package used by the BFD, the FHIR version was changed from `3.0.1` to `3.0.2`. 
+This is a minor FHIR version change. 
+
+The `CapabilitiesStatement` resource returned by the metadata endpoint reflects this change. 
+In the resource the `fhirVersion` field changed and the profile path changed from:
+```
+"reference" : "http://hl7.org/fhir/StructureDefinition/<Resource Type>"
+```
+to:
+```
+"reference" : "http://hl7.org/fhir/Profile/<Resource Type>"
+```
+
 ## BLUEBUTTON-1679: Hashed HICN needs to be removed from Patient Resource
 
 The Hashed HICN identifier is removed from the Patient resource response. This is to ensure that we are in compliance for the HICN rule. This is to leave no traces of the HICN-hash in any external facing data requests to BFD. 
@@ -12,7 +27,6 @@ The following is an example of the identifier that is NO LONGER included in exte
        <system value="https://bluebutton.cms.gov/resources/identifier/hicn-hash"></system>
        <value value="96228a57f37efea543f4f370f96f1dbf01c3e3129041dba3ea4367545507c6e7"></value>
     </identifier>
-
 
 ## BLUEBUTTON-1784: Search for patients by ptdcntrct
 

--- a/apps/bfd-server/pom.xml
+++ b/apps/bfd-server/pom.xml
@@ -15,6 +15,10 @@
 		A parent POM for the bfd-server-* projects, which provide a FHIR-compliant API for querying Medicare beneficiary data.
 	</description>
 
+	<properties>
+		<hapi-fhir.version>4.1.0</hapi-fhir.version>
+	</properties>
+
 	<modules>
 		<module>bfd-server-launcher-sample</module>
 		<module>bfd-server-launcher</module>


### PR DESCRIPTION
**Why**
This PR replaces the DependaBot https://github.com/CMSgov/beneficiary-fhir-data/pull/146 PR. It changes the FHIR library for the whole project. 

**What Changed**
- API changelog updated
- Remove the ResponseHighlighter as it is deprecated in 4.1.0
- Common HAPI version for all bfd-server
- Updated Metadata fhir version from 3.0.1 to 3.0.2

**Testing Done**
- Confirmed that the except for the metadata response, the FHIR endpoint's response does not change. 

**Security Implications**
According to GitHub this pull request will fix a security vulnerability of moderate severity.  