### PR TITLE
BLUEBUTTON-1841 improve coverage query speed

### DIFF
--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PageLinkBuilder.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PageLinkBuilder.java
@@ -91,7 +91,6 @@ public final class PageLinkBuilder {
    * @throws InvalidRequestException HTTP 400: indicates a startIndex less than 0 was provided
    */
   public int getStartIndex() {
-    if (!isPagingRequested()) throw new BadCodeMonkeyException();
     if (startIndex.isPresent()) {
       if (startIndex.get() < 0) {
         throw new InvalidRequestException(

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PageQueryBuilder.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PageQueryBuilder.java
@@ -8,9 +8,9 @@ import javax.persistence.criteria.Root;
 
 public final class PageQueryBuilder<T> {
 
-  public final Root<T> root;
-  public final CriteriaBuilder builder;
-  public final CriteriaQuery criteria;
+  private final Root<T> root;
+  private final CriteriaBuilder builder;
+  private final CriteriaQuery criteria;
   private final EntityManager entityManager;
 
   public PageQueryBuilder(Class<T> returnType, EntityManager em) {
@@ -18,6 +18,18 @@ public final class PageQueryBuilder<T> {
     builder = entityManager.getCriteriaBuilder();
     criteria = builder.createQuery(returnType);
     root = criteria.from(returnType);
+  }
+
+  public Root<T> root() {
+    return this.root;
+  }
+
+  public CriteriaBuilder builder() {
+    return this.builder;
+  }
+
+  public CriteriaQuery criteria() {
+    return this.criteria;
   }
 
   private CriteriaQuery<Long> createCountCriteria() {

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PageQueryBuilder.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PageQueryBuilder.java
@@ -1,0 +1,37 @@
+package gov.cms.bfd.server.war.stu3.providers;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+
+public final class PageQueryBuilder<T> {
+
+  public final Root<T> root;
+  public final CriteriaBuilder builder;
+  public final CriteriaQuery criteria;
+  private final EntityManager entityManager;
+
+  public PageQueryBuilder(Class<T> returnType, EntityManager em) {
+    entityManager = em;
+    builder = entityManager.getCriteriaBuilder();
+    criteria = builder.createQuery(returnType);
+    root = criteria.from(returnType);
+  }
+
+  private CriteriaQuery<Long> createCountCriteria() {
+    criteria.select(builder.count(root));
+    return criteria;
+  }
+
+  public Long count() {
+    return entityManager.createQuery(createCountCriteria()).getSingleResult();
+  }
+
+  public Query createQuery() {
+    criteria.select(root);
+
+    return entityManager.createQuery(criteria);
+  }
+}

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PageQueryBuilder.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PageQueryBuilder.java
@@ -21,17 +21,23 @@ public final class PageQueryBuilder<T> {
   }
 
   private CriteriaQuery<Long> createCountCriteria() {
-    criteria.select(builder.count(root));
-    return criteria;
+    CriteriaQuery countCriteria = builder.createQuery(Long.class);
+    Root<T> countRoot = countCriteria.from(this.criteria.getResultType());
+    countCriteria.select(builder.count(countRoot));
+    countCriteria.where(this.criteria.getRestriction());
+    return countCriteria;
   }
 
   public Long count() {
     return entityManager.createQuery(createCountCriteria()).getSingleResult();
   }
 
-  public Query createQuery() {
+  private CriteriaQuery<T> createCriteria() {
     criteria.select(root);
+    return criteria;
+  }
 
-    return entityManager.createQuery(criteria);
+  public Query createQuery() {
+    return entityManager.createQuery(createCriteria());
   }
 }

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
@@ -277,11 +277,15 @@ public final class PatientResourceProvider implements IResourceProvider {
 
     PageLinkBuilder paging = new PageLinkBuilder(requestDetails, "/Patient?");
 
-    if (count > 0) {
+    if (count > paging.getStartIndex()) {
       Query query = queryBuilder.createQuery();
       if (paging.isPagingRequested()) {
+				int pageSize = paging.getPageSize();
+				if (count < paging.getStartIndex() + paging.getPageSize()) {
+					pageSize = count - startIndex;
+				}
         query.setFirstResult(paging.getStartIndex());
-        query.setMaxResults(paging.getPageSize());
+        query.setMaxResults(pageSize);
       }
       matchingBeneficiaries = query.getResultList();
     }

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
@@ -260,6 +260,9 @@ public final class PatientResourceProvider implements IResourceProvider {
     PageQueryBuilder<Beneficiary> queryBuilder =
         new PageQueryBuilder<Beneficiary>(Beneficiary.class, entityManager);
 
+    queryBuilder.criteria.where(
+        queryBuilder.builder.equal(queryBuilder.root.get(contractMonthField), contractCode));
+
     List<String> includeIdentifiersValues = returnIncludeIdentifiersValues(requestDetails);
 
     if (hasHICN(includeIdentifiersValues))
@@ -268,17 +271,12 @@ public final class PatientResourceProvider implements IResourceProvider {
     if (hasMBI(includeIdentifiersValues))
       queryBuilder.root.fetch(Beneficiary_.medicareBeneficiaryIdHistories, JoinType.LEFT);
 
-    queryBuilder.criteria.where(
-        queryBuilder.builder.equal(queryBuilder.root.get(contractMonthField), contractCode));
+    List<Beneficiary> matchingBeneficiaries = Collections.emptyList();
+    Query query = queryBuilder.createQuery();
 
     Long count = queryBuilder.count();
-
-    List<Beneficiary> matchingBeneficiaries = Collections.emptyList();
-
     PageLinkBuilder paging = new PageLinkBuilder(requestDetails, "/Patient?");
-
     if (count > paging.getStartIndex()) {
-      Query query = queryBuilder.createQuery();
       if (paging.isPagingRequested()) {
         int pageSize = paging.getPageSize();
         if (count < paging.getStartIndex() + paging.getPageSize()) {

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
@@ -280,10 +280,10 @@ public final class PatientResourceProvider implements IResourceProvider {
     if (count > paging.getStartIndex()) {
       Query query = queryBuilder.createQuery();
       if (paging.isPagingRequested()) {
-				int pageSize = paging.getPageSize();
-				if (count < paging.getStartIndex() + paging.getPageSize()) {
-					pageSize = count - startIndex;
-				}
+        int pageSize = paging.getPageSize();
+        if (count < paging.getStartIndex() + paging.getPageSize()) {
+          pageSize = count.intValue() - paging.getStartIndex();
+        }
         query.setFirstResult(paging.getStartIndex());
         query.setMaxResults(pageSize);
       }

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
@@ -260,16 +260,20 @@ public final class PatientResourceProvider implements IResourceProvider {
     PageQueryBuilder<Beneficiary> queryBuilder =
         new PageQueryBuilder<Beneficiary>(Beneficiary.class, entityManager);
 
-    queryBuilder.criteria.where(
-        queryBuilder.builder.equal(queryBuilder.root.get(contractMonthField), contractCode));
+    queryBuilder
+        .criteria()
+        .where(
+            queryBuilder
+                .builder()
+                .equal(queryBuilder.root().get(contractMonthField), contractCode));
 
     List<String> includeIdentifiersValues = returnIncludeIdentifiersValues(requestDetails);
 
     if (hasHICN(includeIdentifiersValues))
-      queryBuilder.root.fetch(Beneficiary_.beneficiaryHistories, JoinType.LEFT);
+      queryBuilder.root().fetch(Beneficiary_.beneficiaryHistories, JoinType.LEFT);
 
     if (hasMBI(includeIdentifiersValues))
-      queryBuilder.root.fetch(Beneficiary_.medicareBeneficiaryIdHistories, JoinType.LEFT);
+      queryBuilder.root().fetch(Beneficiary_.medicareBeneficiaryIdHistories, JoinType.LEFT);
 
     List<Beneficiary> matchingBeneficiaries = Collections.emptyList();
     Query query = queryBuilder.createQuery();


### PR DESCRIPTION
# Why
Queries on the Beneficiary table against the partDContractId columns are occasionally timing out. This work clarifies some common parts of query building allowing for simple optimizations to fall out without obfuscating behavior.

# What changed
A class `PageQueryBuilder` is created to encapsulate the tools used to build queries while still exposing all of their behaviors. It also adds some convenience things like `count()` which is a common operation to get the total matching count of entries against a set of criteria.

The order of operations has changed slightly in `searchByCoverageContract` allowing the system to skip some expensive edge cases when there is no matching data to return, or less data than the requested page size.