### PR TITLE
Reducing the number of load threads to easy data loading

### DIFF
--- a/ops/ansible/roles/bfd-pipeline/defaults/main.yml
+++ b/ops/ansible/roles/bfd-pipeline/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 data_pipeline_dir: /usr/local/bluebutton-data-pipeline
 data_pipeline_user: bb-etl
-data_pipeline_loader_threads: 200
+data_pipeline_loader_threads: 100
 data_pipeline_jvm_args: -Xmx64g
 data_pipeline_tmp_dir: /tmp
 data_pipeline_idempotency_required: true


### PR DESCRIPTION
https://confluence.cms.gov/pages/viewpage.action?pageId=271777831

Reduced the number of data_pipeline_loader_threads to ease the data load in response to Incident listed above.