### PR TITLE
BLUEBUTTON-1872: Run all workflows for PRs due to branch protection

### DIFF
--- a/.github/workflows/ci-java.yml
+++ b/.github/workflows/ci-java.yml
@@ -1,8 +1,5 @@
 name: 'CI - Java'
-on:
-  pull_request:
-    paths:
-      - apps/**
+on: pull_request
 jobs:
   mvn-job:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -1,8 +1,5 @@
 name: 'CI - Terraform'
-on:
-  pull_request:
-    paths:
-      - ops/terraform/**
+on: pull_request
 jobs:
   tf-validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It was discovered that branch protection cannot selectively apply a workflow to a particular PR like the current way we were having them run (on changes to a specific path).  This changes all workflows to run for all PRs.  We could potentially work around this by using `if` statements in our jobs/steps that still selectively trigger based on some context of the PR, hover that feels hacky and I can't think of any productivity impact (at the rate we merge PRs) to running all workflows for all PRs.