### PR TITLE
BLUEBUTTON-1903: Use single packer definition to build AMIs in parallel

### DIFF
--- a/ops/deploy-ccs.groovy
+++ b/ops/deploy-ccs.groovy
@@ -142,23 +142,14 @@ def buildAppAmis(String gitBranchName, String gitCommitId, AmiIds amiIds, AppBui
 				data_pipeline_jar: "${workspace}/${appBuildResults.dataPipelineUberJar}",
 			]))
 
-			// build the ETL pipeline
+			// build AMIs in parallel
 			sh "/usr/bin/packer build -color=false \
 				-var vault_password_file=${vaultPasswordFile} \
 				-var 'source_ami=${amiIds.platinumAmiId}' \
 				-var 'subnet_id=subnet-092c2a68bd18b34d1' \
 				-var 'git_branch=${gitBranchName}' \
 				-var 'git_commit=${gitCommitId}' \
-				../../packer/build_bfd-pipeline.json"
-
-			// build the FHIR server
-			sh "/usr/bin/packer build -color=false \
-				-var vault_password_file=${vaultPasswordFile} \
-				-var 'source_ami=${amiIds.platinumAmiId}' \
-				-var 'subnet_id=subnet-092c2a68bd18b34d1' \
-				-var 'git_branch=${gitBranchName}' \
-				-var 'git_commit=${gitCommitId}' \
-				../../packer/build_bfd-server.json"
+				../../packer/build_bfd-all.json"
 
 			return new AmiIds(
 				platinumAmiId: amiIds.platinumAmiId,

--- a/ops/packer/build_bfd-all.json
+++ b/ops/packer/build_bfd-all.json
@@ -1,0 +1,116 @@
+{
+  "variables": {
+    "source_ami": "",
+    "subnet_id": "",
+    "vault_password_file": ""
+  },
+  "builders": [
+    {
+      "name": "bfd-pipeline",
+      "type": "amazon-ebs",
+      "iam_instance_profile": "bfd-packer",
+      "ssh_username": "ec2-user",
+      "instance_type": "m5.xlarge",
+      "region": "us-east-1",
+      "subnet_id": "{{user `subnet_id`}}",
+      "associate_public_ip_address": "false",
+      "source_ami": "{{user `source_ami`}}",
+      "security_group_filter": {
+        "filters": {
+          "tag:Name": "bfd-mgmt-vpn-private"
+        }
+      },
+      "ami_name": "bfd-etl-{{isotime \"20060102030405\"}}",
+      "ssh_pty": true,
+      "tags": {
+        "Name": "bfd-etl-{{isotime \"20060102030405\"}}",
+        "Application": "BFD",
+        "Environment": "{{user `env`}}",
+        "Function": "ETL APP SERVER",
+        "Layer": "APP",
+        "Branch": "{{user `git_branch`}}",
+        "Commit": "{{user `git_commit`}}"
+      }
+    },
+    {
+      "name": "bfd-server",
+      "type": "amazon-ebs",
+      "iam_instance_profile": "bfd-packer",
+      "ssh_username": "ec2-user",
+      "instance_type": "m5.xlarge",
+      "region": "us-east-1",
+      "subnet_id": "{{user `subnet_id`}}",
+      "associate_public_ip_address": "false",
+      "source_ami": "{{user `source_ami`}}",
+      "security_group_filter": {
+        "filters": {
+          "tag:Name": "bfd-mgmt-vpn-private"
+        }
+      },
+      "ami_name": "bfd-fhir-{{isotime \"20060102030405\"}}",
+      "ssh_pty": true,
+      "tags": {
+        "Name": "bfd-fhir-{{isotime \"20060102030405\"}}",
+        "Application": "BFD",
+        "Environment": "{{user `env`}}",
+        "Function": "FHIR APP SERVER",
+        "Layer": "APP",
+        "Branch": "{{user `git_branch`}}",
+        "Commit": "{{user `git_commit`}}"
+      }
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "file",
+      "source": "extra_vars.json",
+      "destination": "/tmp/extra_vars.json"
+    },
+    {
+      "only": ["bfd-pipeline"],
+      "type": "ansible",
+      "playbook_file": "./build_bfd-pipeline.yml",
+      "extra_arguments": [
+        "-e ansible_python_interpreter=/usr/bin/python",
+        "--extra-vars",
+        "@extra_vars.json",
+        "--tags",
+        "pre-ami"
+      ],
+      "ansible_env_vars": [
+        "ANSIBLE_SSH_ARGS='-o IdentitiesOnly=yes'",
+        "ANSIBLE_VAULT_PASSWORD_FILE={{user `vault_password_file`}}"
+      ]
+    },
+    {
+      "only": ["bfd-server"],
+      "type": "ansible",
+      "playbook_file": "./build_bfd-server.yml",
+      "extra_arguments": [
+        "-e ansible_python_interpreter=/usr/bin/python",
+        "--extra-vars",
+        "@extra_vars.json",
+        "--tags",
+        "pre-ami"
+      ],
+      "ansible_env_vars": [
+        "ANSIBLE_SSH_ARGS='-o IdentitiesOnly=yes'",
+        "ANSIBLE_VAULT_PASSWORD_FILE={{user `vault_password_file`}}"
+      ]
+    }
+  ],
+  "post-processors": [
+    {
+      "only": ["bfd-pipeline"],
+      "type": "manifest",
+      "output": "manifest_data-pipeline.json",
+      "strip_path": true
+    },
+    {
+      "only": ["bfd-server"],
+      "type": "manifest",
+      "output": "manifest_data-server.json",
+      "strip_path": true
+    }
+  ]
+}


### PR DESCRIPTION
Inspired by this week's OEDA engineering meeting, I set out to see if we could build our AMIs in parallel.  As it turns out this is pretty easy to do, and packer supports running builders in parallel by default.  I combined the two packer definitions we had for the FHIR server and pipeline into one, ensured the builders were uniquely named, and that provisioners/post-processors only run for their corresponding named builder.  This shaves about 4-5 minutes off of our deploy times in total.

The only caveat is that since the builds happen in parallel, the ansible playbook output becomes wonky and harder to follow:
```
    bfd-server: TASK [cloudwatch-agent-instrumented : cwagent | Copy agent configuration file] ***
    bfd-pipeline: TASK [cloudwatch-agent-instrumented : cwagent | Copy agent configuration file] ***
    bfd-pipeline: Friday 06 March 2020  12:16:34 -0500 (0:00:00.388)       0:00:00.761 **********
    bfd-server: Friday 06 March 2020  12:16:34 -0500 (0:00:00.388)       0:00:00.761 **********
    bfd-pipeline: changed: [default]
    bfd-server: changed: [default]
    bfd-server:
    bfd-server: TASK [cloudwatch-agent-instrumented : cwagent | install agent from RPM] ********
    bfd-server: Friday 06 March 2020  12:16:36 -0500 (0:00:02.242)       0:00:03.004 **********
    bfd-pipeline:
    bfd-pipeline: TASK [cloudwatch-agent-instrumented : cwagent | install agent from RPM] ********
    bfd-pipeline: Friday 06 March 2020  12:16:36 -0500 (0:00:02.242)       0:00:03.003 **********
    bfd-server: changed: [default]
    bfd-server:
    bfd-server: TASK [cloudwatch-agent-instrumented : cwagent | start agent] *******************
    bfd-server: Friday 06 March 2020  12:16:45 -0500 (0:00:09.518)       0:00:12.522 **********
    bfd-server: changed: [default]