### PR TITLE
BLUEBUTTON-1788: Add Outpatient Data and Tests

### DIFF
--- a/apps/bfd-model/bfd-model-rif-samples/dev/design-sample-data-sets.md
+++ b/apps/bfd-model/bfd-model-rif-samples/dev/design-sample-data-sets.md
@@ -11,6 +11,7 @@ Some notes:
     * Sample/test values for the following fields should be negative (i.e. prefixed with a "`-`"): `BENE_ID`, `CLM_ID`, `PDE_ID`, `CLM_GRP_ID`.
     * Sample/test values for `BENE_CRNT_HIC_NUM` (i.e. HICNs) should follow the following pattern, which is used by CMS' Next Generation Desktop (NGD) system for sample/test data: `MBPnnnnnnA` (where "`n`" is a numeric digit).
         * At this time, NGD is known to have exactly the following sample/test HICNs loaded in (at least) some of its lower environments: `MBP000201A`, `MBP000202A`, `MBP000203A`, `MBP000204A`, `MBP000207A`, `MBP000208A`, `MBP000209A`, `MBP000210A`.
+    * Synthetic MBIs use an `S` in the second character. This is a forbidden value for a real MBI. 
     * Note that most of our sample/test data sets do not yet conform to this best practice.
 3. Ideally, all sample data beneficiary and claim identifiers will be unique when compared to each other and also when compared to production data. This allows for arbitrary subsets of sample data to be deployed into development, test, and production environments.
     * It's very important to have "safe" sample/test data in production! This enables all sorts of best practices around testing code in its actual habitat.
@@ -44,6 +45,46 @@ The following table details the ideal/desired key ranges for all known sample an
 |Random      |`T10000000A` - `T99999999A`                                           |`-10000000` - `-99999999`|`-1000000000` - `-999999999999`|`-1000000000` - `-999999999999`|
 |Synthetic   |`T01000000A` - `T01999999A`                                           | `-1000000` -  `-1999999`| `-100000000` -    `-199999999`| `-100000000` -    `-199999999`|
 |`SAMPLE_MCT`|HICNs: `MBP000201A` - `MBP000210A`, RRBs: `{0099190316`, `B3499290814`|     `-201` -      `-212`|       `-240` -          `-285`|       `-240` -          `-285`|
+
+## Procedures to Load Data 
+
+### Local Dev
+
+The synthetic data set can be loaded to a local Postgres database. An HSQL database
+**cannot** be used. The `RifLoaderIT#loadSyntheticData` test will load the synthetic data set. 
+Normally, this test is marked with `@Ignore` because it will take as much as 20 minutes to run. 
+
+```$xslt
+mvn -Dits.db.url=jdbc:postgresql://localhost:5432/fhir -Dit.test=RifLoaderIT#loadSyntheticData clean install
+```
+
+When adding test new synthetic data, developers should create new integration tests for the new data. 
+The `OutpatientClaimTransformerTest.transformSyntheticData` is a good model to follow for this type of test. 
+
+### TEST, PROD-SBX, and PROD
+
+Before loading data into an environment, ensure that the data loads and works in your local environment. 
+
+To manually load data into an environment, one essentially needs to duplicate the process that the CCW does for its weekly drop of RIF files. 
+Every ETL service monitors an S3 bucket for incoming RIF files. 
+The buckets used in the CCS account are:
+
+| Environment | Bucket         |
+|-------------|-------------------------|
+| Test        | bfd-test-etl-577373831711 |
+| Prod-Sbx    | bfd-prod-sbx-etl-577373831711 |
+| Prod        | bfd-prod-etl-577373831711 |
+
+In each of these buckets there are two special directories: `Done` and `Incoming`. 
+The `Incoming` directory further contains a subdirectory that holds the data for a single data load. 
+The name of this subdirectory must match the timestamp in the manifest file. 
+
+In the subdirectory, there are two types of files: RIF files which hold the data records to be loaded and manifest files which point the RIF files.
+Each manifest file follows the naming convention of `<sequenceId>_manifest.xml` where `sequenceId` is the must match the `sequenceId` found in the manifest file. 
+After the ETL service processes a manifest file in the `Incoming` directory, it writes the RIF file and the manifest file into the `Done` directory.
+After all incoming files are processed, the `Incoming` directory is deleted. 
+
+The `bfd-prod-etl-577373831711` bucket is a good place to find examples of manifest files and data load subdirectories. 
 
 ## Sample Data Set Details
 
@@ -158,10 +199,83 @@ It was created via the following process:
         https://s3.amazonaws.com/gov-hhs-cms-bluebutton-sandbox-etl-test-data/data-synthetic/2017-11-27T00%3A00%3A00.000Z-fixed-with-negative-ids/synthetic-pde-2016.rif
     ```
 
+4. A random MBIs were generated for each synthetic beneficiary. 
+These MBI's have a `S` in as their second character to distinguish them from real MBIs. 
+With a change in AWS accounts for the BFD project, the synthetic data set was moved to a different S3 bucket: `bfd-public-test-data` 
 
+   ```
+    $ wget \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/0_manifest.xml \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-beneficiary-1999.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-beneficiary-2000.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-beneficiary-2014.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-carrier-1999-1999.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-carrier-1999-2000.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-carrier-1999-2001.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-carrier-2000-2000.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-carrier-2000-2001.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-carrier-2000-2002.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-carrier-2014-2014.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-carrier-2014-2015.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-carrier-2014-2016.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-inpatient-1999-1999.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-inpatient-1999-2000.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-inpatient-1999-2001.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-inpatient-2000-2000.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-inpatient-2000-2001.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-inpatient-2000-2002.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-inpatient-2014-2014.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-inpatient-2014-2015.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-inpatient-2014-2016.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-pde-2014.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-pde-2015.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-pde-2016.rif
+   ```
+    
+5. A set of Outpatient claims were generated and added to the synthetic data set. 
+The source data is kept in a team Keybase folder. 
+All the fixups on the source data that was performed are documented in the `outpatient-claims/convert_outpatient_claims_csv_file_to_rif.py` script. 
+
+   ``` 
+     $ wget \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/0_manifest.xml \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/synthetic-beneficiary-1999.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/synthetic-beneficiary-2000.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/synthetic-beneficiary-2014.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/synthetic-carrier-1999-1999.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/synthetic-carrier-1999-2000.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/synthetic-carrier-1999-2001.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/synthetic-carrier-2000-2000.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/synthetic-carrier-2000-2001.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/synthetic-carrier-2000-2002.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/synthetic-carrier-2014-2014.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/synthetic-carrier-2014-2015.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/synthetic-carrier-2014-2016.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/synthetic-inpatient-1999-1999.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/synthetic-inpatient-1999-2000.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/synthetic-inpatient-1999-2001.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/synthetic-inpatient-2000-2000.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/synthetic-inpatient-2000-2001.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/synthetic-inpatient-2000-2002.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/synthetic-inpatient-2014-2014.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/synthetic-inpatient-2014-2015.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/synthetic-inpatient-2014-2016.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/synthetic-pde-2014.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/synthetic-pde-2015.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/synthetic-pde-2016.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/synthetic-outpatient-1999-1999.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/synthetic-outpatient-2000-1999.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/synthetic-outpatient-2001-1999.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/synthetic-outpatient-2000-2000.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/synthetic-outpatient-2001-2000.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/synthetic-outpatient-2002-2000.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/synthetic-outpatient-2014-2014.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/synthetic-outpatient-2015-2014.rif \
+        https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-02-27-add-outpatient/synthetic-outpatient-2016-2014.rif
+   ```     
 The synthetic data set was statistically validated and certified as fit for public use by CMS' Data Governance Board. The documentation from that is published here: [CMSgov/beneficiary-fhir-data:bfd-model-rif-samples/dev](./).
 
-It's important to note that the synthetic data set does not yet cover all supported claim types: it has carrier claims, inpatient claims, and Part D events but does not have DME claims, HHA claims, hospice claims, outpatient claims, or SNF claims. The synthetic data set has the following counts, by record type:
+It's important to note that the synthetic data set does not yet cover all supported claim types: it has carrier claims, inpatient claims, outpatient claims, and Part D events but does not have DME claims, HHA claims, hospice claims, or SNF claims. The synthetic data set has the following counts, by record type:
 
 |Record Type|Count|
 |---|---|
@@ -169,6 +283,10 @@ It's important to note that the synthetic data set does not yet cover all suppor
 |Carrier CLaims|1744920|
 |Inpatient Claims|70212|
 |Part D Events|413347|
+|Outpatient Claims|171144|
+
+
+
 
 ### `SAMPLE_MCT`: MCT-Compatible Test Data (Derived from Synthetic)
 

--- a/apps/bfd-model/bfd-model-rif-samples/src/main/java/gov/cms/bfd/model/rif/samples/StaticRifResource.java
+++ b/apps/bfd-model/bfd-model-rif-samples/src/main/java/gov/cms/bfd/model/rif/samples/StaticRifResource.java
@@ -267,6 +267,41 @@ public enum StaticRifResource {
       RifFileType.PDE,
       145526),
 
+  SYNTHETIC_OUTPATIENT_1999_1999(
+      remoteS3Data(TestDataSetLocation.SYNTHETIC_DATA, "synthetic-outpatient-1999-1999.rif"),
+      RifFileType.OUTPATIENT,
+      20744),
+
+  SYNTHETIC_OUTPATIENT_2000_1999(
+      remoteS3Data(TestDataSetLocation.SYNTHETIC_DATA, "synthetic-outpatient-2000-1999.rif"),
+      RifFileType.OUTPATIENT,
+      22439),
+
+  SYNTHETIC_OUTPATIENT_2001_1999(
+      remoteS3Data(TestDataSetLocation.SYNTHETIC_DATA, "synthetic-outpatient-2001-1999.rif"),
+      RifFileType.OUTPATIENT,
+      23241),
+
+  SYNTHETIC_OUTPATIENT_2002_2000(
+      remoteS3Data(TestDataSetLocation.SYNTHETIC_DATA, "synthetic-outpatient-2002-2000.rif"),
+      RifFileType.OUTPATIENT,
+      24575),
+
+  SYNTHETIC_OUTPATIENT_2014_2014(
+      remoteS3Data(TestDataSetLocation.SYNTHETIC_DATA, "synthetic-outpatient-2014-2014.rif"),
+      RifFileType.OUTPATIENT,
+      25194),
+
+  SYNTHETIC_OUTPATIENT_2015_2014(
+      remoteS3Data(TestDataSetLocation.SYNTHETIC_DATA, "synthetic-outpatient-2015-2014.rif"),
+      RifFileType.OUTPATIENT,
+      26996),
+
+  SYNTHETIC_OUTPATIENT_2016_2014(
+      remoteS3Data(TestDataSetLocation.SYNTHETIC_DATA, "synthetic-outpatient-2016-2014.rif"),
+      RifFileType.OUTPATIENT,
+      27955),
+
   SAMPLE_MCT_BENES(
       resourceUrl("rif-static-samples/sample-mct-beneficiaries.txt"), RifFileType.BENEFICIARY, 8),
 

--- a/apps/bfd-model/bfd-model-rif-samples/src/main/java/gov/cms/bfd/model/rif/samples/StaticRifResourceGroup.java
+++ b/apps/bfd-model/bfd-model-rif-samples/src/main/java/gov/cms/bfd/model/rif/samples/StaticRifResourceGroup.java
@@ -68,7 +68,14 @@ public enum StaticRifResourceGroup {
       StaticRifResource.SYNTHETIC_INPATIENT_2014_2016,
       StaticRifResource.SYNTHETIC_PDE_2014,
       StaticRifResource.SYNTHETIC_PDE_2015,
-      StaticRifResource.SYNTHETIC_PDE_2016),
+      StaticRifResource.SYNTHETIC_PDE_2016,
+      StaticRifResource.SYNTHETIC_OUTPATIENT_1999_1999,
+      StaticRifResource.SYNTHETIC_OUTPATIENT_2000_1999,
+      StaticRifResource.SYNTHETIC_OUTPATIENT_2001_1999,
+      StaticRifResource.SYNTHETIC_OUTPATIENT_2002_2000,
+      StaticRifResource.SYNTHETIC_OUTPATIENT_2014_2014,
+      StaticRifResource.SYNTHETIC_OUTPATIENT_2015_2014,
+      StaticRifResource.SYNTHETIC_OUTPATIENT_2016_2014),
 
   SAMPLE_MCT(StaticRifResource.SAMPLE_MCT_BENES, StaticRifResource.SAMPLE_MCT_PDE),
 

--- a/apps/bfd-model/bfd-model-rif-samples/src/main/java/gov/cms/bfd/model/rif/samples/TestDataSetLocation.java
+++ b/apps/bfd-model/bfd-model-rif-samples/src/main/java/gov/cms/bfd/model/rif/samples/TestDataSetLocation.java
@@ -2,7 +2,7 @@ package gov.cms.bfd.model.rif.samples;
 
 /** Enumerates the locations of various test data sets in S3. */
 public enum TestDataSetLocation {
-  SYNTHETIC_DATA("bfd-public-test-data", "data-synthetic/2020-1-25-mbi-with-negative-ids"),
+  SYNTHETIC_DATA("bfd-public-test-data", "data-synthetic/2020-02-27-add-outpatient"),
   DUMMY_DATA_1000000_BENES("data-random/1000000-beneficiaries-2017-10-21T00:00:00.000Z"),
 
   DUMMY_DATA_100000_BENES("data-random/100000-beneficiaries-2017-10-21T00:00:00.000Z"),

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtils.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtils.java
@@ -308,6 +308,13 @@ public final class TransformerUtils {
                 ctc ->
                     practitionerIdSystem.equals(ctc.getProvider().getIdentifier().getSystem())
                         && practitionerIdValue.equals(ctc.getProvider().getIdentifier().getValue()))
+            .filter(ctc -> ctc.hasRole())
+            .filter(
+                ctc ->
+                    careTeamRole.toCode().equals(ctc.getRole().getCodingFirstRep().getCode())
+                        && careTeamRole
+                            .getSystem()
+                            .equals(ctc.getRole().getCodingFirstRep().getSystem()))
             .findAny()
             .orElse(null);
 

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtilsTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtilsTest.java
@@ -3,8 +3,10 @@ package gov.cms.bfd.server.war.stu3.providers;
 import gov.cms.bfd.model.codebook.data.CcwCodebookVariable;
 import org.hl7.fhir.dstu3.model.CodeableConcept;
 import org.hl7.fhir.dstu3.model.Coding;
+import org.hl7.fhir.dstu3.model.ExplanationOfBenefit;
 import org.hl7.fhir.dstu3.model.Extension;
 import org.hl7.fhir.dstu3.model.Patient;
+import org.hl7.fhir.dstu3.model.codesystems.ClaimCareteamrole;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -83,5 +85,16 @@ public final class TransformerUtilsTest {
         TransformerUtils.createCodeableConcept(
             patientA, CcwCodebookVariable.REV_CNTR_PMT_MTHD_IND_CD, "1");
     Assert.assertNull(paymentMethodConcept_1.getCodingFirstRep().getDisplay());
+  }
+
+  @Test
+  public void addCareTeamPractitioner() {
+    ExplanationOfBenefit eob = new ExplanationOfBenefit();
+    TransformerUtils.addCareTeamPractitioner(eob, null, "system", "123", ClaimCareteamrole.PRIMARY);
+    Assert.assertEquals("Expect there to be one care team member", 1, eob.getCareTeam().size());
+    TransformerUtils.addCareTeamPractitioner(eob, null, "system", "123", ClaimCareteamrole.ASSIST);
+    Assert.assertEquals("Expect there to be two care team members", 2, eob.getCareTeam().size());
+    TransformerUtils.addCareTeamPractitioner(eob, null, "system", "123", ClaimCareteamrole.ASSIST);
+    Assert.assertEquals("Expect there to be two care team members", 2, eob.getCareTeam().size());
   }
 }


### PR DESCRIPTION
**Why**
Add new Outpatient claims to the synthetic data set.

**What Changed**
- A new synthetic data set was created and loaded into the s3.
- In creating the new RIF files many fix-ups had to be done. The keybase://team/oeda_bfs/team/synthetic-data/outpatient-claims folder has the scripts and source data. @dtisza1 did most of this work. Some of the fix-ups include:
  - Setting bene_ids to negative
  - Fixing column names 
  - Date formats
  - White space 
  - Decimal formats
  - Generating REV_CNTR_STUS_IND_CD values from the distribution found in PROD
  - Removed 2 files with conflicting CLM_IDs 
- New synthetic RIF file enumerations for the new outpatient RIF files
- New tests for the data
- Fixed a bug in addAddCareTeamPractitioner where the existing
- Updated the OutpatientClaimTransformerTest.assertMatches test to work with the new synthetic data (It was very SAMPLE_A specific before). 
- Updated the documentation for the data set

**What to review**
- New logic in addAddCareTeamPractitioner
- Tests 
- Documentation

**Next Steps**
- Load data into the environments

**Security Impact**
N/A
