### PR TITLE
Remove Dead Code Uncovered by Static Analysis Tools

### DIFF
--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtils.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtils.java
@@ -140,9 +140,6 @@ public final class TransformerUtils {
   /** Stores the diagnosis ICD codes and their display values */
   private static Map<String, String> icdMap = null;
 
-  /** Tracks the diagnosis ICD codes that have already had code lookup failures. */
-  private static final Set<String> icdLookupMissingFailures = new HashSet<>();
-
   /** Stores the procedure codes and their display values */
   private static Map<String, String> procedureMap = null;
 


### PR DESCRIPTION
### Remove Dead Code Uncovered by Static Analysis Tools

The LGTM Static Analysis Tool has [uncovered a section of dead code](https://lgtm.com/projects/g/CMSgov/beneficiary-fhir-data/snapshot/df4e011a2b10444d7e58c539ee9e775d242963be/files/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtils.java?sort=name&dir=ASC&mode=heatmap#x6617737a5dce7940:1) in the BFD code base.  This code is considered "dead code" because it is not being used/referenced by any other code.  It is likely that this code was introduced into the codebase with [this commit](https://github.com/CMSgov/beneficiary-fhir-data/commit/d440cbcba64dea6dd41ecc6e23730e5e1baf6237).

### Change Details

- Removed the code that is not being utilized

### Security Implications

No PHI/PII is at-risk or affected as a result of this change.  The code in question was not being used and is being removed in an effort to clean up tech debt.

### Acceptance Validation

Performed a `grep` to see if any references to the removed code existed in the codebase after the change.  The `grep` turned up zero results, indicating that the code is truly not being utilized in the codebase.

<img width="486" alt="Screen Shot 2020-03-11 at 6 01 24 PM" src="https://user-images.githubusercontent.com/37818548/76477193-ec7f2f80-63da-11ea-9970-c52c9a8dfe30.png">



Additionally, unit tests were executed locally (`mvn verify -DskipITs`), with zero failed tests.

<img width="568" alt="Screen Shot 2020-03-11 at 8 36 15 PM" src="https://user-images.githubusercontent.com/37818548/76477242-16d0ed00-63db-11ea-9d47-6ca03360d936.png">


### Feedback Requested

Please review.

