### PR TITLE
BLUEBUTTON-1788: Change RifLoader log level

### DIFF
--- a/apps/bfd-pipeline/bfd-pipeline-app/src/main/resources/logback.xml
+++ b/apps/bfd-pipeline/bfd-pipeline-app/src/main/resources/logback.xml
@@ -12,8 +12,8 @@
 	<!-- At 'debug', Hibernate will log SQL statements. -->
 	<logger name="org.hibernate.SQL" level="info" />
 
-  <!-- At 'debug', will display timing information about the idle task batches -->
-	<logger name="gov.cms.bfd.pipeline.rif.load" level="debug" />
+    <!-- At 'debug', will display timing information about the idle task batches -->
+	<logger name="gov.cms.bfd.pipeline.rif.load" level="info" />
 	
 	<!-- At 'trace', Hibernate will log SQL parameter values. -->
 	<logger name="org.hibernate.type" level="info" />

--- a/apps/bfd-pipeline/bfd-pipeline-app/src/main/resources/logback.xml
+++ b/apps/bfd-pipeline/bfd-pipeline-app/src/main/resources/logback.xml
@@ -14,7 +14,10 @@
 
     <!-- At 'debug', will display timing information about the idle task batches -->
 	<logger name="gov.cms.bfd.pipeline.rif.load" level="info" />
-	
+
+	<!-- At 'debug', a RIF file load will log the record counts for all tables. Do not do this in PROD, or TEST -->
+	<logger name="gov.cms.bfd.pipeline.rif.load.RifLoader.recordCounts" level="info" />
+
 	<!-- At 'trace', Hibernate will log SQL parameter values. -->
 	<logger name="org.hibernate.type" level="info" />
 	


### PR DESCRIPTION
**Why**
As part of OUTPATIENT load work, it was discovered that the pipeline load was taking a very long time in TEST (and production). 

**What Changed**
The RifLoader log level was set to debug. At the debug level, the pipeline would count every row in every table after every RIF load. Even in PROD, this query would take hours.  

To get this fix done quickly, this PR just lowers the log level to info. 

**Testing Done**
Local testing to confirm that changing the log level stops the counting step. 

**Future Action**
Filed ticket to fix the debug level problem at the root. 
https://jira.cms.gov/browse/BLUEBUTTON-1921