### PR TITLE
BLUEBUTTON-2002 Return synthetic resources with negative IDs

### DIFF
--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/CoverageResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/CoverageResourceProvider.java
@@ -45,7 +45,10 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public final class CoverageResourceProvider implements IResourceProvider {
-  /** A {@link Pattern} that will match the {@link Coverage#getId()}s used in this application. */
+  /**
+   * A {@link Pattern} that will match the {@link Coverage#getId()}s used in this application, e.g.
+   * <code>part-a-1234</code> or <code>part-a--1234</code> (for negative IDs).
+   */
   private static final Pattern COVERAGE_ID_PATTERN =
       Pattern.compile("(\\p{Alnum}+-\\p{Alnum})-(-?\\p{Alnum}+)");
 

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/CoverageResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/CoverageResourceProvider.java
@@ -46,7 +46,8 @@ import org.springframework.stereotype.Component;
 @Component
 public final class CoverageResourceProvider implements IResourceProvider {
   /** A {@link Pattern} that will match the {@link Coverage#getId()}s used in this application. */
-  private static final Pattern COVERAGE_ID_PATTERN = Pattern.compile("(.*)-(\\p{Alnum}+)");
+  private static final Pattern COVERAGE_ID_PATTERN =
+      Pattern.compile("(\\p{Alnum}+-\\p{Alnum})-(-?\\p{Alnum}+)");
 
   private static final Logger LOGGER = LoggerFactory.getLogger(CoverageResourceProvider.class);
 

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/CoverageResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/CoverageResourceProvider.java
@@ -106,7 +106,9 @@ public final class CoverageResourceProvider implements IResourceProvider {
     operation.publishOperationName();
 
     Matcher coverageIdMatcher = COVERAGE_ID_PATTERN.matcher(coverageIdText);
-    if (!coverageIdMatcher.matches()) throw new ResourceNotFoundException(coverageId);
+    if (!coverageIdMatcher.matches())
+      throw new IllegalArgumentException("Unsupported ID pattern: " + coverageIdText);
+
     String coverageIdSegmentText = coverageIdMatcher.group(1);
     Optional<MedicareSegment> coverageIdSegment =
         MedicareSegment.selectByUrlPrefix(coverageIdSegmentText);

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/ExplanationOfBenefitResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/ExplanationOfBenefitResourceProvider.java
@@ -120,7 +120,9 @@ public final class ExplanationOfBenefitResourceProvider implements IResourceProv
     if (eobIdText == null || eobIdText.trim().isEmpty()) throw new IllegalArgumentException();
 
     Matcher eobIdMatcher = EOB_ID_PATTERN.matcher(eobIdText);
-    if (!eobIdMatcher.matches()) throw new ResourceNotFoundException(eobId);
+    if (!eobIdMatcher.matches())
+      throw new IllegalArgumentException("Unsupported ID pattern: " + eobIdText);
+
     String eobIdTypeText = eobIdMatcher.group(1);
     Optional<ClaimType> eobIdType = ClaimType.parse(eobIdTypeText);
     if (!eobIdType.isPresent()) throw new ResourceNotFoundException(eobId);

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/ExplanationOfBenefitResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/ExplanationOfBenefitResourceProvider.java
@@ -60,7 +60,7 @@ public final class ExplanationOfBenefitResourceProvider implements IResourceProv
    * A {@link Pattern} that will match the {@link ExplanationOfBenefit#getId()}s used in this
    * application.
    */
-  private static final Pattern EOB_ID_PATTERN = Pattern.compile("(\\p{Alpha}+)-(\\p{Alnum}+)");
+  private static final Pattern EOB_ID_PATTERN = Pattern.compile("(\\p{Alpha}+)-(-?\\p{Alnum}+)");
 
   private EntityManager entityManager;
   private MetricRegistry metricRegistry;

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/ExplanationOfBenefitResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/ExplanationOfBenefitResourceProvider.java
@@ -58,7 +58,7 @@ public final class ExplanationOfBenefitResourceProvider implements IResourceProv
 
   /**
    * A {@link Pattern} that will match the {@link ExplanationOfBenefit#getId()}s used in this
-   * application.
+   * application, e.g. <code>pde-1234</code> or <code>pde--1234</code> (for negative IDs).
    */
   private static final Pattern EOB_ID_PATTERN = Pattern.compile("(\\p{Alpha}+)-(-?\\p{Alnum}+)");
 

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/CoverageResourceProviderIT.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/CoverageResourceProviderIT.java
@@ -3,6 +3,7 @@ package gov.cms.bfd.server.war.stu3.providers;
 import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import gov.cms.bfd.model.rif.Beneficiary;
 import gov.cms.bfd.model.rif.samples.StaticRifResourceGroup;
@@ -73,8 +74,8 @@ public final class CoverageResourceProviderIT {
   /**
    * Verifies that {@link
    * gov.cms.bfd.server.war.stu3.providers.CoverageResourceProvider#read(org.hl7.fhir.dstu3.model.IdType)}
-   * works as expected for {@link Beneficiary}-derived {@link Coverage}s that do not exist in the
-   * DB.
+   * works as expected for {@link Beneficiary}-derived {@link Coverage}s that do not exist in the DB
+   * (with both positive and negative IDs).
    */
   @Test
   public void readCoveragesForMissingBeneficiary() {
@@ -107,14 +108,41 @@ public final class CoverageResourceProviderIT {
     }
     Assert.assertNotNull(exception);
 
+    // Tests negative ID will pass regex pattern for valid coverageId.
     exception = null;
     try {
       fhirClient
           .read()
           .resource(Coverage.class)
-          .withId(TransformerUtils.buildCoverageId(MedicareSegment.PART_D, "1234"))
+          .withId(TransformerUtils.buildCoverageId(MedicareSegment.PART_D, "-1234"))
           .execute();
     } catch (ResourceNotFoundException e) {
+      exception = e;
+    }
+    Assert.assertNotNull(exception);
+  }
+
+  /**
+   * Verifies that {@link
+   * gov.cms.bfd.server.war.stu3.providers.CoverageResourceProvider#read(org.hl7.fhir.dstu3.model.IdType)}
+   * works as expected for {@link Beneficiary}-derived {@link Coverage}s that has an invalid {@link
+   * gov.cms.bfd.server.war.stu3.providers.CoverageResourceProvider#IdParam} parameter.
+   */
+  @Test
+  public void readCoveragesForInvalidIdParam() {
+    IGenericClient fhirClient = ServerTestUtils.createFhirClient();
+
+    // Parameter is invalid, should throw exception
+    InvalidRequestException exception;
+
+    exception = null;
+    try {
+      fhirClient
+          .read()
+          .resource(Coverage.class)
+          .withId(TransformerUtils.buildCoverageId(MedicareSegment.PART_A, "1?234"))
+          .execute();
+    } catch (InvalidRequestException e) {
       exception = e;
     }
     Assert.assertNotNull(exception);

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/ExplanationOfBenefitResourceProviderIT.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/ExplanationOfBenefitResourceProviderIT.java
@@ -404,6 +404,43 @@ public final class ExplanationOfBenefitResourceProviderIT {
   /**
    * Verifies that {@link
    * gov.cms.bfd.server.war.stu3.providers.ExplanationOfBenefitResourceProvider#read(org.hl7.fhir.dstu3.model.IdType)}
+   * works as expected for a {@link PartDEvent}-derived {@link ExplanationOfBenefit} that does not
+   * exist in the DB using a negative ID.
+   */
+  @Test(expected = ResourceNotFoundException.class)
+  public void readEobForMissingNegativePartDEvent() {
+    IGenericClient fhirClient = ServerTestUtils.createFhirClient();
+
+    // No data is loaded, so this should return nothing. Tests negative ID will pass regex pattern.
+    fhirClient
+        .read()
+        .resource(ExplanationOfBenefit.class)
+        .withId(TransformerUtils.buildEobId(ClaimType.PDE, "-1234"))
+        .execute();
+  }
+
+  /**
+   * Verifies that {@link
+   * gov.cms.bfd.server.war.stu3.providers.ExplanationOfBenefitResourceProvider#read(org.hl7.fhir.dstu3.model.IdType)}
+   * works as expected for a {@link PartDEvent}-derived {@link ExplanationOfBenefit} that has an
+   * invalid {@link
+   * gov.cms.bfd.server.war.stu3.providers.ExplanationOfBenefitResourceProvider#IdParam} parameter.
+   */
+  @Test(expected = InvalidRequestException.class)
+  public void readEobForInvalidIdParamPartDEvent() {
+    IGenericClient fhirClient = ServerTestUtils.createFhirClient();
+
+    // The IdParam is not valid, so this should return an exception.
+    fhirClient
+        .read()
+        .resource(ExplanationOfBenefit.class)
+        .withId(TransformerUtils.buildEobId(ClaimType.PDE, "-1?234"))
+        .execute();
+  }
+
+  /**
+   * Verifies that {@link
+   * gov.cms.bfd.server.war.stu3.providers.ExplanationOfBenefitResourceProvider#read(org.hl7.fhir.dstu3.model.IdType)}
    * works as expected for an {@link SNFClaim}-derived {@link ExplanationOfBenefit} that does exist
    * in the DB.
    *


### PR DESCRIPTION
### Change Details
NOTE: This is a continuation of a previous PR with the target branch moved local.  Please reference  that PR for previous review comments at:  https://github.com/CMSgov/beneficiary-fhir-data/pull/175

#### Summary:
A regex for parsing the format of EoB and Coverage resource read requests did not successfully parse synthetic Resource read requests due to their negative IDs. The result was that no synthetic EoB or Coverage resources were found on Read requests.

This updates those regex to allow for the IDs of these Resources to be negative.

#### The following was performed:
* Moved the target branch to local and created a new PR so that this works with our deployment process.
* For the Coverage and EOB `read()` ID parameter, changed the exception from `ResourceNotFoundException` to `IllegalArgumentException` when an `IdText` does not match the expected Regex pattern. I believe this failed match should be invalid rather than indicating an ID was not found.
* Updated the IT tests for Coverage and EOB `read()` methods to test that the ID parameters work as expected for negative IDs and IDs that do not pass the regex pattern for a valid format.
* Updated comments per Karl's review suggestions.

### Acceptance Validation
* That Coverage and EOB `read()` requests are able to handle negative IDs.
* That Coverage and EOB `read()` requests with an invalid format ID throw an  `IllegalArgumentException` exception.
* That IT tests are updated to test negative IDs and invalid format.

### External References

- [BLUEBUTTON-2002](https://jira.cms.gov/browse/BLUEBUTTON-2002)
- [BFD-155](https://jira.cms.gov/browse/BFD-155)

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] altered security controls

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications
<!-- Use this to indicate you're unsure how this change may impact system security and would like to solicit the team's feedback. Optionally, provide background information regarding your questions and concerns. -->





