### PR TITLE
BLUEBUTTON-1864: Medicare Opt Out bucket fixes, AB2D onboarding

### DIFF
--- a/ops/terraform/env/prod-sbx/stateful/main.tf
+++ b/ops/terraform/env/prod-sbx/stateful/main.tf
@@ -50,7 +50,7 @@ module "stateful" {
   victor_ops_url      = var.victor_ops_url
 
   medicare_opt_out_config = {
-    read_roles        = ["arn:aws:iam::755619740999:role/dpc-dev-consent-execution-role"]
+    read_roles        = ["arn:aws:iam::755619740999:role/dpc-dev-consent-execution-role", "arn:aws:iam::349849222861:role/Ab2dInstanceRole", "arn:aws:iam::777200079629:role/Ab2dInstanceRole", "arn:aws:iam::330810004472:role/Ab2dInstanceRole"]
     write_roles       = ["arn:aws:iam::755619740999:role/bcda-dev-nfs-instance", "arn:aws:iam::755619740999:role/bcda-test-nfs-instance"]
     admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9"]
   }

--- a/ops/terraform/env/prod-sbx/stateful/main.tf
+++ b/ops/terraform/env/prod-sbx/stateful/main.tf
@@ -52,6 +52,6 @@ module "stateful" {
   medicare_opt_out_config = {
     read_roles        = ["arn:aws:iam::755619740999:role/dpc-dev-consent-execution-role"]
     write_roles       = ["arn:aws:iam::755619740999:role/bcda-dev-nfs-instance", "arn:aws:iam::755619740999:role/bcda-test-nfs-instance"]
-    admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9", "arn:aws:iam::577373831711:user/BYSK"]
+    admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9"]
   }
 }

--- a/ops/terraform/env/prod/stateful/main.tf
+++ b/ops/terraform/env/prod/stateful/main.tf
@@ -61,6 +61,6 @@ module "stateful" {
     # TODO: add read roles for DPC
     read_roles        = []
     write_roles       = ["arn:aws:iam::755619740999:role/bcda-prod-nfs-instance"]
-    admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9", "arn:aws:iam::577373831711:user/BYSK"]
+    admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9"]
   }
 }

--- a/ops/terraform/env/test/stateful/main.tf
+++ b/ops/terraform/env/test/stateful/main.tf
@@ -59,7 +59,7 @@ module "stateful" {
   victor_ops_url      = var.victor_ops_url
 
   medicare_opt_out_config = {
-    read_roles        = ["arn:aws:iam::755619740999:role/dpc-dev-consent-execution-role"]
+    read_roles        = ["arn:aws:iam::755619740999:role/dpc-dev-consent-execution-role", "arn:aws:iam::349849222861:role/Ab2dInstanceRole", "arn:aws:iam::777200079629:role/Ab2dInstanceRole", "arn:aws:iam::330810004472:role/Ab2dInstanceRole"]
     write_roles       = ["arn:aws:iam::755619740999:role/bcda-dev-nfs-instance", "arn:aws:iam::755619740999:role/bcda-test-nfs-instance"]
     admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9"]
   }

--- a/ops/terraform/env/test/stateful/main.tf
+++ b/ops/terraform/env/test/stateful/main.tf
@@ -61,6 +61,6 @@ module "stateful" {
   medicare_opt_out_config = {
     read_roles        = ["arn:aws:iam::755619740999:role/dpc-dev-consent-execution-role"]
     write_roles       = ["arn:aws:iam::755619740999:role/bcda-dev-nfs-instance", "arn:aws:iam::755619740999:role/bcda-test-nfs-instance"]
-    admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9", "arn:aws:iam::577373831711:user/BYSK"]
+    admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9"]
   }
 }

--- a/ops/terraform/modules/resources/s3_pii/templates/bucket-policy.json
+++ b/ops/terraform/modules/resources/s3_pii/templates/bucket-policy.json
@@ -66,23 +66,6 @@
       ]
     },
     {
-      "Sid": "BFDPIIS3DenyNonExplicitUsers",
-      "Effect": "Deny",
-      "NotPrincipal": {
-        "AWS": [
-          %{ for reader in readers ~}"${reader}",%{ endfor ~}
-          %{ for writer in writers ~}"${writer}",%{ endfor ~}
-          %{ for admin in admins ~}"${admin}",%{ endfor ~}
-          "${root}"
-        ]
-      },
-      "Action": "s3:*",
-      "Resource": [
-        "arn:aws:s3:::${bucket_id}/*",
-        "arn:aws:s3:::${bucket_id}"
-      ]
-    },
-    {
       "Sid": "BFDPIIS3DenyUnencrypted",
       "Effect": "Deny",
       "Principal": "*",

--- a/ops/terraform/modules/resources/s3_pii/templates/kms-policy.json
+++ b/ops/terraform/modules/resources/s3_pii/templates/kms-policy.json
@@ -27,7 +27,7 @@
       "Action": [
         "kms:Encrypt",
         "kms:Decrypt",
-        "kms:ReEncrypt",
+        "kms:ReEncrypt*",
         "kms:GenerateDataKey*",
         "kms:DescribeKey"
       ],


### PR DESCRIPTION
### Change Details

This PR contains some minor changes:
- Fixes the KMS policy
- Fixes the bucket policy by removing a non-functional deny statement
- Removes offboarded admin
- Adds AB2D roles as readers to test (not currently used) and prod-sbx

### Acceptance Validation

- AB2D can make S3 requests to prod-sbx bucket

### External References

- [BLUEBUTTON-1864](https://jira.cms.gov/browse/BLUEBUTTON-1864)

### Security Implications

- [ ] new software dependencies

- [X] altered security controls

This is worth discussing, as it was implemented that we'd have an explicit whitelist through denying actions via `NotPrincipal`, however I haven't been able to make this work in practice.  I'm unsure how much this changes to our security posture since we already have PII buckets (data from CCW) without this in place.

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications