### PR TITLE
BLUEBUTTON 2001: Slow Coverage search with paging and identifiers

### DIFF
--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
@@ -345,7 +345,8 @@ public final class PatientResourceProvider implements IResourceProvider {
 
     // Fetching with joins is not compatible with setMaxResults as explained in this post:
     // https://stackoverflow.com/questions/53569908/jpa-eager-fetching-and-pagination-best-practices
-    // So, in cases where there are joins and paging, we query in two steps.
+    // So, in cases where there are joins and paging, we query in two steps: first fetch bene-ids
+    // with paging and the fetch full benes with joins.
     boolean useTwoSteps =
         (hasHICN(includedIdentifiers) || hasMBI(includedIdentifiers)) && paging.isPagingRequested();
     if (useTwoSteps) {

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
@@ -23,7 +23,6 @@ import gov.cms.bfd.model.rif.BeneficiaryHistory_;
 import gov.cms.bfd.model.rif.Beneficiary_;
 import gov.cms.bfd.server.war.Operation;
 import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -41,7 +40,6 @@ import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
-import javax.persistence.metamodel.SetAttribute;
 import javax.persistence.metamodel.SingularAttribute;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.IdType;
@@ -292,33 +290,21 @@ public final class PatientResourceProvider implements IResourceProvider {
     }
   }
 
-  private SingularAttribute<Beneficiary, String> partDFieldFor(CcwCodebookVariable cntrctMonth) {
-    if (cntrctMonth == CcwCodebookVariable.PTDCNTRCT01)
-      return Beneficiary_.partDContractNumberJanId;
-    if (cntrctMonth == CcwCodebookVariable.PTDCNTRCT02)
-      return Beneficiary_.partDContractNumberFebId;
-    if (cntrctMonth == CcwCodebookVariable.PTDCNTRCT03)
-      return Beneficiary_.partDContractNumberMarId;
-    if (cntrctMonth == CcwCodebookVariable.PTDCNTRCT04)
-      return Beneficiary_.partDContractNumberAprId;
-    if (cntrctMonth == CcwCodebookVariable.PTDCNTRCT05)
-      return Beneficiary_.partDContractNumberMayId;
-    if (cntrctMonth == CcwCodebookVariable.PTDCNTRCT06)
-      return Beneficiary_.partDContractNumberJunId;
-    if (cntrctMonth == CcwCodebookVariable.PTDCNTRCT07)
-      return Beneficiary_.partDContractNumberJulId;
-    if (cntrctMonth == CcwCodebookVariable.PTDCNTRCT08)
-      return Beneficiary_.partDContractNumberAugId;
-    if (cntrctMonth == CcwCodebookVariable.PTDCNTRCT09)
-      return Beneficiary_.partDContractNumberSeptId;
-    if (cntrctMonth == CcwCodebookVariable.PTDCNTRCT10)
-      return Beneficiary_.partDContractNumberOctId;
-    if (cntrctMonth == CcwCodebookVariable.PTDCNTRCT11)
-      return Beneficiary_.partDContractNumberNovId;
-    if (cntrctMonth == CcwCodebookVariable.PTDCNTRCT12)
-      return Beneficiary_.partDContractNumberDecId;
+  private String partDFieldFor(CcwCodebookVariable month) {
+    if (month == CcwCodebookVariable.PTDCNTRCT01) return "partDContractNumberJanId";
+    if (month == CcwCodebookVariable.PTDCNTRCT02) return "partDContractNumberFebId";
+    if (month == CcwCodebookVariable.PTDCNTRCT03) return "partDContractNumberMarId";
+    if (month == CcwCodebookVariable.PTDCNTRCT04) return "partDContractNumberAprId";
+    if (month == CcwCodebookVariable.PTDCNTRCT05) return "partDContractNumberMayId";
+    if (month == CcwCodebookVariable.PTDCNTRCT06) return "partDContractNumberJunId";
+    if (month == CcwCodebookVariable.PTDCNTRCT07) return "partDContractNumberJulId";
+    if (month == CcwCodebookVariable.PTDCNTRCT08) return "partDContractNumberAugId";
+    if (month == CcwCodebookVariable.PTDCNTRCT09) return "partDContractNumberSeptId";
+    if (month == CcwCodebookVariable.PTDCNTRCT10) return "partDContractNumberOctId";
+    if (month == CcwCodebookVariable.PTDCNTRCT11) return "partDContractNumberNovId";
+    if (month == CcwCodebookVariable.PTDCNTRCT12) return "partDContractNumberDecId";
     throw new InvalidRequestException(
-        "Unsupported extension system: " + cntrctMonth.getVariable().getId().toLowerCase());
+        "Unsupported extension system: " + month.getVariable().getId().toLowerCase());
   }
 
   /**
@@ -335,18 +321,13 @@ public final class PatientResourceProvider implements IResourceProvider {
     String contractMonth =
         coverageId.getSystem().substring(coverageId.getSystem().lastIndexOf('/') + 1);
     CcwCodebookVariable partDContractMonth = partDCwVariableFor(contractMonth);
-    SingularAttribute<Beneficiary, String> contractMonthField = partDFieldFor(partDContractMonth);
+    String contractMonthField = partDFieldFor(partDContractMonth);
     String contractCode = coverageId.getValueNotNull();
-
-    // Use joins to fetch the mbi and hicn histories
-    List<SetAttribute<Beneficiary, ?>> joins = new ArrayList<>();
-    if (hasHICN(includedIdentifiers)) joins.add(Beneficiary_.beneficiaryHistories);
-    if (hasMBI(includedIdentifiers)) joins.add(Beneficiary_.medicareBeneficiaryIdHistories);
 
     // Fetching with joins is not compatible with setMaxResults as explained in this post:
     // https://stackoverflow.com/questions/53569908/jpa-eager-fetching-and-pagination-best-practices
     // So, in cases where there are joins and paging, we query in two steps: first fetch bene-ids
-    // with paging and the fetch full benes with joins.
+    // with paging and then fetch full benes with joins.
     boolean useTwoSteps =
         (hasHICN(includedIdentifiers) || hasMBI(includedIdentifiers)) && paging.isPagingRequested();
     if (useTwoSteps) {
@@ -357,10 +338,10 @@ public final class PatientResourceProvider implements IResourceProvider {
               .getResultList();
 
       // Fetch the benes using the ids
-      return queryBeneficiariesByIds(ids, joins).getResultList();
+      return queryBeneficiariesByIds(ids, includedIdentifiers).getResultList();
     } else {
       // Fetch benes and their histories in one query
-      return queryBeneficiariesBy(contractMonthField, contractCode, paging, joins)
+      return queryBeneficiariesBy(contractMonthField, contractCode, paging, includedIdentifiers)
           .setMaxResults(paging.getPageSize())
           .getResultList();
     }
@@ -372,29 +353,39 @@ public final class PatientResourceProvider implements IResourceProvider {
    * @param field to match on
    * @param value to match on
    * @param paging to use for the result set
-   * @param joins to add for many-to-one relations
+   * @param identifiers to add for many-to-one relations
    * @return the criteria
    */
   private TypedQuery<Beneficiary> queryBeneficiariesBy(
-      SingularAttribute<Beneficiary, String> field,
-      String value,
-      PatientLinkBuilder paging,
-      List<SetAttribute<Beneficiary, ?>> joins) {
-    CriteriaBuilder cb = entityManager.getCriteriaBuilder();
-    CriteriaQuery<Beneficiary> criteria = cb.createQuery(Beneficiary.class);
-    Root<Beneficiary> b = criteria.from(Beneficiary.class);
+      String field, String value, PatientLinkBuilder paging, List<String> identifiers) {
+    String joinsClause = "";
+    if (hasMBI(identifiers)) joinsClause += "left join fetch b.medicareBeneficiaryIdHistories ";
+    if (hasHICN(identifiers)) joinsClause += "left join fetch b.beneficiaryHistories ";
 
-    joins.forEach(f -> b.fetch(f, JoinType.LEFT));
+    if (paging.isPagingRequested() && !paging.isFirstPage()) {
+      String query =
+          "select b from Beneficiary b "
+              + joinsClause
+              + "where b."
+              + field
+              + " = :value and b.beneficiaryId > :cursor "
+              + "order by b.beneficiaryId asc";
 
-    Predicate whereClause =
-        paging.isPagingRequested() && !paging.isFirstPage()
-            ? cb.and(
-                cb.equal(b.get(field), value),
-                cb.greaterThan(b.get("beneficiaryId"), paging.getCursor()))
-            : cb.equal(b.get(field), value);
+      return entityManager
+          .createQuery(query, Beneficiary.class)
+          .setParameter("value", value)
+          .setParameter("cursor", paging.getCursor());
+    } else {
+      String query =
+          "select b from Beneficiary b "
+              + joinsClause
+              + "where b."
+              + field
+              + " = :value "
+              + "order by b.beneficiaryId asc";
 
-    return entityManager.createQuery(
-        criteria.select(b).where(whereClause).orderBy(cb.asc(b.get("beneficiaryId"))));
+      return entityManager.createQuery(query, Beneficiary.class).setParameter("value", value);
+    }
   }
 
   /**
@@ -406,43 +397,50 @@ public final class PatientResourceProvider implements IResourceProvider {
    * @return the criteria
    */
   private TypedQuery<String> queryBeneficiaryIds(
-      SingularAttribute<Beneficiary, String> field, String value, PatientLinkBuilder paging) {
-    CriteriaBuilder cb = entityManager.getCriteriaBuilder();
-    CriteriaQuery<String> criteria = cb.createQuery(String.class);
-    Root<Beneficiary> b = criteria.from(Beneficiary.class);
+      String field, String value, PatientLinkBuilder paging) {
+    if (paging.isPagingRequested() && !paging.isFirstPage()) {
+      String query =
+          "select b.beneficiaryId from Beneficiary b "
+              + "where b."
+              + field
+              + " = :value and b.beneficiaryId > :cursor "
+              + "order by b.beneficiaryId asc";
 
-    Predicate whereClause =
-        paging.isPagingRequested() && !paging.isFirstPage()
-            ? cb.and(
-                cb.equal(b.get(field), value),
-                cb.greaterThan(b.get("beneficiaryId"), paging.getCursor()))
-            : cb.equal(b.get(field), value);
+      return entityManager
+          .createQuery(query, String.class)
+          .setParameter("value", value)
+          .setParameter("cursor", paging.getCursor());
+    } else {
+      String query =
+          "select b.beneficiaryId from Beneficiary b "
+              + "where b."
+              + field
+              + " = :value "
+              + "order by b.beneficiaryId asc";
 
-    return entityManager.createQuery(
-        criteria
-            .select(b.get("beneficiaryId"))
-            .where(whereClause)
-            .orderBy(cb.asc(b.get("beneficiaryId"))));
+      return entityManager.createQuery(query, String.class).setParameter("value", value);
+    }
   }
 
   /**
    * Build a criteria for a beneficiary query using the passed in list of ids
    *
    * @param ids to use
-   * @param joins to add for many-to-one relations
+   * @param identifiers to add for many-to-one relations
    * @return the criteria
    */
   private TypedQuery<Beneficiary> queryBeneficiariesByIds(
-      List<String> ids, List<SetAttribute<Beneficiary, ?>> joins) {
-    CriteriaBuilder cb = entityManager.getCriteriaBuilder();
-    CriteriaQuery<Beneficiary> criteria = cb.createQuery(Beneficiary.class);
-    Root<Beneficiary> b = criteria.from(Beneficiary.class);
-    joins.forEach(f -> b.fetch(f, JoinType.LEFT));
-    return entityManager.createQuery(
-        criteria
-            .select(b)
-            .where(b.get("beneficiaryId").in(ids))
-            .orderBy(cb.asc(b.get("beneficiaryId"))));
+      List<String> ids, List<String> identifiers) {
+    String joinsClause = "";
+    if (hasMBI(identifiers)) joinsClause += "left join fetch b.medicareBeneficiaryIdHistories ";
+    if (hasHICN(identifiers)) joinsClause += "left join fetch b.beneficiaryHistories ";
+
+    String query =
+        "select b from Beneficiary b "
+            + joinsClause
+            + "where b.beneficiaryId in :ids "
+            + "order by b.beneficiaryId asc";
+    return entityManager.createQuery(query, Beneficiary.class).setParameter("ids", ids);
   }
 
   /**


### PR DESCRIPTION
**Motivation**
https://jira.cms.gov/browse/BLUEBUTTON-2001 reports a bug where a coverage searches together with paging and include-identifiers timed-out. 

**Cause**
When include-identifiers is set, the search uses a `join` clause to fetch the bene-id history. When paging is enabled, the search uses a `limit` clause to limit the number of returned results. 
There is subtle behavior with Hibernate where joins and limits cannot be used together; In this case, Hibernate drops the limit. 

This post explains the problem as well.
https://stackoverflow.com/questions/53569908/jpa-eager-fetching-and-pagination-best-practices

Note: The current code returns correct or nearly correct results. Test cases passed and the current code works small history datasets like those in SBX. 

**Changes Made**
When paging and include identifiers are set, execute the query in two steps: First, fetch bene-ids using a `limit` clause. Next, fetch a full list of beneficiaries with joins. 

Also did some refactoring was done to make the code more readable. This work included switching to JPQL as the language for the query. 

**Reviewer Guidance**
Look that the existing queries did not change. Look at the queries for edge cases. 

**Security**
No impact




