### PR TITLE
Disable Fixup Count

### DIFF
--- a/apps/bfd-pipeline/bfd-pipeline-rif-load/src/main/java/gov/cms/bfd/pipeline/rif/load/RifLoaderIdleTasks.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rif-load/src/main/java/gov/cms/bfd/pipeline/rif/load/RifLoaderIdleTasks.java
@@ -253,6 +253,8 @@ public class RifLoaderIdleTasks {
    * @return true if done with this task.
    */
   public boolean doInitialTask() {
+    if (!options.isFixupsEnabled()) return true;
+
     final EntityManager em = entityManagerFactory.createEntityManager();
 
     final Long beneficiaryCount =


### PR DESCRIPTION
**Why**
When fixupEnabled=false, the fixup code was still counting the number of bene and bene-history records that needed to be fixed up. This count was causing an timeout with the Aurora DB.

**What**
A test for fixupEnabled=true was added to the initial idle task. 

**Testing**
I tried a canary on PROD to see if this fix worked. Confirmed that it does remove the count query and the ETL process starts up. 
```
2020-04-27 21:59:53,241 [main] INFO  org.hibernate.Version - HHH000412: Hibernate Core {5.2.10.Final}
2020-04-27 21:59:53,242 [main] INFO  org.hibernate.cfg.Environment - HHH000206: hibernate.properties not found
2020-04-27 21:59:53,264 [main] INFO  o.h.annotations.common.Version - HCANN000001: Hibernate Commons Annotations {5.0.1.Final}
2020-04-27 21:59:53,407 [main] INFO  org.hibernate.dialect.Dialect - HHH000400: Using dialect: org.hibernate.dialect.PostgreSQL81Dialect
2020-04-27 21:59:53,554 [main] INFO  o.h.e.j.e.i.LobCreatorBuilderImpl - HHH000424: Disabling contextual LOB creation as createClob() method threw error : java.lang.reflect.InvocationTargetException
2020-04-27 21:59:53,846 [main] WARN  o.h.b.i.SessionFactoryBuilderImpl - org.hibernate.tool.schema.Action cannot be cast to java.lang.String  Ignoring
2020-04-27 21:59:54,966 [main] INFO  g.c.b.p.r.extract.s3.DataSetMonitor - Starting data set monitor: watching for data sets to process...
2020-04-27 21:59:54,967 [main] INFO  g.c.b.p.app.S3ToDatabaseLoadApp - Monitoring S3 for new data sets to process...
2020-04-27 21:59:55,569 [pool-2-thread-1] INFO  g.c.b.p.rif.load.RifLoaderIdleTasks - Finished idle task: INITIAL
2020-04-27 21:59:56,896 [pool-2-thread-1] INFO  g.c.b.p.rif.load.RifLoaderIdleTasks - PostStartup fixups are not enabled.
```