### PR TITLE
BLUEBUTTON-1992: Clean up RDS resources post Aurora migration

### DIFF
--- a/ops/terraform/env/prod-sbx/stateful/main.tf
+++ b/ops/terraform/env/prod-sbx/stateful/main.tf
@@ -27,20 +27,20 @@ module "stateful" {
     {name = "work_mem", value = "32768", apply_on_reboot = false}
   ]
 
-  db_config = { 
-    instance_class    = "db.m5.2xlarge"
-    iops              = 1000
-    allocated_storage = 2000
-  }
+  # db_config = {
+  #   instance_class    = "db.m5.2xlarge"
+  #   iops              = 1000
+  #   allocated_storage = 2000
+  # }
 
-  db_params = [
-    {name="max_wal_senders", value="15", apply_on_reboot=true},
-  ]
+  # db_params = [
+  #   {name="max_wal_senders", value="15", apply_on_reboot=true},
+  # ]
 
-  db_import_mode = {
-    enabled = false
-    maintenance_work_mem = "1048576"
-  }
+  # db_import_mode = {
+  #   enabled = false
+  #   maintenance_work_mem = "1048576"
+  # }
 
   env_config = {
     env               = "prod-sbx"

--- a/ops/terraform/env/prod/stateful/main.tf
+++ b/ops/terraform/env/prod/stateful/main.tf
@@ -27,28 +27,28 @@ module "stateful" {
     {name = "work_mem", value = "32768", apply_on_reboot = false}
   ]
 
-  db_config = { 
-    instance_class    = "db.r5.24xlarge"
-    iops              = 16000
-    allocated_storage = 16000
-  }
+  # db_config = {
+  #   instance_class    = "db.r5.24xlarge"
+  #   iops              = 16000
+  #   allocated_storage = 16000
+  # }
 
-  db_params = [
-    {name="auto_explain.log_min_duration", value="6000", apply_on_reboot=false},
-    {name="effective_io_concurrency", value="300", apply_on_reboot=false},
-    {name="default_statistics_target", value="1000", apply_on_reboot=false},
-    {name="max_worker_processes", value="96", apply_on_reboot=true},
-    {name="max_wal_senders", value="15", apply_on_reboot=true},
-    {name="max_parallel_workers_per_gather", value="48", apply_on_reboot=false},
-    {name="random_page_cost", value="1", apply_on_reboot=false},
-    {name="temp_buffers", value="8192", apply_on_reboot=false},
-    {name="work_mem", value="32768", apply_on_reboot=false}
-  ]
+  # db_params = [
+  #   {name="auto_explain.log_min_duration", value="6000", apply_on_reboot=false},
+  #   {name="effective_io_concurrency", value="300", apply_on_reboot=false},
+  #   {name="default_statistics_target", value="1000", apply_on_reboot=false},
+  #   {name="max_worker_processes", value="96", apply_on_reboot=true},
+  #   {name="max_wal_senders", value="15", apply_on_reboot=true},
+  #   {name="max_parallel_workers_per_gather", value="48", apply_on_reboot=false},
+  #   {name="random_page_cost", value="1", apply_on_reboot=false},
+  #   {name="temp_buffers", value="8192", apply_on_reboot=false},
+  #   {name="work_mem", value="32768", apply_on_reboot=false}
+  # ]
 
-  db_import_mode = {
-    enabled = false
-    maintenance_work_mem = "4194304"
-  }
+  # db_import_mode = {
+  #   enabled = false
+  #   maintenance_work_mem = "4194304"
+  # }
 
   env_config = {
     env               = "prod"

--- a/ops/terraform/env/test/stateful/main.tf
+++ b/ops/terraform/env/test/stateful/main.tf
@@ -27,29 +27,29 @@ module "stateful" {
     {name = "work_mem", value = "32768", apply_on_reboot = false}
   ]
 
-  db_config = { 
-    instance_class    = "db.r5.24xlarge"
-    iops              = 6000
-    allocated_storage = 12000
-  }
+  # db_config = {
+  #   instance_class    = "db.r5.24xlarge"
+  #   iops              = 6000
+  #   allocated_storage = 12000
+  # }
 
-  db_params = [
-    {name="auto_explain.log_min_duration", value="6000", apply_on_reboot=false},
-    {name="effective_io_concurrency", value="300", apply_on_reboot=false},
-    {name="default_statistics_target", value="1000", apply_on_reboot=false},
-    {name="max_worker_processes", value="96", apply_on_reboot=true},
-    {name="max_wal_senders", value="15", apply_on_reboot=true},
-    {name="max_parallel_workers_per_gather", value="48", apply_on_reboot=false},
-    {name="random_page_cost", value="1", apply_on_reboot=false},
-    {name="temp_buffers", value="8192", apply_on_reboot=false},
-    {name="work_mem", value="32768", apply_on_reboot=false},
-    {name="log_connections", value="1", apply_on_reboot=false}
-  ]
+  # db_params = [
+  #   {name="auto_explain.log_min_duration", value="6000", apply_on_reboot=false},
+  #   {name="effective_io_concurrency", value="300", apply_on_reboot=false},
+  #   {name="default_statistics_target", value="1000", apply_on_reboot=false},
+  #   {name="max_worker_processes", value="96", apply_on_reboot=true},
+  #   {name="max_wal_senders", value="15", apply_on_reboot=true},
+  #   {name="max_parallel_workers_per_gather", value="48", apply_on_reboot=false},
+  #   {name="random_page_cost", value="1", apply_on_reboot=false},
+  #   {name="temp_buffers", value="8192", apply_on_reboot=false},
+  #   {name="work_mem", value="32768", apply_on_reboot=false},
+  #   {name="log_connections", value="1", apply_on_reboot=false}
+  # ]
 
-  db_import_mode = {
-    enabled = false
-    maintenance_work_mem = "4194304"
-  }
+  # db_import_mode = {
+  #   enabled = false
+  #   maintenance_work_mem = "4194304"
+  # }
 
   env_config = {
     env               = "test"

--- a/ops/terraform/modules/stateful/main.tf
+++ b/ops/terraform/modules/stateful/main.tf
@@ -11,25 +11,25 @@ locals {
   victor_ops_url        = var.victor_ops_url
   enable_victor_ops     = local.is_prod # only wake people up for prod alarms
 
-  db_sgs = [
-    aws_security_group.db.id,
-    data.aws_security_group.vpn.id,
-    data.aws_security_group.tools.id,
-    data.aws_security_group.management.id
-  ]
-  master_db_sgs = [
-    aws_security_group.master_db.id,
-    data.aws_security_group.vpn.id,
-    data.aws_security_group.tools.id,
-    data.aws_security_group.management.id
-  ]
+  # db_sgs = [
+  #   aws_security_group.db.id,
+  #   data.aws_security_group.vpn.id,
+  #   data.aws_security_group.tools.id,
+  #   data.aws_security_group.management.id
+  # ]
+  # master_db_sgs = [
+  #   aws_security_group.master_db.id,
+  #   data.aws_security_group.vpn.id,
+  #   data.aws_security_group.tools.id,
+  #   data.aws_security_group.management.id
+  # ]
 
-  cw_period             = 60    # Seconds
-  cw_eval_periods       = 3
-  cw_disk_queue_depth   = 5
-  cw_replica_lag_period = 3600
-  cw_replica_lag        = 1800   # Seconds
-  cw_latency            = 0.2   # Seconds
+  # cw_period             = 60    # Seconds
+  # cw_eval_periods       = 3
+  # cw_disk_queue_depth   = 5
+  # cw_replica_lag_period = 3600
+  # cw_replica_lag        = 1800   # Seconds
+  # cw_latency            = 0.2   # Seconds
 
 }
 
@@ -137,58 +137,58 @@ resource "aws_sns_topic_subscription" "ok" {
   endpoint_auto_confirms = true
 }
 
-# DB Security group
-#
-resource "aws_security_group" "db" {
-  name        = "bfd-${var.env_config.env}-rds"
-  description = "Security group for replica DPC DB"
-  vpc_id      = local.env_config.vpc_id
-  tags        = merge({Name="bfd-${var.env_config.env}-rds"}, local.env_config.tags)
+# # DB Security group
+# #
+# resource "aws_security_group" "db" {
+#   name        = "bfd-${var.env_config.env}-rds"
+#   description = "Security group for replica DPC DB"
+#   vpc_id      = local.env_config.vpc_id
+#   tags        = merge({Name="bfd-${var.env_config.env}-rds"}, local.env_config.tags)
 
-  # Ingress will come from security group rules defined later
-  egress {
-    from_port = 0
-    protocol  = "-1"
-    to_port   = 0
+#   # Ingress will come from security group rules defined later
+#   egress {
+#     from_port = 0
+#     protocol  = "-1"
+#     to_port   = 0
 
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-}
+#     cidr_blocks = ["0.0.0.0/0"]
+#   }
+# }
 
-resource "aws_security_group" "master_db" {
-  name        = "bfd-${var.env_config.env}-master-rds"
-  description = "Security group for master DPC DB"
-  vpc_id      = local.env_config.vpc_id
-  tags        = merge({Name="bfd-${var.env_config.env}-master-rds"}, local.env_config.tags)
+# resource "aws_security_group" "master_db" {
+#   name        = "bfd-${var.env_config.env}-master-rds"
+#   description = "Security group for master DPC DB"
+#   vpc_id      = local.env_config.vpc_id
+#   tags        = merge({Name="bfd-${var.env_config.env}-master-rds"}, local.env_config.tags)
 
-  # Ingress will come from security group rules defined later
-  egress {
-    from_port = 0
-    protocol  = "-1"
-    to_port   = 0
+#   # Ingress will come from security group rules defined later
+#   egress {
+#     from_port = 0
+#     protocol  = "-1"
+#     to_port   = 0
 
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-}
+#     cidr_blocks = ["0.0.0.0/0"]
+#   }
+# }
 
-resource "aws_security_group_rule" "allow_master_access" {
-  type                      = "ingress"
-  from_port                 = 5432
-  to_port                   = 5432
-  protocol                  = "tcp"
+# resource "aws_security_group_rule" "allow_master_access" {
+#   type                      = "ingress"
+#   from_port                 = 5432
+#   to_port                   = 5432
+#   protocol                  = "tcp"
 
-  description               = "Allow every replica db to call the master"
-  security_group_id         = aws_security_group.master_db.id  
-  source_security_group_id  = aws_security_group.db.id     
-}
+#   description               = "Allow every replica db to call the master"
+#   security_group_id         = aws_security_group.master_db.id
+#   source_security_group_id  = aws_security_group.db.id
+# }
 
-# Subnet Group
-#
-resource "aws_db_subnet_group" "db" {
-  name            = "bfd-${local.env_config.env}-subnet-group"
-  tags            = local.env_config.tags
-  subnet_ids      = [for s in data.aws_subnet.data_subnets: s.id]
-}
+# # Subnet Group
+# #
+# resource "aws_db_subnet_group" "db" {
+#   name            = "bfd-${local.env_config.env}-subnet-group"
+#   tags            = local.env_config.tags
+#   subnet_ids      = [for s in data.aws_subnet.data_subnets: s.id]
+# }
 
 # Aurora module: supplants separate param groups, rds modules, and rds
 # alarms modules
@@ -211,242 +211,242 @@ module "aurora" {
   }
 }
 
-# Parameter Group
-#
-resource "aws_db_parameter_group" "default_mode" {
-  name        = "bfd-${local.env_config.env}-default-mode-parameter-group"
-  family      = "postgres9.6"
-  description = "Sets parameters for standard operation"
+# # Parameter Group
+# #
+# resource "aws_db_parameter_group" "default_mode" {
+#   name        = "bfd-${local.env_config.env}-default-mode-parameter-group"
+#   family      = "postgres9.6"
+#   description = "Sets parameters for standard operation"
 
-  dynamic "parameter" {
-    for_each = var.db_params
-    content {
-      name         = parameter.value.name
-      value        = parameter.value.value
-      apply_method = parameter.value.apply_on_reboot ? "pending-reboot" : null
-    }
-  }
-}
+#   dynamic "parameter" {
+#     for_each = var.db_params
+#     content {
+#       name         = parameter.value.name
+#       value        = parameter.value.value
+#       apply_method = parameter.value.apply_on_reboot ? "pending-reboot" : null
+#     }
+#   }
+# }
 
-resource "aws_db_parameter_group" "import_mode" {
-  name        = "bfd-${local.env_config.env}-import-mode-parameter-group"
-  family      = "postgres9.6"
-  description = "Sets parameters that optimize bulk data imports"
+# resource "aws_db_parameter_group" "import_mode" {
+#   name        = "bfd-${local.env_config.env}-import-mode-parameter-group"
+#   family      = "postgres9.6"
+#   description = "Sets parameters that optimize bulk data imports"
 
-  parameter {
-    name  = "maintenance_work_mem"
-    value = var.db_import_mode.maintenance_work_mem
-  }
+#   parameter {
+#     name  = "maintenance_work_mem"
+#     value = var.db_import_mode.maintenance_work_mem
+#   }
 
-  parameter {
-    name  = "max_wal_size"
-    value = "256"
-    apply_method = "pending-reboot"
-  }
+#   parameter {
+#     name  = "max_wal_size"
+#     value = "256"
+#     apply_method = "pending-reboot"
+#   }
 
-  parameter {
-    name  = "checkpoint_timeout"
-    value = "1800"
-  }
+#   parameter {
+#     name  = "checkpoint_timeout"
+#     value = "1800"
+#   }
 
-  parameter {
-    name  = "synchronous_commit"
-    value = "off"
-  }
+#   parameter {
+#     name  = "synchronous_commit"
+#     value = "off"
+#   }
 
-  parameter {
-    name  = "wal_buffers"
-    value = "8192"
-    apply_method = "pending-reboot"
-  }
+#   parameter {
+#     name  = "wal_buffers"
+#     value = "8192"
+#     apply_method = "pending-reboot"
+#   }
 
-  parameter {
-    name  = "autovacuum"
-    value = "0"
-  }
+#   parameter {
+#     name  = "autovacuum"
+#     value = "0"
+#   }
   
-  parameter {
-    name = "log_connections"
-    value = "1"
-  }
+#   parameter {
+#     name = "log_connections"
+#     value = "1"
+#   }
 
-}
+# }
 
-# Master Database
-#
-module "master" {
-  source              = "../resources/rds"
-  db_config           = var.db_config
-  env_config          = local.env_config
-  role                = "master"
-  availability_zone   = local.azs[1]
-  replicate_source_db = ""
-  subnet_group        = aws_db_subnet_group.db.name
-  kms_key_id          = data.aws_kms_key.master_key.arn
+# # Master Database
+# #
+# module "master" {
+#   source              = "../resources/rds"
+#   db_config           = var.db_config
+#   env_config          = local.env_config
+#   role                = "master"
+#   availability_zone   = local.azs[1]
+#   replicate_source_db = ""
+#   subnet_group        = aws_db_subnet_group.db.name
+#   kms_key_id          = data.aws_kms_key.master_key.arn
 
-  vpc_security_group_ids = local.master_db_sgs
+#   vpc_security_group_ids = local.master_db_sgs
 
-  apply_immediately    = var.db_import_mode.enabled
-  parameter_group_name = var.db_import_mode.enabled ? aws_db_parameter_group.import_mode.name : aws_db_parameter_group.default_mode.name
-}
+#   apply_immediately    = var.db_import_mode.enabled
+#   parameter_group_name = var.db_import_mode.enabled ? aws_db_parameter_group.import_mode.name : aws_db_parameter_group.default_mode.name
+# }
 
-# Replicas Database 
-# 
-# No count on modules yet, so do build them one by one
-#
-module "replica1" {
-  source              = "../resources/rds"
-  db_config           = var.db_config
-  env_config          = local.env_config
-  role                = "replica1"
-  availability_zone   = local.azs[0]
-  replicate_source_db = module.master.identifier
-  subnet_group        = aws_db_subnet_group.db.name
-  kms_key_id          = data.aws_kms_key.master_key.arn
+# # Replicas Database
+# #
+# # No count on modules yet, so do build them one by one
+# #
+# module "replica1" {
+#   source              = "../resources/rds"
+#   db_config           = var.db_config
+#   env_config          = local.env_config
+#   role                = "replica1"
+#   availability_zone   = local.azs[0]
+#   replicate_source_db = module.master.identifier
+#   subnet_group        = aws_db_subnet_group.db.name
+#   kms_key_id          = data.aws_kms_key.master_key.arn
 
-  vpc_security_group_ids = local.db_sgs
+#   vpc_security_group_ids = local.db_sgs
 
-  apply_immediately    = var.db_import_mode.enabled
-  parameter_group_name = aws_db_parameter_group.default_mode.name
-}
+#   apply_immediately    = var.db_import_mode.enabled
+#   parameter_group_name = aws_db_parameter_group.default_mode.name
+# }
 
-module "replica2" {
-  source              = "../resources/rds"
-  db_config           = var.db_config
-  env_config          = local.env_config
-  role                = "replica2"
-  availability_zone   = local.azs[1]
-  replicate_source_db = module.master.identifier
-  subnet_group        = aws_db_subnet_group.db.name
-  kms_key_id          = data.aws_kms_key.master_key.arn
+# module "replica2" {
+#   source              = "../resources/rds"
+#   db_config           = var.db_config
+#   env_config          = local.env_config
+#   role                = "replica2"
+#   availability_zone   = local.azs[1]
+#   replicate_source_db = module.master.identifier
+#   subnet_group        = aws_db_subnet_group.db.name
+#   kms_key_id          = data.aws_kms_key.master_key.arn
 
-  vpc_security_group_ids = local.db_sgs
+#   vpc_security_group_ids = local.db_sgs
 
-  apply_immediately    = var.db_import_mode.enabled
-  parameter_group_name = aws_db_parameter_group.default_mode.name
-}
+#   apply_immediately    = var.db_import_mode.enabled
+#   parameter_group_name = aws_db_parameter_group.default_mode.name
+# }
 
-module "replica3" {
-  source              = "../resources/rds"
-  db_config           = var.db_config
-  env_config          = local.env_config
-  role                = "replica3"
-  availability_zone   = local.azs[2]
-  replicate_source_db = module.master.identifier
-  subnet_group        = aws_db_subnet_group.db.name
-  kms_key_id          = data.aws_kms_key.master_key.arn
+# module "replica3" {
+#   source              = "../resources/rds"
+#   db_config           = var.db_config
+#   env_config          = local.env_config
+#   role                = "replica3"
+#   availability_zone   = local.azs[2]
+#   replicate_source_db = module.master.identifier
+#   subnet_group        = aws_db_subnet_group.db.name
+#   kms_key_id          = data.aws_kms_key.master_key.arn
 
-  vpc_security_group_ids = local.db_sgs
+#   vpc_security_group_ids = local.db_sgs
 
-  apply_immediately    = var.db_import_mode.enabled
-  parameter_group_name = aws_db_parameter_group.default_mode.name
-}
+#   apply_immediately    = var.db_import_mode.enabled
+#   parameter_group_name = aws_db_parameter_group.default_mode.name
+# }
 
-# Cloud Watch alarms for each RDS instance
-#
-module "master_alarms" {
-  source              = "../resources/rds_alarms"
-  rds_name            = module.master.identifier
-  env                 = var.env_config.env
-  app                 = "bfd"
-  tags                = var.env_config.tags
+# # Cloud Watch alarms for each RDS instance
+# #
+# module "master_alarms" {
+#   source              = "../resources/rds_alarms"
+#   rds_name            = module.master.identifier
+#   env                 = var.env_config.env
+#   app                 = "bfd"
+#   tags                = var.env_config.tags
 
-  free_storage = {
-    period            = local.cw_period
-    eval_periods      = local.cw_eval_periods
-    threshold         = 50000000000 # Bytes
-  }
+#   free_storage = {
+#     period            = local.cw_period
+#     eval_periods      = local.cw_eval_periods
+#     threshold         = 50000000000 # Bytes
+#   }
 
-  write_latency = {
-    period            = local.cw_period
-    eval_periods      = local.cw_eval_periods
-    threshold         = local.cw_latency
-  }
+#   write_latency = {
+#     period            = local.cw_period
+#     eval_periods      = local.cw_eval_periods
+#     threshold         = local.cw_latency
+#   }
 
-  # Do not alarm on disk_queue_depth. This metric didn't
-  # have much correlation to a healthy database
+#   # Do not alarm on disk_queue_depth. This metric didn't
+#   # have much correlation to a healthy database
 
-  alarm_notification_arn = aws_sns_topic.cloudwatch_alarms.arn
-  ok_notification_arn = aws_sns_topic.cloudwatch_ok.arn
-}
+#   alarm_notification_arn = aws_sns_topic.cloudwatch_alarms.arn
+#   ok_notification_arn = aws_sns_topic.cloudwatch_ok.arn
+# }
 
-module "replica1_alarms" {
-  source              = "../resources/rds_alarms"
-  rds_name            = module.replica1.identifier
-  env                 = var.env_config.env
-  app                 = "bfd"
-  tags                = var.env_config.tags
+# module "replica1_alarms" {
+#   source              = "../resources/rds_alarms"
+#   rds_name            = module.replica1.identifier
+#   env                 = var.env_config.env
+#   app                 = "bfd"
+#   tags                = var.env_config.tags
 
-  read_latency = {
-    period            = local.cw_period
-    eval_periods      = local.cw_eval_periods
-    threshold         = local.cw_latency
-  }
+#   read_latency = {
+#     period            = local.cw_period
+#     eval_periods      = local.cw_eval_periods
+#     threshold         = local.cw_latency
+#   }
 
-  replica_lag = {
-    period            = local.cw_replica_lag_period
-    eval_periods      = local.cw_eval_periods
-    threshold         = local.cw_replica_lag
-  }
+#   replica_lag = {
+#     period            = local.cw_replica_lag_period
+#     eval_periods      = local.cw_eval_periods
+#     threshold         = local.cw_replica_lag
+#   }
 
-  # Do not alarm on disk_queue_depth. This metric didn't
-  # have much correlation to a healthy database
+#   # Do not alarm on disk_queue_depth. This metric didn't
+#   # have much correlation to a healthy database
 
-  alarm_notification_arn = aws_sns_topic.cloudwatch_alarms.arn
-  ok_notification_arn = aws_sns_topic.cloudwatch_ok.arn
-}
+#   alarm_notification_arn = aws_sns_topic.cloudwatch_alarms.arn
+#   ok_notification_arn = aws_sns_topic.cloudwatch_ok.arn
+# }
 
-module "replica2_alarms" {
-  source              = "../resources/rds_alarms"
-  rds_name            = module.replica2.identifier
-  env                 = var.env_config.env
-  app                 = "bfd"
-  tags                = var.env_config.tags
+# module "replica2_alarms" {
+#   source              = "../resources/rds_alarms"
+#   rds_name            = module.replica2.identifier
+#   env                 = var.env_config.env
+#   app                 = "bfd"
+#   tags                = var.env_config.tags
 
-  read_latency = {
-    period            = local.cw_period
-    eval_periods      = local.cw_eval_periods
-    threshold         = local.cw_latency
-  }
+#   read_latency = {
+#     period            = local.cw_period
+#     eval_periods      = local.cw_eval_periods
+#     threshold         = local.cw_latency
+#   }
 
-  replica_lag = {
-    period            = local.cw_replica_lag_period
-    eval_periods      = local.cw_eval_periods
-    threshold         = local.cw_replica_lag
-  }
+#   replica_lag = {
+#     period            = local.cw_replica_lag_period
+#     eval_periods      = local.cw_eval_periods
+#     threshold         = local.cw_replica_lag
+#   }
 
-  # Do not alarm on disk_queue_depth. This metric didn't
-  # have much correlation to a healthy database
+#   # Do not alarm on disk_queue_depth. This metric didn't
+#   # have much correlation to a healthy database
 
-  alarm_notification_arn = aws_sns_topic.cloudwatch_alarms.arn
-  ok_notification_arn = aws_sns_topic.cloudwatch_ok.arn
-}
+#   alarm_notification_arn = aws_sns_topic.cloudwatch_alarms.arn
+#   ok_notification_arn = aws_sns_topic.cloudwatch_ok.arn
+# }
 
-module "replica3_alarms" {
-  source              = "../resources/rds_alarms"
-  rds_name            = module.replica3.identifier
-  env                 = var.env_config.env
-  app                 = "bfd"
-  tags                = var.env_config.tags
+# module "replica3_alarms" {
+#   source              = "../resources/rds_alarms"
+#   rds_name            = module.replica3.identifier
+#   env                 = var.env_config.env
+#   app                 = "bfd"
+#   tags                = var.env_config.tags
 
-  read_latency = {
-    period            = local.cw_period
-    eval_periods      = local.cw_eval_periods
-    threshold         = local.cw_latency
-  }
+#   read_latency = {
+#     period            = local.cw_period
+#     eval_periods      = local.cw_eval_periods
+#     threshold         = local.cw_latency
+#   }
 
-  replica_lag = {
-    period            = local.cw_replica_lag_period
-    eval_periods      = local.cw_eval_periods
-    threshold         = local.cw_replica_lag
-  }
+#   replica_lag = {
+#     period            = local.cw_replica_lag_period
+#     eval_periods      = local.cw_eval_periods
+#     threshold         = local.cw_replica_lag
+#   }
   
-  # Do not alarm on disk_queue_depth. This metric didn't
-  # have much correlation to a healthy database
+#   # Do not alarm on disk_queue_depth. This metric didn't
+#   # have much correlation to a healthy database
 
-  alarm_notification_arn = aws_sns_topic.cloudwatch_alarms.arn
-  ok_notification_arn = aws_sns_topic.cloudwatch_ok.arn
-}
+#   alarm_notification_arn = aws_sns_topic.cloudwatch_alarms.arn
+#   ok_notification_arn = aws_sns_topic.cloudwatch_ok.arn
+# }
 
 # S3 Admin bucket for adminstrative stuff
 #

--- a/ops/terraform/modules/stateful/variables.tf
+++ b/ops/terraform/modules/stateful/variables.tf
@@ -8,20 +8,20 @@ variable "aurora_node_params" {
   type        = list(object({name = string, value = string, apply_on_reboot = bool}))
 }
 
-variable "db_config" {
-  description       = "All the high-level configuration needed to setup an RDS instances"
-  type              = object({instance_class = string, allocated_storage=number, iops = number})
-}
+# variable "db_config" {
+#   description       = "All the high-level configuration needed to setup an RDS instances"
+#   type              = object({instance_class = string, allocated_storage=number, iops = number})
+# }
 
-variable "db_params" {
-  description       = "Parameters that populate the default parameter group"
-  type              = list(object({name = string, value = string, apply_on_reboot = bool}))
-}
+# variable "db_params" {
+#   description       = "Parameters that populate the default parameter group"
+#   type              = list(object({name = string, value = string, apply_on_reboot = bool}))
+# }
 
-variable "db_import_mode" {
-  description       = "Enable or disable parameters that optimize bulk data imports"
-  type              = object({enabled = bool, maintenance_work_mem = string})
-}
+# variable "db_import_mode" {
+#   description       = "Enable or disable parameters that optimize bulk data imports"
+#   type              = object({enabled = bool, maintenance_work_mem = string})
+# }
 
 variable "env_config" {
   description       = "All high-level info for the whole vpc"

--- a/ops/terraform/modules/stateless/main.tf
+++ b/ops/terraform/modules/stateless/main.tf
@@ -87,28 +87,28 @@ data "aws_sns_topic" "cloudwatch_ok" {
   name  = "bfd-${var.env_config.env}-cloudwatch-ok"
 }
 
-# RDS Replicas
-#
-data "aws_db_instance" "replica" {
-  count                   = 3
-  db_instance_identifier  = "bfd-${var.env_config.env}-replica${count.index+1}"
-}
+# # RDS Replicas
+# #
+# data "aws_db_instance" "replica" {
+#   count                   = 3
+#   db_instance_identifier  = "bfd-${var.env_config.env}-replica${count.index+1}"
+# }
 
-# RDS Security Groups
-#
-data "aws_security_group" "db_primary" {
-  filter {
-    name        = "tag:Name"
-    values      = ["bfd-${var.env_config.env}-master-rds"]
-  }
-}
+# # RDS Security Groups
+# #
+# data "aws_security_group" "db_primary" {
+#   filter {
+#     name        = "tag:Name"
+#     values      = ["bfd-${var.env_config.env}-master-rds"]
+#   }
+# }
 
-data "aws_security_group" "db_replicas" {
-  filter {
-    name        = "tag:Name"
-    values      = ["bfd-${var.env_config.env}-rds"]
-  }
-}
+# data "aws_security_group" "db_replicas" {
+#   filter {
+#     name        = "tag:Name"
+#     values      = ["bfd-${var.env_config.env}-rds"]
+#   }
+# }
 
 # Aurora security group
 #


### PR DESCRIPTION
### Change Details

This comments out all RDS resources and variable definitions/values from upstream modules in order to effectively destroy all unused RDS resources without removing them from code (yet).  Resources destroyed include:
- RDS parameter groups
- RDS subnet groups
- RDS security groups
- RDS instances
- RDS route 53 records
- RDS cloudwatch alarms

### Acceptance Validation

- Unused RDS resources are destroyed per environment via terraform, and this change does not impact anything running in that environment

NOTE: This has already been run successfully in test and prod-sbx

### External References

- [BLUEBUTTON-1992](https://jira.cms.gov/browse/BLUEBUTTON-1992)

### Security Implications

- [ ] new software dependencies

- [ ] altered security controls

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications