### PR TITLE
BLUEBUTTON-1864: Refactor medicare opt out module to support assumed writer role

### DIFF
--- a/ops/terraform/env/prod-sbx/stateful/main.tf
+++ b/ops/terraform/env/prod-sbx/stateful/main.tf
@@ -52,6 +52,7 @@ module "stateful" {
   medicare_opt_out_config = {
     read_roles        = ["arn:aws:iam::755619740999:role/dpc-dev-consent-execution-role", "arn:aws:iam::349849222861:role/Ab2dInstanceRole", "arn:aws:iam::777200079629:role/Ab2dInstanceRole", "arn:aws:iam::330810004472:role/Ab2dInstanceRole"]
     write_roles       = ["arn:aws:iam::755619740999:role/bcda-dev-nfs-instance", "arn:aws:iam::755619740999:role/bcda-test-nfs-instance"]
+    write_assume_acct = "arn:aws:iam::755619740999:root"
     admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9"]
   }
 }

--- a/ops/terraform/env/prod-sbx/stateful/main.tf
+++ b/ops/terraform/env/prod-sbx/stateful/main.tf
@@ -51,8 +51,7 @@ module "stateful" {
 
   medicare_opt_out_config = {
     read_roles        = ["arn:aws:iam::755619740999:role/dpc-dev-consent-execution-role", "arn:aws:iam::349849222861:role/Ab2dInstanceRole", "arn:aws:iam::777200079629:role/Ab2dInstanceRole", "arn:aws:iam::330810004472:role/Ab2dInstanceRole"]
-    write_roles       = ["arn:aws:iam::755619740999:role/bcda-dev-nfs-instance", "arn:aws:iam::755619740999:role/bcda-test-nfs-instance"]
-    write_assume_acct = "arn:aws:iam::755619740999:root"
-    admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9"]
+    write_accts       = ["arn:aws:iam::755619740999:root"]
+    admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9", "arn:aws:iam::755619740999:user/HWRI"]
   }
 }

--- a/ops/terraform/env/prod-sbx/stateful/main.tf
+++ b/ops/terraform/env/prod-sbx/stateful/main.tf
@@ -50,7 +50,7 @@ module "stateful" {
   victor_ops_url      = var.victor_ops_url
 
   medicare_opt_out_config = {
-    read_roles        = ["arn:aws:iam::755619740999:role/dpc-dev-consent-execution-role", "arn:aws:iam::349849222861:role/Ab2dInstanceRole", "arn:aws:iam::349849222861:root", "arn:aws:iam::777200079629:role/Ab2dInstanceRole", "arn:aws:iam::777200079629:root", "arn:aws:iam::330810004472:role/Ab2dInstanceRole", "arn:aws:iam::330810004472:root"]
+    read_roles        = ["arn:aws:iam::755619740999:role/dpc-dev-consent-execution-role", "arn:aws:iam::349849222861:role/Ab2dInstanceRole", "arn:aws:iam::777200079629:role/Ab2dInstanceRole", "arn:aws:iam::330810004472:role/Ab2dInstanceRole"]
     write_roles       = ["arn:aws:iam::755619740999:role/bcda-dev-nfs-instance", "arn:aws:iam::755619740999:role/bcda-test-nfs-instance"]
     admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9"]
   }

--- a/ops/terraform/env/prod-sbx/stateful/main.tf
+++ b/ops/terraform/env/prod-sbx/stateful/main.tf
@@ -50,7 +50,7 @@ module "stateful" {
   victor_ops_url      = var.victor_ops_url
 
   medicare_opt_out_config = {
-    read_roles        = ["arn:aws:iam::755619740999:role/dpc-dev-consent-execution-role", "arn:aws:iam::349849222861:role/Ab2dInstanceRole", "arn:aws:iam::777200079629:role/Ab2dInstanceRole", "arn:aws:iam::330810004472:role/Ab2dInstanceRole"]
+    read_roles        = ["arn:aws:iam::755619740999:role/dpc-dev-consent-execution-role", "arn:aws:iam::349849222861:role/Ab2dInstanceRole", "arn:aws:iam::349849222861:root", "arn:aws:iam::777200079629:role/Ab2dInstanceRole", "arn:aws:iam::777200079629:root", "arn:aws:iam::330810004472:role/Ab2dInstanceRole", "arn:aws:iam::330810004472:root"]
     write_roles       = ["arn:aws:iam::755619740999:role/bcda-dev-nfs-instance", "arn:aws:iam::755619740999:role/bcda-test-nfs-instance"]
     admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9"]
   }

--- a/ops/terraform/env/prod-sbx/stateful/main.tf
+++ b/ops/terraform/env/prod-sbx/stateful/main.tf
@@ -52,6 +52,6 @@ module "stateful" {
   medicare_opt_out_config = {
     read_roles        = ["arn:aws:iam::755619740999:role/dpc-dev-consent-execution-role", "arn:aws:iam::349849222861:role/Ab2dInstanceRole", "arn:aws:iam::777200079629:role/Ab2dInstanceRole", "arn:aws:iam::330810004472:role/Ab2dInstanceRole"]
     write_accts       = ["arn:aws:iam::755619740999:root"]
-    admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9", "arn:aws:iam::755619740999:user/HWRI"]
+    admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9", "arn:aws:iam::577373831711:user/HWRI"]
   }
 }

--- a/ops/terraform/env/prod/stateful/main.tf
+++ b/ops/terraform/env/prod/stateful/main.tf
@@ -60,8 +60,7 @@ module "stateful" {
   medicare_opt_out_config = {
     # TODO: add read roles for DPC
     read_roles        = []
-    write_roles       = ["arn:aws:iam::755619740999:role/bcda-prod-nfs-instance"]
-    write_assume_acct = "arn:aws:iam::755619740999:root"
-    admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9"]
+    write_accts       = ["arn:aws:iam::755619740999:root"]
+    admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9", "arn:aws:iam::755619740999:user/HWRI"]
   }
 }

--- a/ops/terraform/env/prod/stateful/main.tf
+++ b/ops/terraform/env/prod/stateful/main.tf
@@ -61,6 +61,7 @@ module "stateful" {
     # TODO: add read roles for DPC
     read_roles        = []
     write_roles       = ["arn:aws:iam::755619740999:role/bcda-prod-nfs-instance"]
+    write_assume_acct = "arn:aws:iam::755619740999:root"
     admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9"]
   }
 }

--- a/ops/terraform/env/prod/stateful/main.tf
+++ b/ops/terraform/env/prod/stateful/main.tf
@@ -61,6 +61,6 @@ module "stateful" {
     # TODO: add read roles for DPC
     read_roles        = []
     write_accts       = ["arn:aws:iam::755619740999:root"]
-    admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9", "arn:aws:iam::755619740999:user/HWRI"]
+    admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9", "arn:aws:iam::577373831711:user/HWRI"]
   }
 }

--- a/ops/terraform/env/test/stateful/main.tf
+++ b/ops/terraform/env/test/stateful/main.tf
@@ -59,7 +59,7 @@ module "stateful" {
   victor_ops_url      = var.victor_ops_url
 
   medicare_opt_out_config = {
-    read_roles        = ["arn:aws:iam::755619740999:role/dpc-dev-consent-execution-role", "arn:aws:iam::349849222861:role/Ab2dInstanceRole", "arn:aws:iam::777200079629:role/Ab2dInstanceRole", "arn:aws:iam::330810004472:role/Ab2dInstanceRole"]
+    read_roles        = ["arn:aws:iam::755619740999:role/dpc-dev-consent-execution-role", "arn:aws:iam::349849222861:role/Ab2dInstanceRole", "arn:aws:iam::349849222861:root", "arn:aws:iam::777200079629:role/Ab2dInstanceRole", "arn:aws:iam::777200079629:root", "arn:aws:iam::330810004472:role/Ab2dInstanceRole", "arn:aws:iam::330810004472:root"]
     write_roles       = ["arn:aws:iam::755619740999:role/bcda-dev-nfs-instance", "arn:aws:iam::755619740999:role/bcda-test-nfs-instance"]
     admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9"]
   }

--- a/ops/terraform/env/test/stateful/main.tf
+++ b/ops/terraform/env/test/stateful/main.tf
@@ -59,7 +59,7 @@ module "stateful" {
   victor_ops_url      = var.victor_ops_url
 
   medicare_opt_out_config = {
-    read_roles        = ["arn:aws:iam::755619740999:role/dpc-dev-consent-execution-role", "arn:aws:iam::349849222861:role/Ab2dInstanceRole", "arn:aws:iam::349849222861:root", "arn:aws:iam::777200079629:role/Ab2dInstanceRole", "arn:aws:iam::777200079629:root", "arn:aws:iam::330810004472:role/Ab2dInstanceRole", "arn:aws:iam::330810004472:root"]
+    read_roles        = ["arn:aws:iam::755619740999:role/dpc-dev-consent-execution-role", "arn:aws:iam::349849222861:role/Ab2dInstanceRole", "arn:aws:iam::777200079629:role/Ab2dInstanceRole", "arn:aws:iam::330810004472:role/Ab2dInstanceRole"]
     write_roles       = ["arn:aws:iam::755619740999:role/bcda-dev-nfs-instance", "arn:aws:iam::755619740999:role/bcda-test-nfs-instance"]
     admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9"]
   }

--- a/ops/terraform/env/test/stateful/main.tf
+++ b/ops/terraform/env/test/stateful/main.tf
@@ -61,6 +61,7 @@ module "stateful" {
   medicare_opt_out_config = {
     read_roles        = ["arn:aws:iam::755619740999:role/dpc-dev-consent-execution-role", "arn:aws:iam::349849222861:role/Ab2dInstanceRole", "arn:aws:iam::777200079629:role/Ab2dInstanceRole", "arn:aws:iam::330810004472:role/Ab2dInstanceRole"]
     write_roles       = ["arn:aws:iam::755619740999:role/bcda-dev-nfs-instance", "arn:aws:iam::755619740999:role/bcda-test-nfs-instance"]
+    write_assume_acct = "arn:aws:iam::755619740999:root"
     admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9"]
   }
 }

--- a/ops/terraform/env/test/stateful/main.tf
+++ b/ops/terraform/env/test/stateful/main.tf
@@ -60,8 +60,7 @@ module "stateful" {
 
   medicare_opt_out_config = {
     read_roles        = ["arn:aws:iam::755619740999:role/dpc-dev-consent-execution-role", "arn:aws:iam::349849222861:role/Ab2dInstanceRole", "arn:aws:iam::777200079629:role/Ab2dInstanceRole", "arn:aws:iam::330810004472:role/Ab2dInstanceRole"]
-    write_roles       = ["arn:aws:iam::755619740999:role/bcda-dev-nfs-instance", "arn:aws:iam::755619740999:role/bcda-test-nfs-instance"]
-    write_assume_acct = "arn:aws:iam::755619740999:root"
-    admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9"]
+    write_accts       = ["arn:aws:iam::755619740999:root"]
+    admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9", "arn:aws:iam::755619740999:user/HWRI"]
   }
 }

--- a/ops/terraform/env/test/stateful/main.tf
+++ b/ops/terraform/env/test/stateful/main.tf
@@ -61,6 +61,6 @@ module "stateful" {
   medicare_opt_out_config = {
     read_roles        = ["arn:aws:iam::755619740999:role/dpc-dev-consent-execution-role", "arn:aws:iam::349849222861:role/Ab2dInstanceRole", "arn:aws:iam::777200079629:role/Ab2dInstanceRole", "arn:aws:iam::330810004472:role/Ab2dInstanceRole"]
     write_accts       = ["arn:aws:iam::755619740999:root"]
-    admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9", "arn:aws:iam::755619740999:user/HWRI"]
+    admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9", "arn:aws:iam::577373831711:user/HWRI"]
   }
 }

--- a/ops/terraform/modules/resources/s3_pii/main.tf
+++ b/ops/terraform/modules/resources/s3_pii/main.tf
@@ -14,11 +14,12 @@ resource "aws_kms_key" "pii_bucket_key" {
   enable_key_rotation     = true
 
   policy = templatefile("${path.module}/templates/kms-policy.json", {
-    env    = var.env_config.env
-    name   = var.pii_bucket_config.name
-    admins = formatlist("%s", var.pii_bucket_config.admin_arns)
-    roles  = formatlist("%s", concat(var.pii_bucket_config.read_arns, var.pii_bucket_config.write_arns))
-    root   = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+    env     = var.env_config.env
+    name    = var.pii_bucket_config.name
+    admins  = var.pii_bucket_config.admin_arns
+    readers = var.pii_bucket_config.read_arns
+    writers = [aws_iam_role.pii_bucket_writer_role.arn]
+    root    = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
   })
 }
 
@@ -81,41 +82,34 @@ resource "aws_s3_bucket_policy" "pii_bucket_policy" {
     env         = var.env_config.env
     bucket_id   = aws_s3_bucket.pii_bucket.id
     bucket_name = var.pii_bucket_config.name
-    admins      = formatlist("%s", var.pii_bucket_config.admin_arns)
-    readers     = formatlist("%s", var.pii_bucket_config.read_arns)
-    writers     = formatlist("%s", var.pii_bucket_config.write_arns)
-    root        = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+    admins      = var.pii_bucket_config.admin_arns
+    readers     = var.pii_bucket_config.read_arns
+    writers     = [aws_iam_role.pii_bucket_writer_role.arn]
+    root        = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
   })
 }
 
-resource "aws_iam_role" "pii_bucket_write_assume_role" {
-  name = "bfd-${var.env_config.env}-${var.pii_bucket_config.name}-write-assume-role"
+resource "aws_iam_role" "pii_bucket_writer_role" {
+  name = "bfd-${var.env_config.env}-${var.pii_bucket_config.name}-writer-role"
 
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "${var.pii_bucket_config.write_assume_arn}"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOF
+  assume_role_policy = templatefile("${path.module}/templates/iam-writer-assume-policy.json", {
+    env     = var.env_config.env
+    name    = var.pii_bucket_config.name
+    writers = var.pii_bucket_config.write_accts
+  })
 }
 
-resource "aws_iam_policy" "pii_bucket_write_assume_policy" {
-  name = "bfd-${var.env_config.env}-${var.pii_bucket_config.name}-write-assume-policy"
+resource "aws_iam_policy" "pii_bucket_writer_policy" {
+  name = "bfd-${var.env_config.env}-${var.pii_bucket_config.name}-writer-policy"
 
-  policy = templatefile("${path.module}/templates/iam-write-assume-policy.json", {
+  policy = templatefile("${path.module}/templates/iam-writer-policy.json", {
+    env       = var.env_config.env
+    name      = var.pii_bucket_config.name
     bucket_id = aws_s3_bucket.pii_bucket.id
   })
 }
 
-resource "aws_iam_role_policy_attachment" "pii_bucket_write_assume_policy_attachment" {
-  role       = aws_iam_role.pii_bucket_write_assume_role.name
-  policy_arn = aws_iam_policy.pii_bucket_write_assume_policy.arn
+resource "aws_iam_role_policy_attachment" "pii_bucket_writer_policy_attachment" {
+  role       = aws_iam_role.pii_bucket_writer_role.name
+  policy_arn = aws_iam_policy.pii_bucket_writer_policy.arn
 }

--- a/ops/terraform/modules/resources/s3_pii/templates/bucket-policy.json
+++ b/ops/terraform/modules/resources/s3_pii/templates/bucket-policy.json
@@ -13,8 +13,7 @@
       },
       "Action": [
         "s3:ListBucket*",
-        "s3:GetObject*",
-        "s3:HeadBucket"
+        "s3:GetObject*"
       ],
       "Resource": [
         "arn:aws:s3:::${bucket_id}",

--- a/ops/terraform/modules/resources/s3_pii/templates/bucket-policy.json
+++ b/ops/terraform/modules/resources/s3_pii/templates/bucket-policy.json
@@ -9,15 +9,11 @@
         "AWS": [
           %{ for reader in readers ~}"${reader}",%{ endfor ~}
           %{ for writer in writers ~}"${writer}",%{ endfor ~}
-          %{ for admin in admins ~}"${admin}",%{ endfor ~}
-          "${root}"
         ]
       },
       "Action": [
-        "s3:ListBucket",
-        "s3:ListBucketVersions",
-        "s3:GetObject",
-        "s3:GetObjectVersion*"
+        "s3:ListBucket*",
+        "s3:GetObject*"
       ],
       "Resource": [
         "arn:aws:s3:::${bucket_id}",
@@ -30,15 +26,11 @@
       "Principal": {
         "AWS": [
           %{ for writer in writers ~}"${writer}",%{ endfor ~}
-          %{ for admin in admins ~}"${admin}",%{ endfor ~}
-          "${root}"
         ]
       },
       "Action": [
-        "s3:PutObject",
-        "s3:PutObjectVersion*",
-        "s3:DeleteObject",
-        "s3:DeleteObjectVersion*"
+        "s3:PutObject*",
+        "s3:DeleteObject*"
       ],
       "Resource": [
         "arn:aws:s3:::${bucket_id}",

--- a/ops/terraform/modules/resources/s3_pii/templates/bucket-policy.json
+++ b/ops/terraform/modules/resources/s3_pii/templates/bucket-policy.json
@@ -15,7 +15,9 @@
       },
       "Action": [
         "s3:ListBucket",
-        "s3:GetObject"
+        "s3:ListBucketVersions",
+        "s3:GetObject",
+        "s3:GetObjectVersion*"
       ],
       "Resource": [
         "arn:aws:s3:::${bucket_id}",
@@ -34,7 +36,9 @@
       },
       "Action": [
         "s3:PutObject",
-        "s3:DeleteObject"
+        "s3:PutObjectVersion*",
+        "s3:DeleteObject",
+        "s3:DeleteObjectVersion*"
       ],
       "Resource": [
         "arn:aws:s3:::${bucket_id}",

--- a/ops/terraform/modules/resources/s3_pii/templates/bucket-policy.json
+++ b/ops/terraform/modules/resources/s3_pii/templates/bucket-policy.json
@@ -14,8 +14,7 @@ ${jsonencode(
       "Action": [
         "s3:ListBucket*",
         "s3:GetBucket*",
-        "s3:GetObject*",
-        "s3:HeadBucket"
+        "s3:GetObject*"
       ],
       "Resource": [
         "arn:aws:s3:::${bucket_id}",

--- a/ops/terraform/modules/resources/s3_pii/templates/bucket-policy.json
+++ b/ops/terraform/modules/resources/s3_pii/templates/bucket-policy.json
@@ -13,7 +13,8 @@
       },
       "Action": [
         "s3:ListBucket*",
-        "s3:GetObject*"
+        "s3:GetObject*",
+        "s3:HeadBucket"
       ],
       "Resource": [
         "arn:aws:s3:::${bucket_id}",

--- a/ops/terraform/modules/resources/s3_pii/templates/bucket-policy.json
+++ b/ops/terraform/modules/resources/s3_pii/templates/bucket-policy.json
@@ -3,22 +3,6 @@
   "Id": "bfd-${env}-${bucket_name}-s3-policy",
   "Statement": [
     {
-      "Sid": "BFDPIIS3ListBucket",
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": [
-          %{ for reader in readers ~}"${reader}",%{ endfor ~}
-          %{ for writer in writers ~}"${writer}",%{ endfor ~}
-          %{ for admin in admins ~}"${admin}",%{ endfor ~}
-          "${root}"
-        ]
-      },
-      "Action": [
-        "s3:ListBucket"
-      ],
-      "Resource": "arn:aws:s3:::${bucket_id}"
-    },
-    {
       "Sid": "BFDPIIS3ReadBucket",
       "Effect": "Allow",
       "Principal": {
@@ -30,9 +14,13 @@
         ]
       },
       "Action": [
+        "s3:ListBucket",
         "s3:GetObject"
       ],
-      "Resource": "arn:aws:s3:::${bucket_id}/*"
+      "Resource": [
+        "arn:aws:s3:::${bucket_id}",
+        "arn:aws:s3:::${bucket_id}/*"
+      ]
     },
     {
       "Sid": "BFDPIIS3WriteBucket",
@@ -48,7 +36,10 @@
         "s3:PutObject",
         "s3:DeleteObject"
       ],
-      "Resource": "arn:aws:s3:::${bucket_id}/*"
+      "Resource": [
+        "arn:aws:s3:::${bucket_id}",
+        "arn:aws:s3:::${bucket_id}/*"
+      ]
     },
     {
       "Sid": "BFDPIIS3AdminBucket",

--- a/ops/terraform/modules/resources/s3_pii/templates/bucket-policy.json
+++ b/ops/terraform/modules/resources/s3_pii/templates/bucket-policy.json
@@ -13,7 +13,9 @@ ${jsonencode(
       },
       "Action": [
         "s3:ListBucket*",
-        "s3:GetObject*"
+        "s3:GetBucket*",
+        "s3:GetObject*",
+        "s3:HeadBucket"
       ],
       "Resource": [
         "arn:aws:s3:::${bucket_id}",

--- a/ops/terraform/modules/resources/s3_pii/templates/bucket-policy.json
+++ b/ops/terraform/modules/resources/s3_pii/templates/bucket-policy.json
@@ -1,3 +1,4 @@
+${jsonencode(
 {
   "Version": "2012-10-17",
   "Id": "bfd-${env}-${bucket_name}-s3-policy",
@@ -7,8 +8,7 @@
       "Effect": "Allow",
       "Principal": {
         "AWS": [
-          %{ for reader in readers ~}"${reader}",%{ endfor ~}
-          %{ for writer in writers ~}"${writer}",%{ endfor ~}
+          for arn in concat(readers, writers) : "${arn}"
         ]
       },
       "Action": [
@@ -25,7 +25,7 @@
       "Effect": "Allow",
       "Principal": {
         "AWS": [
-          %{ for writer in writers ~}"${writer}",%{ endfor ~}
+          for arn in writers : "${arn}"
         ]
       },
       "Action": [
@@ -42,8 +42,7 @@
       "Effect": "Allow",
       "Principal": {
         "AWS": [
-          %{ for admin in admins ~}"${admin}",%{ endfor ~}
-          "${root}"
+          for arn in concat(admins, root) : "${arn}"
         ]
       },
       "Action": "s3:*",
@@ -66,3 +65,4 @@
     }
   ]
 }
+)}

--- a/ops/terraform/modules/resources/s3_pii/templates/iam-write-assume-policy.json
+++ b/ops/terraform/modules/resources/s3_pii/templates/iam-write-assume-policy.json
@@ -2,12 +2,21 @@
   "Version": "2012-10-17",
   "Statement": [
     {
+      "Sid": "BFDPIIS3ReadAll",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListAllMyBuckets",
+        "s3:HeadBucket"
+      ],
+      "Resource": "*"
+    }
+    {
       "Sid": "BFDPIIS3WriteAssume",
       "Effect": "Allow",
       "Action": [
         "s3:ListBucket*",
+        "s3:ListMultipartUploadParts",
         "s3:GetObject*",
-        "s3:HeadBucket",
         "s3:PutObject*",
         "s3:DeleteObject*"
       ],

--- a/ops/terraform/modules/resources/s3_pii/templates/iam-write-assume-policy.json
+++ b/ops/terraform/modules/resources/s3_pii/templates/iam-write-assume-policy.json
@@ -7,6 +7,7 @@
       "Action": [
         "s3:ListBucket*",
         "s3:GetObject*",
+        "s3:HeadBucket",
         "s3:PutObject*",
         "s3:DeleteObject*"
       ],

--- a/ops/terraform/modules/resources/s3_pii/templates/iam-write-assume-policy.json
+++ b/ops/terraform/modules/resources/s3_pii/templates/iam-write-assume-policy.json
@@ -9,7 +9,7 @@
         "s3:HeadBucket"
       ],
       "Resource": "*"
-    }
+    },
     {
       "Sid": "BFDPIIS3WriteAssume",
       "Effect": "Allow",

--- a/ops/terraform/modules/resources/s3_pii/templates/iam-write-assume-policy.json
+++ b/ops/terraform/modules/resources/s3_pii/templates/iam-write-assume-policy.json
@@ -1,0 +1,19 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "BFDPIIS3WriteAssume",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket*",
+        "s3:GetObject*",
+        "s3:PutObject*",
+        "s3:DeleteObject*"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${bucket_id}",
+        "arn:aws:s3:::${bucket_id}/*"
+      ]
+    }
+  ]
+}

--- a/ops/terraform/modules/resources/s3_pii/templates/iam-writer-assume-policy.json
+++ b/ops/terraform/modules/resources/s3_pii/templates/iam-writer-assume-policy.json
@@ -1,0 +1,17 @@
+${jsonencode(
+{
+  "Version": "2012-10-17",
+  "Id": "bfd-${env}-${name}-writer-assume-policy",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": [
+          for arn in writers : "${arn}"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+)}

--- a/ops/terraform/modules/resources/s3_pii/templates/iam-writer-policy.json
+++ b/ops/terraform/modules/resources/s3_pii/templates/iam-writer-policy.json
@@ -1,5 +1,7 @@
+${jsonencode(
 {
   "Version": "2012-10-17",
+  "Id": "bfd-${env}-${name}-iam-writer-policy",
   "Statement": [
     {
       "Sid": "BFDPIIS3ReadAll",
@@ -27,3 +29,4 @@
     }
   ]
 }
+)}

--- a/ops/terraform/modules/resources/s3_pii/templates/kms-policy.json
+++ b/ops/terraform/modules/resources/s3_pii/templates/kms-policy.json
@@ -1,3 +1,4 @@
+${jsonencode(
 {
   "Version": "2012-10-17",
   "Id": "bfd-${env}-${name}-kms-policy",
@@ -7,8 +8,7 @@
       "Effect": "Allow",
       "Principal": {
         "AWS": [
-          %{ for admin in admins ~}"${admin}",%{ endfor ~}
-          "${root}"
+          for arn in concat(admins, root) : "${arn}"
         ]
       },
       "Action": [
@@ -21,7 +21,7 @@
       "Effect": "Allow",
       "Principal": {
         "AWS": [
-          %{ for idx, role in roles ~}"${role}"%{ if idx + 1 != length(roles) ~},%{ endif ~}%{ endfor ~}
+          for arn in concat(readers, writers) : "${arn}"
         ]
       },
       "Action": [
@@ -35,3 +35,4 @@
     }
   ]
 }
+)}

--- a/ops/terraform/modules/resources/s3_pii/variables.tf
+++ b/ops/terraform/modules/resources/s3_pii/variables.tf
@@ -6,10 +6,11 @@ variable "env_config" {
 variable "pii_bucket_config" {
   description = "Config for PII S3 bucket"
   type        = object({
-    name       = string
-    log_bucket = string
-    read_arns  = list(string)
-    write_arns = list(string)
-    admin_arns = list(string)
+    name             = string
+    log_bucket       = string
+    read_arns        = list(string)
+    write_arns       = list(string)
+    write_assume_arn = string
+    admin_arns       = list(string)
   })
 }

--- a/ops/terraform/modules/resources/s3_pii/variables.tf
+++ b/ops/terraform/modules/resources/s3_pii/variables.tf
@@ -9,8 +9,7 @@ variable "pii_bucket_config" {
     name             = string
     log_bucket       = string
     read_arns        = list(string)
-    write_arns       = list(string)
-    write_assume_arn = string
+    write_accts      = list(string)
     admin_arns       = list(string)
   })
 }

--- a/ops/terraform/modules/resources/s3_pii/variables.tf
+++ b/ops/terraform/modules/resources/s3_pii/variables.tf
@@ -6,10 +6,10 @@ variable "env_config" {
 variable "pii_bucket_config" {
   description = "Config for PII S3 bucket"
   type        = object({
-    name             = string
-    log_bucket       = string
-    read_arns        = list(string)
-    write_accts      = list(string)
-    admin_arns       = list(string)
+    name        = string
+    log_bucket  = string
+    read_arns   = list(string)
+    write_accts = list(string)
+    admin_arns  = list(string)
   })
 }

--- a/ops/terraform/modules/stateful/main.tf
+++ b/ops/terraform/modules/stateful/main.tf
@@ -539,8 +539,7 @@ module "medicare_opt_out" {
     name             = "medicare-opt-out"
     log_bucket       = module.logs.id
     read_arns        = var.medicare_opt_out_config.read_roles
-    write_arns       = var.medicare_opt_out_config.write_roles
-    write_assume_arn = var.medicare_opt_out_config.write_assume_acct
+    write_accts      = var.medicare_opt_out_config.write_accts
     admin_arns       = var.medicare_opt_out_config.admin_users
   }
 }

--- a/ops/terraform/modules/stateful/main.tf
+++ b/ops/terraform/modules/stateful/main.tf
@@ -536,11 +536,11 @@ module "medicare_opt_out" {
   env_config        = local.env_config
 
   pii_bucket_config = {
-    name             = "medicare-opt-out"
-    log_bucket       = module.logs.id
-    read_arns        = var.medicare_opt_out_config.read_roles
-    write_accts      = var.medicare_opt_out_config.write_accts
-    admin_arns       = var.medicare_opt_out_config.admin_users
+    name            = "medicare-opt-out"
+    log_bucket      = module.logs.id
+    read_arns       = var.medicare_opt_out_config.read_roles
+    write_accts     = var.medicare_opt_out_config.write_accts
+    admin_arns      = var.medicare_opt_out_config.admin_users
   }
 }
 

--- a/ops/terraform/modules/stateful/main.tf
+++ b/ops/terraform/modules/stateful/main.tf
@@ -536,11 +536,12 @@ module "medicare_opt_out" {
   env_config        = local.env_config
 
   pii_bucket_config = {
-    name            = "medicare-opt-out"
-    log_bucket      = module.logs.id
-    read_arns       = var.medicare_opt_out_config.read_roles
-    write_arns      = var.medicare_opt_out_config.write_roles
-    admin_arns      = var.medicare_opt_out_config.admin_users
+    name             = "medicare-opt-out"
+    log_bucket       = module.logs.id
+    read_arns        = var.medicare_opt_out_config.read_roles
+    write_arns       = var.medicare_opt_out_config.write_roles
+    write_assume_arn = var.medicare_opt_out_config.write_assume_acct
+    admin_arns       = var.medicare_opt_out_config.admin_users
   }
 }
 

--- a/ops/terraform/modules/stateful/variables.tf
+++ b/ops/terraform/modules/stateful/variables.tf
@@ -35,5 +35,5 @@ variable "victor_ops_url" {
 
 variable "medicare_opt_out_config" {
   description       = "Config for medicare opt out S3 bucket"
-  type              = object({read_roles = list(string), write_roles = list(string), write_assume_acct = string, admin_users = list(string)})
+  type              = object({read_roles = list(string), write_accts = list(string), admin_users = list(string)})
 }

--- a/ops/terraform/modules/stateful/variables.tf
+++ b/ops/terraform/modules/stateful/variables.tf
@@ -35,5 +35,5 @@ variable "victor_ops_url" {
 
 variable "medicare_opt_out_config" {
   description       = "Config for medicare opt out S3 bucket"
-  type              = object({read_roles = list(string), write_roles = list(string), write_assume_account = string, admin_users = list(string)})
+  type              = object({read_roles = list(string), write_roles = list(string), write_assume_acct = string, admin_users = list(string)})
 }

--- a/ops/terraform/modules/stateful/variables.tf
+++ b/ops/terraform/modules/stateful/variables.tf
@@ -35,5 +35,5 @@ variable "victor_ops_url" {
 
 variable "medicare_opt_out_config" {
   description       = "Config for medicare opt out S3 bucket"
-  type              = object({read_roles = list(string), write_roles = list(string), admin_users = list(string)})
+  type              = object({read_roles = list(string), write_roles = list(string), write_assume_account = string, admin_users = list(string)})
 }


### PR DESCRIPTION
**JIRA Ticket:**
[BLUEBUTTON-1864](https://jira.cms.gov/browse/BLUEBUTTON-1864)

**User Story or Bug Summary:**
Refactor medicare opt out module to support assumed writer role

### What Does This PR Do?

- Refactors the `s3_pii` module so that we no longer pass in a list of external writer roles, but instead pass in a list of writer AWS accounts that will assume a writer role we create.  This solves the issue of a bucket owner not being able to apply policies to objects owned by another account.
- While refactoring this module I ran into multiple issues with JSON formatting due to terraform template string interpolation, so I have wrapped the JSON templates in `jsonencode` and moved to native terraform expressions as per recommendations: https://www.terraform.io/docs/configuration/functions/templatefile.html#generating-json-or-yaml-from-a-template
- Restructured the bucket policy a bit so it is simpler to reason about and reduces duplication
- Minor formatting changes
- Adds @RickHawesUSDS as an admin

### What Should Reviewers Watch For?

This has successfully been applied in test, prod-sbx, and prod (and tested by 3rd party teams in prod-sbx) however it would be good to watch out for:
- Unintended side effects
- General clarity

### What Security Implications Does This PR Have?

* If the answer to any of the questions below is **Yes**, then here's a link to the associated Security Impact Assessment: N/A.
    * Does this PR add any new software dependencies? **No**.
    * Does this PR modify or invalidate any of our security controls?**No**.
    * Does this PR store or transmit data that was not stored or transmitted before? **No**.
* If the answer to any of the questions below is **Yes**, then please add @StewGoin as a reviewer, and note that this PR should not be merged unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons? **No**.

### What Needs to Be Merged and Deployed Before this PR?

N/A

### Submitter Checklist

Before requesting final review, I've gone through and verified that this PR complies with the following requirements:

* [x] I've refactored and rebased this PR (for help, see: [this](https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had) and [this](https://raphaelfabeni.com/git-editing-commits-part-1/), if needed, so that it is as small as it can reasonably be, in order to:
    1. Ensure that any problems it causes have a small "blast radius".
    2. Ensure that it'll be easier to rollback if that becomes necessary.
    3. Ease the burden on reviewers.
* [ ] I've verified that the commits in this PR:
    1. Reasonably explain the "what" and "why" of the changes.
    2. Leverage JIRA's [smart commits](https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html) to reference the JIRA ticket that they're associated with. For example, aim for commit messages like this (note also [the 50/72 formatting](https://stackoverflow.com/q/2290016) used here):
        
        ```
        Added the whizbang to the doodad.

        The new whizbang should really simplify things for our whoosit users.
        It was a bit tricky to get it into the doodad, but we decided that the
        flipwhee pattern was the best approach for now. Might want to revisit
        that in the future if it ends up being too hard to maintain.

        SOMEPROJECT-42
        ```
        
* [x] I've verified that this PR includes all required documentation changes, including `README` updates and changelog / release notes entries.
* [ ] I've verified that all new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] I've verified that all tech debt and/or shortcomings introduced by this PR is detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] I've requested review from at least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
* [x] I've requested review from any relevant engineers on other projects (e.g. BFD, SLS, etc.).
* [x] I've verified that this PR and its changes comply with all other policies in the [DASG Engineering Standards](../policies/engineering_standards.md) and have specifically called out any/all deviations in this PR.