### PR TITLE
BFD-168: Refactor CloudWatch metric alarms

### DIFF
--- a/ops/terraform/modules/resources/bfd_pipeline/main.tf
+++ b/ops/terraform/modules/resources/bfd_pipeline/main.tf
@@ -7,8 +7,16 @@ locals {
 
   pipeline_messages_error = {
     period       = "300"
+    eval_periods = "10"
+    threshold    = "0"
+    datapoints   = "10"
+  }
+
+  pipeline_messages_datasetfailed = {
+    period       = "300"
     eval_periods = "1"
     threshold    = "0"
+    datapoints   = "1"
   }
 
   alarm_actions  = var.alarm_notification_arn == null ? [] : [var.alarm_notification_arn]
@@ -42,6 +50,19 @@ resource "aws_cloudwatch_log_metric_filter" "pipeline-messages-error-count" {
   }
 }
 
+resource "aws_cloudwatch_log_metric_filter" "pipeline-messages-datasetfailed-count" {
+  name            = "bfd-${var.env_config.env}/bfd-pipeline/messages/count/error"
+  pattern         = "[date, time, java_thread, level = \"ERROR\", java_class, message = \"*Data set failed with an unhandled error*\"]"
+  log_group_name  = local.log_groups.messages
+
+  metric_transformation {
+    name          = "messages/count/datasetfailed"
+    namespace     = "bfd-${var.env_config.env}/bfd-pipeline"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
 # CloudWatch metric alarms
 #
 resource "aws_cloudwatch_metric_alarm" "pipeline-messages-error" {
@@ -49,7 +70,7 @@ resource "aws_cloudwatch_metric_alarm" "pipeline-messages-error" {
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = local.pipeline_messages_error.eval_periods
   period              = local.pipeline_messages_error.period
-  statistic           = "Maximum"
+  statistic           = "Sum"
   threshold           = local.pipeline_messages_error.threshold
   alarm_description   = "Pipeline errors detected within ${local.pipeline_messages_error.period} seconds in APP-ENV: bfd-${var.env_config.env}"
 
@@ -59,7 +80,26 @@ resource "aws_cloudwatch_metric_alarm" "pipeline-messages-error" {
   alarm_actions       = local.is_prod ? local.alarm_actions : []
   ok_actions          = local.is_prod ? local.ok_actions : []
 
-  datapoints_to_alarm = "1"
+  datapoints_to_alarm = local.pipeline_messages_error.datapoints
+  treat_missing_data  = "notBreaching"
+}
+
+resource "aws_cloudwatch_metric_alarm" "pipeline-messages-datasetfailed" {
+  alarm_name          = "bfd-${var.env_config.env}-pipeline-messages-datasetfailed"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = local.pipeline_messages_datasetfailed.eval_periods
+  period              = local.pipeline_messages_datasetfailed.period
+  statistic           = "Sum"
+  threshold           = local.pipeline_messages_datasetfailed.threshold
+  alarm_description   = "Data set processing failed, pipeline has shut down in APP-ENV: bfd-${var.env_config.env}"
+
+  metric_name         = "messages/count/datasetfailed"
+  namespace           = "bfd-${var.env_config.env}/bfd-pipeline"
+
+  alarm_actions       = local.is_prod ? local.alarm_actions : []
+  ok_actions          = local.is_prod ? local.ok_actions : []
+
+  datapoints_to_alarm = local.pipeline_messages_datasetfailed.datapoints
   treat_missing_data  = "notBreaching"
 }
 

--- a/ops/terraform/modules/resources/bfd_pipeline/main.tf
+++ b/ops/terraform/modules/resources/bfd_pipeline/main.tf
@@ -72,7 +72,7 @@ resource "aws_cloudwatch_metric_alarm" "pipeline-messages-error" {
   period              = local.pipeline_messages_error.period
   statistic           = "Sum"
   threshold           = local.pipeline_messages_error.threshold
-  alarm_description   = "Pipeline errors detected within ${local.pipeline_messages_error.period} seconds in APP-ENV: bfd-${var.env_config.env}"
+  alarm_description   = "Pipeline errors detected over ${local.pipeline-messages_error.eval_periods} evaluation periods of ${local.pipeline_messages_error.period} seconds in APP-ENV: bfd-${var.env_config.env}"
 
   metric_name         = "messages/count/error"
   namespace           = "bfd-${var.env_config.env}/bfd-pipeline"

--- a/ops/terraform/modules/resources/bfd_pipeline/main.tf
+++ b/ops/terraform/modules/resources/bfd_pipeline/main.tf
@@ -72,7 +72,7 @@ resource "aws_cloudwatch_metric_alarm" "pipeline-messages-error" {
   period              = local.pipeline_messages_error.period
   statistic           = "Sum"
   threshold           = local.pipeline_messages_error.threshold
-  alarm_description   = "Pipeline errors detected over ${local.pipeline-messages_error.eval_periods} evaluation periods of ${local.pipeline_messages_error.period} seconds in APP-ENV: bfd-${var.env_config.env}"
+  alarm_description   = "Pipeline errors detected over ${local.pipeline_messages_error.eval_periods} evaluation periods of ${local.pipeline_messages_error.period} seconds in APP-ENV: bfd-${var.env_config.env}"
 
   metric_name         = "messages/count/error"
   namespace           = "bfd-${var.env_config.env}/bfd-pipeline"

--- a/ops/terraform/modules/resources/bfd_pipeline/main.tf
+++ b/ops/terraform/modules/resources/bfd_pipeline/main.tf
@@ -51,7 +51,7 @@ resource "aws_cloudwatch_log_metric_filter" "pipeline-messages-error-count" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "pipeline-messages-datasetfailed-count" {
-  name            = "bfd-${var.env_config.env}/bfd-pipeline/messages/count/error"
+  name            = "bfd-${var.env_config.env}/bfd-pipeline/messages/count/datasetfailed"
   pattern         = "[date, time, java_thread, level = \"ERROR\", java_class, message = \"*Data set failed with an unhandled error*\"]"
   log_group_name  = local.log_groups.messages
 

--- a/ops/terraform/modules/resources/bfd_server_alarm/main.tf
+++ b/ops/terraform/modules/resources/bfd_server_alarm/main.tf
@@ -13,7 +13,7 @@ resource "aws_cloudwatch_metric_alarm" "bfd-server-alarm" {
   statistic           = var.alarm_config.statistic
   extended_statistic  = var.alarm_config.ext_statistic
   threshold           = var.alarm_config.threshold
-  datapoints_to_alarm = "1"
+  datapoints_to_alarm = var.alarm_config.datapoints
   treat_missing_data  = "notBreaching"
 
   alarm_actions       = var.alarm_config.alarm_notify_arn == null ? [] : [var.alarm_config.alarm_notify_arn]

--- a/ops/terraform/modules/resources/bfd_server_alarm/variables.tf
+++ b/ops/terraform/modules/resources/bfd_server_alarm/variables.tf
@@ -12,6 +12,7 @@ variable "alarm_config" {
     statistic        = string,
     ext_statistic    = string,
     threshold        = string,
+    datapoints       = string,
     alarm_notify_arn = string,
     ok_notify_arn    = string
   })

--- a/ops/terraform/modules/stateless/main.tf
+++ b/ops/terraform/modules/stateless/main.tf
@@ -336,67 +336,26 @@ module "bfd_server_metrics_ab2d" {
 # FHIR server alarms, partner specific
 #
 
-# Deprecate classic HTTP 500 alarm for expression HTTP 500 alarm
-# module "bfd_server_alarm_all_500s" {
-#   source = "../resources/bfd_server_alarm"
+# TODO: Deprecate this alarm in favor of metric math expression to more accurately
+# represet our error budget
+#
+module "bfd_server_alarm_all_500s" {
+  source = "../resources/bfd_server_alarm"
 
-#   env    = var.env_config.env
+  env    = var.env_config.env
 
-#   alarm_config = {
-#     alarm_name       = "all-500s"
-#     partner_name     = "all"
-#     metric_prefix    = "http-requests/count-500"
-#     eval_periods     = "15"
-#     period           = "60"
-#     datapoints       = "15"
-#     statistic        = "Sum"
-#     ext_statistic    = null
-#     threshold        = "8.0"
-#     alarm_notify_arn = data.aws_sns_topic.cloudwatch_alarms.arn
-#     ok_notify_arn    = data.aws_sns_topic.cloudwatch_ok.arn
-#   }
-# }
-
-resource "aws_cloudwatch_metric_alarm" "bfd_server_alarm_all_500s" {
-  alarm_name          = "bfd-${var.env_config.env}-server-all-500s"
-
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "15"
-  datapoints_to_alarm = "15"
-  threshold           = "0.1"
-
-  treat_missing_data  = "notBreaching"
-
-  alarm_actions       = data.aws_sns_topic.cloudwatch_alarms.arn == null ? [] : [data.aws_sns_topic.cloudwatch_alarms.arn]
-  ok_actions          = data.aws_sns_topic.cloudwatch_ok.arn == null ? [] : [data.aws_sns_topic.cloudwatch_ok.arn]
-
-  metric_query {
-    id          = "e1"
-    expression  = "m2/m1*100"
-    label       = "Error Rate"
-    return_data = "true"
-  }
-
-  metric_query {
-    id = "m1"
-
-    metric {
-      metric_name = "http-requests/count/all/all"
-      namespace   = "bfd-${var.env_config.env}/bfd-server"
-      period      = "60"
-      stat        = "Sum"
-    }
-  }
-
-  metric_query {
-    id = "m2"
-
-    metric {
-      metric_name = "http-requests/count-500/all"
-      namespace   = "bfd-${var.env_config.env}/bfd-server"
-      period      = "60"
-      stat        = "Sum"
-    }
+  alarm_config = {
+    alarm_name       = "all-500s"
+    partner_name     = "all"
+    metric_prefix    = "http-requests/count-500"
+    eval_periods     = "15"
+    period           = "60"
+    datapoints       = "15"
+    statistic        = "Sum"
+    ext_statistic    = null
+    threshold        = "8.0"
+    alarm_notify_arn = data.aws_sns_topic.cloudwatch_alarms.arn
+    ok_notify_arn    = data.aws_sns_topic.cloudwatch_ok.arn
   }
 }
 

--- a/ops/terraform/modules/stateless/main.tf
+++ b/ops/terraform/modules/stateless/main.tf
@@ -344,52 +344,52 @@ module "bfd_server_alarm_all_500s" {
     alarm_name       = "all-500s"
     partner_name     = "all"
     metric_prefix    = "http-requests/count-500"
-    eval_periods     = "30"
+    eval_periods     = "10"
     period           = "60"
-    datapoints       = "30"
+    datapoints       = "10"
     statistic        = "Sum"
     ext_statistic    = null
-    threshold        = "5.0"
+    threshold        = "8.0"
     alarm_notify_arn = data.aws_sns_topic.cloudwatch_alarms.arn
     ok_notify_arn    = data.aws_sns_topic.cloudwatch_ok.arn
   }
 }
 
-module "bfd_server_alarm_all_eob_6s" {
+module "bfd_server_alarm_all_eob_4s-p95" {
   source = "../resources/bfd_server_alarm"
 
   env    = var.env_config.env
 
   alarm_config = {
-    alarm_name       = "all-eob-6s"
+    alarm_name       = "all-eob-4s-p95"
     partner_name     = "all"
     metric_prefix    = "http-requests/latency/eobAll"
-    eval_periods     = "30"
-    period           = "60"
-    datapoints       = "30"
+    eval_periods     = "10"
+    period           = "300"
+    datapoints       = "10"
     statistic        = null
-    ext_statistic    = "p99"
-    threshold        = "6000.0"
+    ext_statistic    = "p95"
+    threshold        = "4000.0"
     alarm_notify_arn = data.aws_sns_topic.cloudwatch_alarms.arn
     ok_notify_arn    = data.aws_sns_topic.cloudwatch_ok.arn
   }
 }
 
-module "bfd_server_alarm_mct_eob_6s" {
+module "bfd_server_alarm_mct_eob_4s_p95" {
   source = "../resources/bfd_server_alarm"
 
   env    = var.env_config.env
 
   alarm_config = {
-    alarm_name       = "mct-eob-6s"
+    alarm_name       = "mct-eob-4s-p95"
     partner_name     = "mct"
     metric_prefix    = "http-requests/latency/eobAll"
     eval_periods     = "10"
     period           = "60"
     datapoints       = "10"
     statistic        = null
-    ext_statistic    = "p99"
-    threshold        = "6000.0"
+    ext_statistic    = "p95"
+    threshold        = "4000.0"
     alarm_notify_arn = data.aws_sns_topic.cloudwatch_alarms.arn
     ok_notify_arn    = data.aws_sns_topic.cloudwatch_ok.arn
   }

--- a/ops/terraform/modules/stateless/main.tf
+++ b/ops/terraform/modules/stateless/main.tf
@@ -344,30 +344,12 @@ module "bfd_server_alarm_all_500s" {
     alarm_name       = "all-500s"
     partner_name     = "all"
     metric_prefix    = "http-requests/count-500"
-    eval_periods     = "1"
-    period           = "300"
+    eval_periods     = "30"
+    period           = "60"
+    datapoints       = "30"
     statistic        = "Sum"
     ext_statistic    = null
-    threshold        = "20.0"
-    alarm_notify_arn = data.aws_sns_topic.cloudwatch_alarms.arn
-    ok_notify_arn    = data.aws_sns_topic.cloudwatch_ok.arn
-  }
-}
-
-module "bfd_server_alarm_all_eob_4s" {
-  source = "../resources/bfd_server_alarm"
-
-  env    = var.env_config.env
-
-  alarm_config = {
-    alarm_name       = "all-eob-4s"
-    partner_name     = "all"
-    metric_prefix    = "http-requests/latency/eobAll"
-    eval_periods     = "1"
-    period           = "900"
-    statistic        = null
-    ext_statistic    = "p90"
-    threshold        = "4000.0"
+    threshold        = "5.0"
     alarm_notify_arn = data.aws_sns_topic.cloudwatch_alarms.arn
     ok_notify_arn    = data.aws_sns_topic.cloudwatch_ok.arn
   }
@@ -382,8 +364,9 @@ module "bfd_server_alarm_all_eob_6s" {
     alarm_name       = "all-eob-6s"
     partner_name     = "all"
     metric_prefix    = "http-requests/latency/eobAll"
-    eval_periods     = "1"
-    period           = "3600"
+    eval_periods     = "30"
+    period           = "60"
+    datapoints       = "30"
     statistic        = null
     ext_statistic    = "p99"
     threshold        = "6000.0"
@@ -401,8 +384,9 @@ module "bfd_server_alarm_mct_eob_6s" {
     alarm_name       = "mct-eob-6s"
     partner_name     = "mct"
     metric_prefix    = "http-requests/latency/eobAll"
-    eval_periods     = "1"
-    period           = "900"
+    eval_periods     = "10"
+    period           = "60"
+    datapoints       = "10"
     statistic        = null
     ext_statistic    = "p99"
     threshold        = "6000.0"

--- a/ops/terraform/modules/stateless/main.tf
+++ b/ops/terraform/modules/stateless/main.tf
@@ -335,23 +335,70 @@ module "bfd_server_metrics_ab2d" {
 
 # FHIR server alarms, partner specific
 #
-module "bfd_server_alarm_all_500s" {
-  source = "../resources/bfd_server_alarm"
 
-  env    = var.env_config.env
+# Deprecate classic HTTP 500 alarm for expression HTTP 500 alarm
+# module "bfd_server_alarm_all_500s" {
+#   source = "../resources/bfd_server_alarm"
 
-  alarm_config = {
-    alarm_name       = "all-500s"
-    partner_name     = "all"
-    metric_prefix    = "http-requests/count-500"
-    eval_periods     = "15"
-    period           = "60"
-    datapoints       = "15"
-    statistic        = "Sum"
-    ext_statistic    = null
-    threshold        = "8.0"
-    alarm_notify_arn = data.aws_sns_topic.cloudwatch_alarms.arn
-    ok_notify_arn    = data.aws_sns_topic.cloudwatch_ok.arn
+#   env    = var.env_config.env
+
+#   alarm_config = {
+#     alarm_name       = "all-500s"
+#     partner_name     = "all"
+#     metric_prefix    = "http-requests/count-500"
+#     eval_periods     = "15"
+#     period           = "60"
+#     datapoints       = "15"
+#     statistic        = "Sum"
+#     ext_statistic    = null
+#     threshold        = "8.0"
+#     alarm_notify_arn = data.aws_sns_topic.cloudwatch_alarms.arn
+#     ok_notify_arn    = data.aws_sns_topic.cloudwatch_ok.arn
+#   }
+# }
+
+resource "aws_cloudwatch_metric_alarm" "bfd_server_alarm_all_500s" {
+  alarm_name          = "bfd-${var.env_config.env}-server-all-500s"
+
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "15"
+  datapoints_to_alarm = "15"
+  threshold           = "0.1"
+
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions       = data.aws_sns_topic.cloudwatch_alarms.arn == null ? [] : [data.aws_sns_topic.cloudwatch_alarms.arn]
+  ok_actions          = data.aws_sns_topic.cloudwatch_ok.arn == null ? [] : [data.aws_sns_topic.cloudwatch_ok.arn]
+
+  metric_query {
+    id          = "e1"
+    expression  = "m2/m1*100"
+    label       = "Error Rate"
+    return_data = "true"
+  }
+
+  metric_query {
+    id = "m1"
+
+    metric {
+      metric_name = "http-requests/count/all/all"
+      namespace   = "bfd-${var.env_config.env}/bfd-server"
+      period      = "60"
+      stat        = "Sum"
+      unit        = "Count"
+    }
+  }
+
+  metric_query {
+    id = "m2"
+
+    metric {
+      metric_name = "http-requests/count-500/all"
+      namespace   = "bfd-${var.env_config.env}/bfd-server"
+      period      = "60"
+      stat        = "Sum"
+      unit        = "Count"
+    }
   }
 }
 

--- a/ops/terraform/modules/stateless/main.tf
+++ b/ops/terraform/modules/stateless/main.tf
@@ -385,7 +385,6 @@ resource "aws_cloudwatch_metric_alarm" "bfd_server_alarm_all_500s" {
       namespace   = "bfd-${var.env_config.env}/bfd-server"
       period      = "60"
       stat        = "Sum"
-      unit        = "Count"
     }
   }
 
@@ -397,7 +396,6 @@ resource "aws_cloudwatch_metric_alarm" "bfd_server_alarm_all_500s" {
       namespace   = "bfd-${var.env_config.env}/bfd-server"
       period      = "60"
       stat        = "Sum"
-      unit        = "Count"
     }
   }
 }

--- a/ops/terraform/modules/stateless/main.tf
+++ b/ops/terraform/modules/stateless/main.tf
@@ -344,9 +344,9 @@ module "bfd_server_alarm_all_500s" {
     alarm_name       = "all-500s"
     partner_name     = "all"
     metric_prefix    = "http-requests/count-500"
-    eval_periods     = "10"
+    eval_periods     = "15"
     period           = "60"
-    datapoints       = "10"
+    datapoints       = "15"
     statistic        = "Sum"
     ext_statistic    = null
     threshold        = "8.0"
@@ -355,41 +355,41 @@ module "bfd_server_alarm_all_500s" {
   }
 }
 
-module "bfd_server_alarm_all_eob_4s-p95" {
+module "bfd_server_alarm_all_eob_6s-p95" {
   source = "../resources/bfd_server_alarm"
 
   env    = var.env_config.env
 
   alarm_config = {
-    alarm_name       = "all-eob-4s-p95"
+    alarm_name       = "all-eob-6s-p95"
     partner_name     = "all"
     metric_prefix    = "http-requests/latency/eobAll"
-    eval_periods     = "10"
-    period           = "300"
-    datapoints       = "10"
+    eval_periods     = "15"
+    period           = "60"
+    datapoints       = "15"
     statistic        = null
     ext_statistic    = "p95"
-    threshold        = "4000.0"
+    threshold        = "6000.0"
     alarm_notify_arn = data.aws_sns_topic.cloudwatch_alarms.arn
     ok_notify_arn    = data.aws_sns_topic.cloudwatch_ok.arn
   }
 }
 
-module "bfd_server_alarm_mct_eob_4s_p95" {
+module "bfd_server_alarm_mct_eob_3s_p95" {
   source = "../resources/bfd_server_alarm"
 
   env    = var.env_config.env
 
   alarm_config = {
-    alarm_name       = "mct-eob-4s-p95"
+    alarm_name       = "mct-eob-3s-p95"
     partner_name     = "mct"
     metric_prefix    = "http-requests/latency/eobAll"
-    eval_periods     = "10"
+    eval_periods     = "15"
     period           = "60"
-    datapoints       = "10"
+    datapoints       = "15"
     statistic        = null
     ext_statistic    = "p95"
-    threshold        = "4000.0"
+    threshold        = "3000.0"
     alarm_notify_arn = data.aws_sns_topic.cloudwatch_alarms.arn
     ok_notify_arn    = data.aws_sns_topic.cloudwatch_ok.arn
   }


### PR DESCRIPTION
**JIRA Ticket:**
[BFD-168](https://jira.cms.gov/browse/BFD-168)

**User Story or Bug Summary:**
Adjust CloudWatch alarms to alert when there is a systemic issue rather than an outlier, bring alerts slightly closer to reality with our SLOs

### What Does This PR Do?

FHIR server:
- Refactor to pass in a configurable number of datapoints for alarms rather than hardcoding "1"
- Attempt to set sane configuration parameters for evaluating unacceptable P95 latencies for MCT and other partners over time
- Attempt to set sane configuration parameters for evaluating persistent HTTP 500 errors over time

Pipeline:
- Refactor to pass in a configurable number of datapoints for alarms rather than hardcoding "1"
- Add metric for data set failure event
- Add alarm for data set failure event
- Attempt to set sane configuration parameters for evaluating persistent pipeline errors over time

### What Should Reviewers Watch For?

Generally, are these configuration parameters reasonable?  Once this is hashed out PR can move from draft.  Current proposal:

- FHIR server: MCT: P95 > 4s for 10 consecutive periods of 1 minute
- FHIR server: all other partners: P95 > 4s for 10 consecutive periods of 5 minutes
- FHIR server: all HTTP 500s > 8 ( minimum request threshold I've seen in prod ) for 10 consecutive periods of 5 minutes
- Pipeline server: data set failed event occurs one time within 5 minute period
- Pipeline server: general error occurs at least once over 10 consecutive periods of 5 minutes

On the pipeline side, are there any other failure events we should watch for?  "Data set processing failed" is the most important one is it indicates a direct violation of our SLO.

### What Security Implications Does This PR Have?

* If the answer to any of the questions below is **Yes**, then here's a link to the associated Security Impact Assessment: N/A.
    * Does this PR add any new software dependencies? **No**.
    * Does this PR modify or invalidate any of our security controls?**No**.
    * Does this PR store or transmit data that was not stored or transmitted before? **No**.
* If the answer to any of the questions below is **Yes**, then please add @StewGoin as a reviewer, and note that this PR should not be merged unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons? **No**.

### What Needs to Be Merged and Deployed Before this PR?

N/A

### Submitter Checklist

Before requesting final review, I've gone through and verified that this PR complies with the following requirements:

* [x] I've refactored and rebased this PR (for help, see: [this](https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had) and [this](https://raphaelfabeni.com/git-editing-commits-part-1/), if needed, so that it is as small as it can reasonably be, in order to:
    1. Ensure that any problems it causes have a small "blast radius".
    2. Ensure that it'll be easier to rollback if that becomes necessary.
    3. Ease the burden on reviewers.
* [x] I've verified that the commits in this PR:
    1. Reasonably explain the "what" and "why" of the changes.
    2. Leverage JIRA's [smart commits](https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html) to reference the JIRA ticket that they're associated with. For example, aim for commit messages like this (note also [the 50/72 formatting](https://stackoverflow.com/q/2290016) used here):
        
        ```
        Added the whizbang to the doodad.

        The new whizbang should really simplify things for our whoosit users.
        It was a bit tricky to get it into the doodad, but we decided that the
        flipwhee pattern was the best approach for now. Might want to revisit
        that in the future if it ends up being too hard to maintain.

        SOMEPROJECT-42
        ```
        
* [ ] I've verified that this PR includes all required documentation changes, including `README` updates and changelog / release notes entries.
* [x] I've verified that all new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] I've verified that all tech debt and/or shortcomings introduced by this PR is detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] I've requested review from at least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
* [x] I've requested review from any relevant engineers on other projects (e.g. BFD, SLS, etc.).
* [x] I've verified that this PR and its changes comply with all other policies in the [DASG Engineering Standards](../policies/engineering_standards.md) and have specifically called out any/all deviations in this PR.