### PR TITLE
Changed hapi-fihr from v 4.1.0 to 4.2.0

### DIFF
--- a/apps/bfd-server/pom.xml
+++ b/apps/bfd-server/pom.xml
@@ -16,7 +16,7 @@
 	</description>
 
 	<properties>
-		<hapi-fhir.version>4.1.0</hapi-fhir.version>
+		<hapi-fhir.version>4.2.0</hapi-fhir.version>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
JIRA Ticket:
BFD-169

User Story or Bug Summary:

As the BFD, I'd like to use FHIR HAPI version 4.2 in order to take advantage of performance enhancements associated with the improved parsing.

A/C:

Run performance test of 4.1 to establish baseline in TEST
BFD is updated to use FHIR HAPI 4.2 i/o version 4.1.
Run a post update performance test of version 4.2 in TEST to quantify performance gain (and confirm no performance degradation)

What Does This PR Do?
Upgrades the HAPI-FIHR library from v4.1.0 to 4.2.0

What Should Reviewers Watch For?
Make sure all unit and integration test pass. That performance is not downgraded by upgrading to v4.2.0

What Security Implications Does This PR Have?
Submitters should complete the following questionnaire:

If the answer to any of the questions below is Yes, then here's a link to the associated Security Impact Assessment: N/A.
Does this PR add any new software dependencies? =No.
Does this PR modify or invalidate any of our security controls? No.
Does this PR store or transmit data that was not stored or transmitted before? No.
If the answer to any of the questions below is Yes, then please add @StewGoin as a reviewer, and note that this PR should not be merged unless/until he also approves it.
Do you think this PR requires additional review of its security implications for other reasons? No.
What Needs to Be Merged and Deployed Before this PR?
N/A

