### PR TITLE
BFD-211: Fix for broken AWS terraform provider >= 2.61.0

### DIFF
--- a/ops/terraform/env/prod-sbx/stateless/main.tf
+++ b/ops/terraform/env/prod-sbx/stateless/main.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 provider "aws" {
-  # Revert once this is fixed: https://github.com/terraform-providers/terraform-provider-aws/issues/13236
+  # FIXME BFD-211: Revert once this is fixed: https://github.com/terraform-providers/terraform-provider-aws/issues/13236
   # version = "~> 2.25"
   version = "<= 2.60.0"
   region = "us-east-1"

--- a/ops/terraform/env/prod-sbx/stateless/main.tf
+++ b/ops/terraform/env/prod-sbx/stateless/main.tf
@@ -3,7 +3,9 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.25"
+  # Revert once this is fixed: https://github.com/terraform-providers/terraform-provider-aws/issues/13236
+  # version = "~> 2.25"
+  version = "<= 2.60.0"
   region = "us-east-1"
 }
 

--- a/ops/terraform/env/prod/stateless/main.tf
+++ b/ops/terraform/env/prod/stateless/main.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 provider "aws" {
-  # Revert once this is fixed: https://github.com/terraform-providers/terraform-provider-aws/issues/13236
+  # FIXME BFD-211: Revert once this is fixed: https://github.com/terraform-providers/terraform-provider-aws/issues/13236
   # version = "~> 2.25"
   version = "<= 2.60.0"
   region = "us-east-1"

--- a/ops/terraform/env/prod/stateless/main.tf
+++ b/ops/terraform/env/prod/stateless/main.tf
@@ -3,7 +3,9 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.25"
+  # Revert once this is fixed: https://github.com/terraform-providers/terraform-provider-aws/issues/13236
+  # version = "~> 2.25"
+  version = "<= 2.60.0"
   region = "us-east-1"
 }
 

--- a/ops/terraform/env/test/stateless/main.tf
+++ b/ops/terraform/env/test/stateless/main.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 provider "aws" {
-  # Revert once this is fixed: https://github.com/terraform-providers/terraform-provider-aws/issues/13236
+  # FIXME BFD-211: Revert once this is fixed: https://github.com/terraform-providers/terraform-provider-aws/issues/13236
   # version = "~> 2.25"
   version = "<= 2.60.0"
   region = "us-east-1"

--- a/ops/terraform/env/test/stateless/main.tf
+++ b/ops/terraform/env/test/stateless/main.tf
@@ -3,7 +3,9 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.25"
+  # Revert once this is fixed: https://github.com/terraform-providers/terraform-provider-aws/issues/13236
+  # version = "~> 2.25"
+  version = "<= 2.60.0"
   region = "us-east-1"
 }
 


### PR DESCRIPTION
Hotfix for: https://github.com/terraform-providers/terraform-provider-aws/issues/13236

This should be reverted one we validate that the most recent AWS provider version works again.