### PR TITLE
Add prod role for AB2D

### DIFF
--- a/ops/terraform/env/prod/stateful/main.tf
+++ b/ops/terraform/env/prod/stateful/main.tf
@@ -59,7 +59,7 @@ module "stateful" {
 
   medicare_opt_out_config = {
     # TODO: add read roles for DPC
-    read_roles        = []
+    read_roles        = ["arn:aws:iam::595094747606:role/Ab2dInstanceRole"]
     write_accts       = ["arn:aws:iam::755619740999:root"]
     admin_users       = ["arn:aws:iam::577373831711:user/DS7H", "arn:aws:iam::577373831711:user/VZG9", "arn:aws:iam::577373831711:user/HWRI"]
   }


### PR DESCRIPTION
**JIRA Ticket:**

Slack reference: https://cmsgov.slack.com/archives/CMT1YS2KY/p1590523487339100

**User Story or Bug Summary:**

Add AB2D role to prod medicare opt out bucket

### What Does This PR Do?

Adds AB2D's instance role to the S3 policy for the prod medicare opt out bucket

### What Should Reviewers Watch For?

That this successfully grants AB2D access to the intended bucket

### What Security Implications Does This PR Have?

* If the answer to any of the questions below is **Yes**, then here's a link to the associated Security Impact Assessment: N/A.
    * Does this PR add any new software dependencies? **No**.
    * Does this PR modify or invalidate any of our security controls? **No**.
    * Does this PR store or transmit data that was not stored or transmitted before? **Yes**.
* If the answer to any of the questions below is **Yes**, then please add @StewGoin as a reviewer, and note that this PR should not be merged unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons? **No**.

@StewGoin Can you verify AB2D has approval for this change?

### What Needs to Be Merged and Deployed Before this PR?

N/A

### Submitter Checklist

Before requesting final review, I've gone through and verified that this PR complies with the following requirements:

* [x] I've refactored and rebased this PR (for help, see: [this](https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had) and [this](https://raphaelfabeni.com/git-editing-commits-part-1/), if needed, so that it is as small as it can reasonably be, in order to:
    1. Ensure that any problems it causes have a small "blast radius".
    2. Ensure that it'll be easier to rollback if that becomes necessary.
    3. Ease the burden on reviewers.
* [x] I've verified that the commits in this PR:
    1. Reasonably explain the "what" and "why" of the changes.
    2. Leverage JIRA's [smart commits](https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html) to reference the JIRA ticket that they're associated with. For example, aim for commit messages like this (note also [the 50/72 formatting](https://stackoverflow.com/q/2290016) used here):
        
        ```
        Added the whizbang to the doodad.

        The new whizbang should really simplify things for our whoosit users.
        It was a bit tricky to get it into the doodad, but we decided that the
        flipwhee pattern was the best approach for now. Might want to revisit
        that in the future if it ends up being too hard to maintain.

        SOMEPROJECT-42
        ```
        
* [x] I've verified that this PR includes all required documentation changes, including `README` updates and changelog / release notes entries.
* [x] I've verified that all new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] I've verified that all tech debt and/or shortcomings introduced by this PR is detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] I've requested review from at least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
* [x] I've requested review from any relevant engineers on other projects (e.g. BFD, SLS, etc.).
* [x] I've verified that this PR and its changes comply with all other policies in the [DASG Engineering Standards](../policies/engineering_standards.md) and have specifically called out any/all deviations in this PR.