### PR TITLE
BFD-63: Deployment information and troubleshooting documentation

### DIFF
--- a/ops/ccs-ops-misc/DEPLOY-INFO.md
+++ b/ops/ccs-ops-misc/DEPLOY-INFO.md
@@ -1,5 +1,5 @@
-Deployment Runbook
-------------------
+Deployment Info
+---------------
 
 ### General Info
 

--- a/ops/ccs-ops-misc/DEPLOY-INFO.md
+++ b/ops/ccs-ops-misc/DEPLOY-INFO.md
@@ -24,6 +24,8 @@ Non-outage deployment timeout is the #1 issue encountered when deploying BFD, an
 - BFD service itself fails or is slow to start
 - AWS operations called by terraform are slow
 
+For insight into the cloud-init stage look at /var/log/cloud-init.log and /var/log/cloud-init-output.log
+For insight into the BFD FHIR application servers look in /usr/local/bfd-server/
 In circumstances where the old deployment autoscaling group is online and no outage has occured, the best option is to roll forward and attempt another deployment with any associated fixes.
 
 In circumstances where the old deployment autoscaling group is no longer online, but performance or functionality of the new autoscaling group is degraded, a determiniation should be made whether to perform a roll forward or a roll back:

--- a/ops/ccs-ops-misc/DEPLOY-INFO.md
+++ b/ops/ccs-ops-misc/DEPLOY-INFO.md
@@ -31,6 +31,6 @@ In circumstances where the old deployment autoscaling group is no longer online,
 - If a large subset of requests are affected, a roll forward may be less acceptable and a roll back should be attempted
 
 There is no safe way to perform a roll back in Jenkins as all stages are dependent on variables acquired from previous stages at runtime, so the safe way to perform a roll back so to extract the terraform apply command from a previous deploy and run it locally:
-- Change to the appropriate terraform environment directory: `cd ops/terraform/env/test/stateless/`
-- Extract and run the terraform plan command from Jenkins: `terraform plan -var=fhir_ami=ami-034084a3946310dc4 -var=etl_ami=ami-0dba7ffeecdd9b8be -var=ssh_key_name=bfd-test -var=git_branch_name=master -var=git_commit_id=ec883a06fbdc7fdc72daa1655eefe26643aac008 -no-color -out=tfplan`
-- Extract and run the terraform apply command from Jenkins: `terraform apply -no-color -input=false tfplan`
+- Change to the appropriate terraform environment directory. Example: `cd ops/terraform/env/test/stateless/`
+- Extract and run the terraform plan command from Jenkins. Example `terraform plan -var=fhir_ami=ami-034084a3946310dc4 -var=etl_ami=ami-0dba7ffeecdd9b8be -var=ssh_key_name=bfd-test -var=git_branch_name=master -var=git_commit_id=ec883a06fbdc7fdc72daa1655eefe26643aac008 -no-color -out=tfplan`
+- Extract and run the terraform apply command from Jenkins. Example: `terraform apply -no-color -input=false tfplan`

--- a/ops/ccs-ops-misc/DEPLOY-INFO.md
+++ b/ops/ccs-ops-misc/DEPLOY-INFO.md
@@ -1,0 +1,36 @@
+Deployment Runbook
+------------------
+
+# General Info
+
+- Single, multibranch Jenkinsfile provides all stage orchestration.
+  - App build logic located here: `apps/build.groovy`
+  - Deploy logic located here: `ops/deploy-ccs.groovy`
+- Platinum AMI is an optional stage controlled by `build_platinum` var.  Recommend building at least once a month.
+- Only the master branch can deploy to production environments unless `deploy_prod_from_non_master` var is set to true.
+- Deployment stages use locks to prevent multiple deployments from occuring at once to the same environment.
+- There is a gate (manual approval stage) between TEST and PROD-SBX deployment, but not between PROD-SBX and PROD deployment.  Recommend locking the PROD environment in order to gate the PROD-SBX deployment for additional testing.
+- Our merge strategy in Jenkins is to merge the current deploying branch with master, which creates a unique commit ID in Jenkins that is appended to deployed AMIs.  To look up the commit ID of an AMI, you'll need to look up the merge commit in Jenkins and then find the originating commit from the BFD repo.
+
+# Failed Deployment Troubleshooting
+
+ELB health checks and smoke testing embedded in the BFD startup script prevent completely broken deployments.  Additionally we use a create-before-destroy apply method in terraform when creating a new deployment autoscaling group.  If a new deployment fails these checks, it will time out the terraform deployment, leaving the original autoscaling group in tact, thus preventing an outage.
+
+Non-outage deployment timeout is the #1 issue encountered when deploying BFD, and unfortunately can happen for many reasons:
+- Startup routines in the gold image defined stage of cloud-init are failing or slow
+- Startup routines in our user data defined stage of cloud-init are failing or slow
+  - Can occur in our actual user data bash script
+  - Can occur in ansible launch playbook
+- BFD service itself fails or is slow to start
+- AWS operations called by terraform are slow
+
+In circumstances where the old deployment autoscaling group is online and no outage has occured, the best option is to roll forward and attempt another deployment with any associated fixes.
+
+In circumstances where the old deployment autoscaling group is no longer online, but performance or functionality of the new autoscaling group is degraded, a determiniation should be made whether to perform a roll forward or a roll back:
+- If a small subset of requests are affected, a roll forward (new deployment with fix) may be an acceptable strategy
+- If a large subset of requests are affected, a roll forward may be less acceptable and a roll back should be attempted
+
+There is no safe way to perform a roll back in Jenkins as all stages are dependent on variables acquired from previous stages at runtime, so the safe way to perform a roll back so to extract the terraform apply command from a previous deploy and run it locally:
+- Change to the appropriate terraform environment directory: `cd ops/terraform/env/test/stateless/`
+- Extract and run the terraform plan command from Jenkins: `terraform plan -var=fhir_ami=ami-034084a3946310dc4 -var=etl_ami=ami-0dba7ffeecdd9b8be -var=ssh_key_name=bfd-test -var=git_branch_name=master -var=git_commit_id=ec883a06fbdc7fdc72daa1655eefe26643aac008 -no-color -out=tfplan`
+- Extract and run the terraform apply command from Jenkins: `terraform apply -no-color -input=false tfplan`

--- a/ops/ccs-ops-misc/DEPLOY-INFO.md
+++ b/ops/ccs-ops-misc/DEPLOY-INFO.md
@@ -1,7 +1,7 @@
 Deployment Runbook
 ------------------
 
-# General Info
+### General Info
 
 - Single, multibranch Jenkinsfile provides all stage orchestration.
   - App build logic located here: `apps/build.groovy`
@@ -12,7 +12,7 @@ Deployment Runbook
 - There is a gate (manual approval stage) between TEST and PROD-SBX deployment, but not between PROD-SBX and PROD deployment.  Recommend locking the PROD environment in order to gate the PROD-SBX deployment for additional testing.
 - Our merge strategy in Jenkins is to merge the current deploying branch with master, which creates a unique commit ID in Jenkins that is appended to deployed AMIs.  To look up the commit ID of an AMI, you'll need to look up the merge commit in Jenkins and then find the originating commit from the BFD repo.
 
-# Failed Deployment Troubleshooting
+### Failed Deployment Troubleshooting
 
 ELB health checks and smoke testing embedded in the BFD startup script prevent completely broken deployments.  Additionally we use a create-before-destroy apply method in terraform when creating a new deployment autoscaling group.  If a new deployment fails these checks, it will time out the terraform deployment, leaving the original autoscaling group in tact, thus preventing an outage.
 


### PR DESCRIPTION
**JIRA Ticket:**
[BFD-63](https://jira.cms.gov/browse/BFD-63)

**User Story or Bug Summary:**
Provide deployment general and troubleshooting information as documentation

### What Does This PR Do?
This documentation outlines general information regarding how our Jenkins multibranch pipeline is architected, along with some edge cases.  It also provides deployment troubleshooting guidance based on past issues seen, and some theoretical scenarios that have never come to pass (rollbacks) but could be needed in the future.

### What Should Reviewers Watch For?

If you're reviewing this PR, please check these things, in particular:
- Anything else you feel you don't know about our deployment scenario that I could provide here?

### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then here's a link to the associated Security Impact Assessment: N/A.
    * Does this PR add any new software dependencies? **No**.
    * Does this PR modify or invalidate any of our security controls? **No**.
    * Does this PR store or transmit data that was not stored or transmitted before? **No**.
* If the answer to any of the questions below is **Yes**, then please add @StewGoin as a reviewer, and note that this PR should not be merged unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons? **No**.

### What Needs to Be Merged and Deployed Before this PR?
N/A

### Submitter Checklist

Before requesting final review, I've gone through and verified that this PR complies with the following requirements:

* [x] I've refactored and rebased this PR (for help, see: [this](https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had) and [this](https://raphaelfabeni.com/git-editing-commits-part-1/), if needed, so that it is as small as it can reasonably be, in order to:
    1. Ensure that any problems it causes have a small "blast radius".
    2. Ensure that it'll be easier to rollback if that becomes necessary.
    3. Ease the burden on reviewers.
* [x] I've verified that the commits in this PR:
    1. Reasonably explain the "what" and "why" of the changes.
    2. Leverage JIRA's [smart commits](https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html) to reference the JIRA ticket that they're associated with. For example, aim for commit messages like this (note also [the 50/72 formatting](https://stackoverflow.com/q/2290016) used here):
        
        ```
        Added the whizbang to the doodad.

        The new whizbang should really simplify things for our whoosit users.
        It was a bit tricky to get it into the doodad, but we decided that the
        flipwhee pattern was the best approach for now. Might want to revisit
        that in the future if it ends up being too hard to maintain.

        SOMEPROJECT-42
        ```
        
* [x] I've verified that this PR includes all required documentation changes, including `README` updates and changelog / release notes entries.
* [x] I've verified that all new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] I've verified that all tech debt and/or shortcomings introduced by this PR is detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] I've requested review from at least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
* [x] I've requested review from any relevant engineers on other projects (e.g. BFD, SLS, etc.).
* [x] I've verified that this PR and its changes comply with all other policies in the [DASG Engineering Standards](../policies/engineering_standards.md) and have specifically called out any/all deviations in this PR.