### PR TITLE
BFD-256 - Increase min ASG size for prod and prod-sbx

### DIFF
--- a/ops/terraform/modules/stateless/main.tf
+++ b/ops/terraform/modules/stateless/main.tf
@@ -6,6 +6,7 @@
 locals {
   azs               = ["us-east-1a", "us-east-1b", "us-east-1c"]
   env_config        = {env=var.env_config.env, tags=var.env_config.tags, vpc_id=data.aws_vpc.main.id, zone_id=data.aws_route53_zone.local_zone.id, azs=local.azs}
+  is_prod           = substr(var.env_config.env, 0, 4) == "prod"
   port              = 7443
   cw_period         = 60    # Seconds
   cw_eval_periods   = 3
@@ -231,9 +232,9 @@ module "fhir_asg" {
 
   # Initial size is one server per AZ
   asg_config        = {
-    min             = length(local.azs)
+    min             = local.is_prod ? 2*length(local.azs): length(local.azs)
     max             = 8*length(local.azs)
-    desired         = length(local.azs)
+    desired         = local.is_prod ? 2*length(local.azs): length(local.azs)
     sns_topic_arn   = ""
     instance_warmup = 430
   }


### PR DESCRIPTION
### Change Details

In support of increasing performance for AB2D, we are increasing the minimum number of running instances from 3 to 6 for prod and prod-sbx environments (test should remain at 3 to save on costs).

This is a temporary measure until a better AutoScaling metric can be created.

### Acceptance Validation

- Min and Desired counts should be twice the count of availability zones (we have 3) if prod or prod-sbx
- Test should remain at the default number of 1 per AZ (3 total)

Notes:
A `terraform plan` was run manually to verify that test would remain at 3 instances and prod would be increased to 6. This is a snippet from prod (test remained at 3):

```
      ~ min_elb_capacity.   = 3 -> 6
      ~ min_size.   = 3 -> 6
```

### External References

- [BFD-256](https://jira.cms.gov/browse/BFD-256)

### Security Implications
None
