### PR TITLE
Correct type mismatch in TransformerUtils

### DIFF
--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtils.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtils.java
@@ -336,8 +336,10 @@ public final class TransformerUtils {
     }
 
     // Link the EOB.item to the care team entry (if it isn't already).
-    if (!eobItem.getCareTeamLinkId().contains(careTeamEntry.getSequence())) {
-      eobItem.addCareTeamLinkId(careTeamEntry.getSequence());
+    final int careTeamEntrySequence = careTeamEntry.getSequence();
+    if (eobItem.getCareTeamLinkId().stream()
+        .noneMatch(id -> id.getValue() == careTeamEntrySequence)) {
+      eobItem.addCareTeamLinkId(careTeamEntrySequence);
     }
 
     return careTeamEntry;


### PR DESCRIPTION
### Change Details

LGTM identified a type mismatch when checking for a care team entry in an ExplanationOfBenefit item, where `PositiveIntType` objects are being compared to an `int`. This changes the check to use the `PositiveIntType`'s value, an `Integer`.

### External References

- https://lgtm.com/projects/g/CMSgov/beneficiary-fhir-data/snapshot/fe72eb2cf5aa84e17bf1be7738398f59f645d081/files/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtils.java#x1661a4d14162ef46:1

### Security Implications

No security implications.

- [ ] new software dependencies

- [ ] altered security controls

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

