### PR TITLE
Add V2_ENABLED environment variable for all environments

### DIFF
--- a/.github/workflows/ci-java.yml
+++ b/.github/workflows/ci-java.yml
@@ -2,7 +2,7 @@ name: 'CI - Java'
 on: pull_request
 jobs:
   mvn-job:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     strategy:
       matrix: 
         mvn_command: ['verify', 'com.coveo:fmt-maven-plugin:check']

--- a/ops/ansible/playbooks-ccs/vars/prod-sbx/group_vars/all/env_specific.yml
+++ b/ops/ansible/playbooks-ccs/vars/prod-sbx/group_vars/all/env_specific.yml
@@ -13,7 +13,7 @@ s3_bucket_etl_staging: 'bfd-prod-sbx-etl-577373831711'
 env_name_std: 'prod-sbx'
 
 # Whether to enable BFD API V2
-data_server_v2_enabled: true
+data_server_v2_enabled: false
 
 # This system is an m5.xlarge (4 vCPUs, 16 GB RAM).
 data_pipeline_ec2_instance_type_mem_mib: "{{ 16 * 1024 }}"

--- a/ops/ansible/playbooks-ccs/vars/prod-sbx/group_vars/all/env_specific.yml
+++ b/ops/ansible/playbooks-ccs/vars/prod-sbx/group_vars/all/env_specific.yml
@@ -12,6 +12,9 @@ s3_bucket_etl_staging: 'bfd-prod-sbx-etl-577373831711'
 # The abbreviated name for this environment, per https://confluence.cms.gov/display/ODI/AWS+Naming+and+Tagging+Conventions.
 env_name_std: 'prod-sbx'
 
+# Whether to enable BFD API V2
+data_server_v2_enabled: true
+
 # This system is an m5.xlarge (4 vCPUs, 16 GB RAM).
 data_pipeline_ec2_instance_type_mem_mib: "{{ 16 * 1024 }}"
 data_pipeline_ec2_instance_type_vcpu: 4

--- a/ops/ansible/playbooks-ccs/vars/prod/group_vars/all/env_specific.yml
+++ b/ops/ansible/playbooks-ccs/vars/prod/group_vars/all/env_specific.yml
@@ -18,6 +18,9 @@ data_pipeline_ec2_instance_type_vcpu: 16
 
 data_pipeline_idempotency_required: false
 
+# Whether to enable BFD API V2
+data_server_v2_enabled: false
+
 # These systems are m5.xlarge (4 vCPUs, 16 GB RAM).
 data_server_ec2_instance_type_mem_mib: "{{ 16 * 1024 }}"
 

--- a/ops/ansible/playbooks-ccs/vars/test/group_vars/all/env_specific.yml
+++ b/ops/ansible/playbooks-ccs/vars/test/group_vars/all/env_specific.yml
@@ -23,6 +23,9 @@ data_pipeline_ec2_instance_type_vcpu: 4
 # load.
 data_pipeline_idempotency_required: false
 
+# Whether to enable BFD API V2
+data_server_v2_enabled: true
+
 # These systems are m5.xlarge (4 vCPUs, 16 GB RAM).
 data_server_ec2_instance_type_mem_mib: "{{ 16 * 1024 }}"
 

--- a/ops/ansible/playbooks-ccs/vars/test/group_vars/all/env_specific.yml
+++ b/ops/ansible/playbooks-ccs/vars/test/group_vars/all/env_specific.yml
@@ -24,7 +24,7 @@ data_pipeline_ec2_instance_type_vcpu: 4
 data_pipeline_idempotency_required: false
 
 # Whether to enable BFD API V2
-data_server_v2_enabled: true
+data_server_v2_enabled: false
 
 # These systems are m5.xlarge (4 vCPUs, 16 GB RAM).
 data_server_ec2_instance_type_mem_mib: "{{ 16 * 1024 }}"

--- a/ops/ansible/roles/bfd-server/defaults/main.yml
+++ b/ops/ansible/roles/bfd-server/defaults/main.yml
@@ -24,4 +24,4 @@ data_server_ssl_client_certificates: []
 data_server_db_connections_max: 40
 
 # Whether to enable BFD API V2
-data_pipeline_v2_enabled: false
+data_server_v2_enabled: false

--- a/ops/ansible/roles/bfd-server/defaults/main.yml
+++ b/ops/ansible/roles/bfd-server/defaults/main.yml
@@ -22,3 +22,6 @@ data_server_ssl_client_certificates: []
 
 # The max size of the DB connection pool for the Blue Button Data Server.
 data_server_db_connections_max: 40
+
+# Whether to enable BFD API V2
+data_pipeline_v2_enabled: false

--- a/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
+++ b/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
@@ -5,6 +5,7 @@ export BFD_PORT='{{ data_server_appserver_https_port }}'
 export BFD_KEYSTORE='{{ data_server_dir }}/bluebutton-appserver-keystore.jks'
 export BFD_TRUSTSTORE='{{ data_server_dir }}/bluebutton-appserver-truststore.jks'
 export BFD_WAR='{{ data_server_dir }}/{{ data_server_war | basename }}'
+export V2_ENABLED='{{ data_pipeline_v2_enabled }}'
 
 # The WAR picks up its config from Java system properties, so set some variables we can use for
 # those.

--- a/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
+++ b/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
@@ -5,7 +5,7 @@ export BFD_PORT='{{ data_server_appserver_https_port }}'
 export BFD_KEYSTORE='{{ data_server_dir }}/bluebutton-appserver-keystore.jks'
 export BFD_TRUSTSTORE='{{ data_server_dir }}/bluebutton-appserver-truststore.jks'
 export BFD_WAR='{{ data_server_dir }}/{{ data_server_war | basename }}'
-export V2_ENABLED='{{ data_pipeline_v2_enabled }}'
+export V2_ENABLED='{{ data_server_v2_enabled }}'
 
 # The WAR picks up its config from Java system properties, so set some variables we can use for
 # those.


### PR DESCRIPTION
<!--

### Change Details

This change creates an environment variable that lives in the Ansible vars files and is made available to the OS on our FHIR App servers. Currently the V2_ENABLED is set to false for all environments so that we can confirm this feature flag when disabled does indeed block V2 from being available. 

<!-- Add detailed discussion of changes here: -->
<!-- This is likely a summary, or the complete contents, of your commit messages -->

### Acceptance Validation

Does this variable definition look complete?
Is the variable set to FALSE in all environments?

### Feedback Requested

N/A

### External References

<!-- For example: replace xxx with the JIRA ticket number: -->

- [BLUEBUTTON-347](https://jira.cms.gov/browse/BLUEBUTTON-347)

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] altered security controls

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications
<!-- Use this to indicate you're unsure how this change may impact system security and would like to solicit the team's feedback. Optionally, provide background information regarding your questions and concerns. -->

