### PR TITLE
Remove docker from our build servers.

### DIFF
--- a/ops/ansible/playbooks-ccs/build_jenkins.yml
+++ b/ops/ansible/playbooks-ccs/build_jenkins.yml
@@ -33,8 +33,6 @@
     - import_role:
         name: install_jenkins
     - import_role:
-        name: install_docker
-    - import_role:
         name: conf_jenkins
     - import_role:
         name: cloudwatch-agent-instrumented

--- a/ops/ansible/playbooks-ccs/update_jenkins.yml
+++ b/ops/ansible/playbooks-ccs/update_jenkins.yml
@@ -32,8 +32,6 @@
     - import_role:
         name: install_jenkins
     - import_role:
-        name: install_docker
-    - import_role:
         name: cloudwatch-agent-instrumented
 
     - name: Build CloudWatch unified agent configuration


### PR DESCRIPTION
### Change Details

This change removes (or does not install) the unused docker installation from our build servers. Since we do not use docker in any shape or form on our build servers, this service simply eats up system resources for no reason.

Note: I deployed this change to mgmt-test and verified that docker was not present and we were able to build.

### Acceptance Validation
The 'install_docker' ansible role is not included when building or updating jenkins.

### Security Implications
None. It actually improves security by decreasing our build server's attack surface.

