### PR TITLE
BCDA-3815: BFD Insights: Adding tables for BCDA insights queries

### DIFF
--- a/insights/terraform/projects/bcda/backend.tf
+++ b/insights/terraform/projects/bcda/backend.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.12"
+  required_version = "~> 0.13.4"
   # Use the common terraform bucket for all of BFD's state
   backend "s3" {
     bucket         = "bfd-tf-state"

--- a/insights/terraform/projects/bcda/main.tf
+++ b/insights/terraform/projects/bcda/main.tf
@@ -31,65 +31,65 @@ data "aws_kms_alias" "moderate_cmk" {
 ## Athena workgroup
 
 module "workgroup" {
-  source          = "../../modules/workgroup"
-  bucket          = module.bucket.id
-  bucket_cmk      = module.bucket.bucket_cmk
-  name            = local.database
-  tags            = local.tags
+  source     = "../../modules/workgroup"
+  bucket     = module.bucket.id
+  bucket_cmk = module.bucket.bucket_cmk
+  name       = local.database
+  tags       = local.tags
 }
 
 ## Database for the project
 
 module "database" {
-  source          = "../../modules/database"
-  database        = local.database
-  bucket          = module.bucket.id
-  bucket_cmk      = module.bucket.bucket_cmk
-  tags            = local.tags
+  source     = "../../modules/database"
+  database   = local.database
+  bucket     = module.bucket.id
+  bucket_cmk = module.bucket.bucket_cmk
+  tags       = local.tags
 }
 
 ## Glue setup
 
 module "glue_jobs" {
-  source          = "../../modules/jobs"
-  project         = local.project
-  tags            = local.tags
+  source  = "../../modules/jobs"
+  project = local.project
+  tags    = local.tags
 
   # Setup access to both the AB2D and common moderate bucket
-  buckets         = [
-    {bucket = module.bucket.arn, cmk = module.bucket.bucket_cmk_arn},
-    {bucket = data.aws_s3_bucket.moderate_bucket.arn, cmk = data.aws_kms_alias.moderate_cmk.arn }
+  buckets = [
+    { bucket = module.bucket.arn, cmk = module.bucket.bucket_cmk_arn },
+    { bucket = data.aws_s3_bucket.moderate_bucket.arn, cmk = data.aws_kms_alias.moderate_cmk.arn }
   ]
 }
 
-module "get_num_jobs_opensbx" {
-  source          = "../../modules/table"
-  database        = module.database.name          # adds a dependency
-  table           = "opensbx_get_num_jobs" # "${environment}_${name of job}"
-  description     = "gets number of data requests (jobs)"
-  bucket          = module.bucket.id
-  bucket_cmk      = module.bucket.bucket_cmk
-  tags            = local.tags
-  partitions      = local.partitions
+module "insights_data_table_opensbx" {
+  source      = "../../modules/table"
+  database    = module.database.name
+  table       = "opensbx_insights"
+  description = "opensbx insights data"
+  bucket      = module.bucket.id
+  bucket_cmk  = module.bucket.bucket_cmk
+  tags        = local.tags
+  partitions  = local.partitions
   columns = [
-    {name="name", type="string", comment=""},
-    {name="timestamp", type="bigint", comment=""},
-    {name="data", type="array<struct<count:string>>", comment=""},
+    { name = "name", type = "string", comment = "" },
+    { name = "timestamp", type = "bigint", comment = "" },
+    { name = "json_result", type = "string", comment = "" },
   ]
 }
 
-module "get_num_queued_tasks_opensbx" {
-  source          = "../../modules/table"
-  database        = module.database.name          # adds a dependency
-  table           = "opensbx_get_num_queued_tasks" # "${environment}_${name of job}"
-  description     = "gets number of queued job tasks"
-  bucket          = module.bucket.id
-  bucket_cmk      = module.bucket.bucket_cmk
-  tags            = local.tags
-  partitions      = local.partitions
+module "insights_data_table_prod" {
+  source      = "../../modules/table"
+  database    = module.database.name
+  table       = "prod_insights"
+  description = "prod insights data"
+  bucket      = module.bucket.id
+  bucket_cmk  = module.bucket.bucket_cmk
+  tags        = local.tags
+  partitions  = local.partitions
   columns = [
-    {name="name", type="string", comment=""},
-    {name="timestamp", type="bigint", comment=""},
-    {name="data", type="array<struct<count:string>>", comment=""},
+    { name = "name", type = "string", comment = "" },
+    { name = "timestamp", type = "bigint", comment = "" },
+    { name = "json_result", type = "string", comment = "" },
   ]
 }

--- a/insights/terraform/projects/bcda/main.tf
+++ b/insights/terraform/projects/bcda/main.tf
@@ -28,10 +28,68 @@ data "aws_kms_alias" "moderate_cmk" {
   name = "alias/bfd-insights-moderate-cmk"
 }
 
+## Athena workgroup
+
 module "workgroup" {
   source          = "../../modules/workgroup"
   bucket          = module.bucket.id
   bucket_cmk      = module.bucket.bucket_cmk
   name            = local.database
   tags            = local.tags
+}
+
+## Database for the project
+
+module "database" {
+  source          = "../../modules/database"
+  database        = local.database
+  bucket          = module.bucket.id
+  bucket_cmk      = module.bucket.bucket_cmk
+  tags            = local.tags
+}
+
+## Glue setup
+
+module "glue_jobs" {
+  source          = "../../modules/jobs"
+  project         = local.project
+  tags            = local.tags
+
+  # Setup access to both the AB2D and common moderate bucket
+  buckets         = [
+    {bucket = module.bucket.arn, cmk = module.bucket.bucket_cmk_arn},
+    {bucket = data.aws_s3_bucket.moderate_bucket.arn, cmk = data.aws_kms_alias.moderate_cmk.arn }
+  ]
+}
+
+module "get_num_jobs_opensbx" {
+  source          = "../../modules/table"
+  database        = module.database.name          # adds a dependency
+  table           = "opensbx_get_num_jobs" # "${environment}_${name of job}"
+  description     = "gets number of data requests (jobs)"
+  bucket          = module.bucket.id
+  bucket_cmk      = module.bucket.bucket_cmk
+  tags            = local.tags
+  partitions      = local.partitions
+  columns = [
+    {name="name", type="string", comment=""},
+    {name="timestamp", type="bigint", comment=""},
+    {name="data", type="array<struct<count:string>>", comment=""},
+  ]
+}
+
+module "get_num_queued_tasks_opensbx" {
+  source          = "../../modules/table"
+  database        = module.database.name          # adds a dependency
+  table           = "opensbx_get_num_queued_tasks" # "${environment}_${name of job}"
+  description     = "gets number of queued job tasks"
+  bucket          = module.bucket.id
+  bucket_cmk      = module.bucket.bucket_cmk
+  tags            = local.tags
+  partitions      = local.partitions
+  columns = [
+    {name="name", type="string", comment=""},
+    {name="timestamp", type="bigint", comment=""},
+    {name="data", type="array<struct<count:string>>", comment=""},
+  ]
 }

--- a/insights/terraform/projects/bcda/main.tf
+++ b/insights/terraform/projects/bcda/main.tf
@@ -55,7 +55,7 @@ module "glue_jobs" {
   project = local.project
   tags    = local.tags
 
-  # Setup access to both the AB2D and common moderate bucket
+  # Setup access to both the BCDA and common moderate bucket
   buckets = [
     { bucket = module.bucket.arn, cmk = module.bucket.bucket_cmk_arn },
     { bucket = data.aws_s3_bucket.moderate_bucket.arn, cmk = data.aws_kms_alias.moderate_cmk.arn }


### PR DESCRIPTION
### Change Details

This branch adds glue catalog tables per environment for the postgres queries that we are currently making in BCDA using the insights data samplers.

These tables allow us to query any information that is being pushed through our firehoses.

#### Total number of data requests:
![image](https://user-images.githubusercontent.com/5049068/104035129-c44d9200-519f-11eb-8fa9-caea5744455a.png)

#### Current number of jobs in the queue:
![image](https://user-images.githubusercontent.com/5049068/104035187-d62f3500-519f-11eb-9e24-006593986712.png)

Additionally, this fixes version of terraform to `0.13.4`.

### Acceptance Validation

- [x] We are able to analyze data from BCDA in AWS Athena.

### Feedback Requested

All feedback is welcome.

### External References

<!-- For example: replace xxx with the JIRA ticket number: -->

- [BCDA-3815](https://jira.cms.gov/browse/BCDA-3815)
- [BCDA-3873](https://jira.cms.gov/browse/BCDA-3873)

### Security Implications

- [ ] new software dependencies

- [ ] altered security controls

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

All feedback is welcome.
