### PR TITLE
BFD Insights: Adding codeowners for BCDA project

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,3 +9,5 @@
 /ops @jzulim @keithdadkins
 
 /apps @karlmdavis @cbrunefearless @dshekhar18 @jzulim
+
+/insights/terraform/projects/bcda @msnook @orenfromberg


### PR DESCRIPTION
### Change Details

This branch adds BCDA/DPC SRE team as codeowners for the BFD Insights BCDA project directory. Currently this is limited to @msnook and myself (@orenfromberg) according to the principle of least privilege. If the repository is configured properly, this will allow us the ability to merge PRs relevant to this project.

### Acceptance Validation

* BCDA devs can merge branches to master that have changes relevant to the Insights BCDA project

### Feedback Requested

All feedback is welcome, especially if merges to master should be remain at the discretion of the top level codeowners.

### External References

- [BCDA-3815](https://jira.cms.gov/browse/BCDA-3815)

### Security Implications

- [ ] new software dependencies

- [ ] altered security controls

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications
