### PR TITLE
Aide fixup

### DIFF
--- a/ops/ansible/playbooks-ccs/build_bfd-platinum.yml
+++ b/ops/ansible/playbooks-ccs/build_bfd-platinum.yml
@@ -22,3 +22,5 @@
         name: install_java
     - import_role: 
         name: ops_tools
+    - import_role:
+        name: platinum_post

--- a/ops/ansible/playbooks-ccs/roles/platinum_post/tasks/main.yml
+++ b/ops/ansible/playbooks-ccs/roles/platinum_post/tasks/main.yml
@@ -11,4 +11,4 @@
 # update the aide database
 - name: Update aide database
   become: true
-  ansible.builtin.shell: /sbin/aide --update
+  shell: /sbin/aide --update

--- a/ops/ansible/playbooks-ccs/roles/platinum_post/tasks/main.yml
+++ b/ops/ansible/playbooks-ccs/roles/platinum_post/tasks/main.yml
@@ -1,0 +1,14 @@
+## Final tasks to be run when building the platinum image.
+
+## AIDE fixup
+# remove the failing aide cron job
+- name: 'Ensure failing aide cron job is removed.'
+  become: true
+  ansible.builtin.cron:
+    name: "run AIDE check"
+    state: absent
+
+# update the aide database
+- name: Update aide database
+  become: true
+  ansible.builtin.shell: /sbin/aide --update

--- a/ops/ansible/playbooks-ccs/roles/platinum_post/tasks/main.yml
+++ b/ops/ansible/playbooks-ccs/roles/platinum_post/tasks/main.yml
@@ -4,7 +4,7 @@
 # remove the failing aide cron job
 - name: 'Ensure failing aide cron job is removed.'
   become: true
-  ansible.builtin.cron:
+  cron:
     name: "run AIDE check"
     state: absent
 


### PR DESCRIPTION
There is a cron entry baked into the gold image that runs `aide` and attempts to send the results over email. This is problematic because:
1. Email is not a secure method of sending sensitive data.
2. The results of the aide check is too large so the email fails.
3. The aide database needs to be updated after installing/updating packages.

This patch removes the failing cron job and updates the aide database so our ops can run it on live instances as needed.

For more information on `aide` see:
- https://aide.github.io
- https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/sec-using-aide

<!--

--- PR Hygiene Checklist ---

1. Make sure the changeset can be reviewed, keep it's scope and size succinct 
2. Make sure your branch is from your fork and has a meaningful name
3. Update the PR title: `BFD-99999: Add Awesomeness`
4. Edit the text below - do not leave placeholders in the text.
4.1. Remove sections that you don't feel apply
5. Add any other details that will be helpful for the reviewers: details description, screenshots, etc
6. Request a review from someone/multiple someones
7. <optional> Review your changes yourself and write up any comments / concerns as if you were reviewing someone else's code.
-->

### Change Details

<!-- Add detailed discussion of changes here: -->
<!-- This is likely a summary, or the complete contents, of your commit messages -->

### Acceptance Validation
- Removes the cron job in root's crontab.
- Runs `aide --update` after all other platinum roles have run.

### External References
- [BFD-602](https://jira.cms.gov/browse/BFD-602)

