### PR TITLE
[FIX] Notify that a build was started.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -147,6 +147,9 @@ try {
 
 			// Get the remote repo url. This assumes we are using git+https not git+ssh.
 			gitRepoUrl = sh(returnStdout: true, script: 'git config --get remote.origin.url').trim().replaceAll(/\.git$/,"")
+
+			// Send notifications that the build has started
+			sendNotifications('STARTED', currentStage, gitCommitId, gitRepoUrl)
 		}
 	}
 


### PR DESCRIPTION
Fix to send Slack notifications when builds are started (doh).

Somehow this was missing from my previous [Jenkins/Slack PR](https://github.com/CMSgov/beneficiary-fhir-data/pull/447)

### Change Details
- Sends slack notifications during the 'Prepare' stage. 

### Acceptance Validation
Nothin obvious stands out.


