### PR TITLE
[BFD-665] Dynamically select node identifier name to help resolve tf state

### DIFF
--- a/ops/terraform/modules/resources/aurora/main.tf
+++ b/ops/terraform/modules/resources/aurora/main.tf
@@ -1,5 +1,7 @@
 locals {
   is_prod = substr(var.env_config.env, 0, 4) == "prod"
+
+  # see https://jira.cms.gov/browse/BFD-665 for reference
   node_identifier = {
     "prod" = "bfd-prod-aurora-cluster",
     "prod-sbx" = "bfd-prod-sbx-aurora",

--- a/ops/terraform/modules/resources/aurora/main.tf
+++ b/ops/terraform/modules/resources/aurora/main.tf
@@ -1,5 +1,10 @@
 locals {
   is_prod = substr(var.env_config.env, 0, 4) == "prod"
+  node_identifier = {
+    "prod" = "bfd-prod-aurora-cluster",
+    "prod-sbx" = "bfd-prod-sbx-aurora",
+    "test" = "bfd-test-aurora"
+  }
 }
 
 data "aws_iam_role" "rds_monitoring" {
@@ -91,7 +96,7 @@ resource "aws_rds_cluster_instance" "aurora_nodes" {
   count          = var.aurora_config.cluster_nodes
   instance_class = var.aurora_config.instance_class
 
-  identifier         = "bfd-${var.env_config.env}-aurora-node-${count.index}"
+  identifier         = "${lookup(local.node_identifier, var.env_config.env)}-node-${count.index}"
   cluster_identifier = aws_rds_cluster.aurora_cluster.id
 
   availability_zone       = var.stateful_config.azs[count.index]

--- a/ops/terraform/modules/resources/aurora/main.tf
+++ b/ops/terraform/modules/resources/aurora/main.tf
@@ -1,7 +1,7 @@
 locals {
   is_prod = substr(var.env_config.env, 0, 4) == "prod"
 
-  # see https://jira.cms.gov/browse/BFD-665 for reference
+  # see https://github.com/CMSgov/beneficiary-fhir-data/pull/476 for reference
   node_identifier = {
     "prod" = "bfd-prod-aurora-cluster",
     "prod-sbx" = "bfd-prod-sbx-aurora",


### PR DESCRIPTION
<!--

--- PR Hygiene Checklist ---

1. Make sure the changeset can be reviewed, keep it's scope and size succinct 
2. Make sure your branch is from your fork and has a meaningful name
3. Update the PR title: `BFD-99999: Add Awesomeness`
4. Edit the text below - do not leave placeholders in the text.
4.1. Remove sections that you don't feel apply
5. Add any other details that will be helpful for the reviewers: details description, screenshots, etc
6. Request a review from someone/multiple someones
7. <optional> Review your changes yourself and write up any comments / concerns as if you were reviewing someone else's code.
-->

### Change Details
Background:

Recently, in order to backfill many millions of MBI hashes, we cloned our production database cluster, did the work, and then switched over our production environment to use this clone. As a result, our terraform state is now out of sync because of this out-of-band work.

Unfortunately, during this cloning process, the cloned (and now live) cluster db instance identifiers were named slightly different than before. For example, we went from `bfd-prod-aurora-node-0` to `bfd-prod-aurorar-cluster-node-0`. This naming difference only occurs in prod, not prod-sbx or test and the same issue occurs for nodes 1 and 2.

Now terraform does not know about these "new" nodes and wants to create them. Normally, a simple `terraform import` would fix this issue, but because of the naming issues, these appear to be new resources.

This PR avoids the risk of renaming/modifying our live production databases and simply selects the appropriate identifier depending on env (prod, prod-sbx, test).

Once this PR is approved and merged, we can then run the appropriate `terraform import` commands to reconcile our tf state.

Notes:
1. I was not able to use the `local.is_prod` because it also matches `prod-sbx`.
2. I tested this locally in all environments (including `terraform import`'ing the nodes), which resulted in a plan to update the cluster nodes in place (no creating/recreating/deleting). The updates are due to the following (large parts of the `plan` are omitted for brevity) with similar results for nodes 1 and 2:

```
# module.stateful.module.aurora.aws_rds_cluster_instance.aurora_nodes[0] will be updated in-place
...
  cluster_identifier              = "bfd-prod-aurora-cluster"
~ copy_tags_to_snapshot           = false -> true
  db_parameter_group_name         = "bfd-prod-aurora-node"
...
  storage_encrypted               = true
~ tags                            = {
    + "Environment" = "prod"
    + "Layer"       = "data"
    + "application" = "bfd"
    + "business"    = "oeda"
    + "stack"       = "prod"
  }
...
```
<!-- Add detailed discussion of changes here: -->
<!-- This is likely a summary, or the complete contents, of your commit messages -->

### Acceptance Validation
No glaring issues.
<!-- What should reviewers look for to determine completeness -->

<!-- Insert screenshots if applicable (drag images here) -->

### Feedback Requested

<!-- What type of feedback you want from your reviewers? -->

### External References

<!-- For example: replace xxx with the JIRA ticket number: -->

- [BFD-655](https://jira.cms.gov/browse/BFD-665)

### Security Implications
None.

