### PR TITLE
[BFD-679] Install AWS EFS Utils on ETL/Pipeline

### DIFF
--- a/ops/ansible/roles/bfd-pipeline/tasks/main.yml
+++ b/ops/ansible/roles/bfd-pipeline/tasks/main.yml
@@ -7,6 +7,9 @@
   with_items:
     # Needed to run the ETL service.
     - java-1.8.0-openjdk
+    # Needed for working with AWS EFS file systems (when using IAM roles/policies, KMS for crypto, etc)
+    # See https://docs.aws.amazon.com/efs/latest/ug/using-amazon-efs-utils.html
+    - amazon-efs-utils
   become: true
   tags: 
     - pre-ami


### PR DESCRIPTION
<!--

--- PR Hygiene Checklist ---

1. Make sure the changeset can be reviewed, keep it's scope and size succinct 
2. Make sure your branch is from your fork and has a meaningful name
3. Update the PR title: `BFD-99999: Add Awesomeness`
4. Edit the text below - do not leave placeholders in the text.
4.1. Remove sections that you don't feel apply
5. Add any other details that will be helpful for the reviewers: details description, screenshots, etc
6. Request a review from someone/multiple someones
7. <optional> Review your changes yourself and write up any comments / concerns as if you were reviewing someone else's code.
-->

### Change Details
Amazon's EFS Utils package allows us to mount EFS file systems using IAM
permissions and is generally recommended over the standard NFS utils
when working with EFS shares.

This is required for the EFT<>BFD<>EFS<>BCDA work.
<!-- Add detailed discussion of changes here: -->
<!-- This is likely a summary, or the complete contents, of your commit messages -->

### Acceptance Validation
- Deployed to test and verified no impact to ETL pipeline

<!-- What should reviewers look for to determine completeness -->

<!-- Insert screenshots if applicable (drag images here) -->

### Feedback Requested

<!-- What type of feedback you want from your reviewers? -->

### External References

<!-- For example: replace xxx with the JIRA ticket number: -->

- [BFD-679](https://jira.cms.gov/browse/BFD-679)
- [BFD-615](https://jira.cms.gov/browse/BFD-615)
- https://docs.aws.amazon.com/efs/latest/ug/using-amazon-efs-utils.html


### Security Implications
None. This package is available in our standard yum repos.