### PR TITLE
[BFD-692] Install and configure amazon-efs-utils on ETL

### DIFF
--- a/ops/ansible/playbooks-ccs/build_bfd-pipeline.yml
+++ b/ops/ansible/playbooks-ccs/build_bfd-pipeline.yml
@@ -6,7 +6,7 @@
   hosts: all
   become: true
   remote_user: ec2-user
-  gather_facts: yes
+  gather_facts: no
   vars:
     ansible_ssh_pipelining: no
     env: "test"

--- a/ops/ansible/playbooks-ccs/build_bfd-pipeline.yml
+++ b/ops/ansible/playbooks-ccs/build_bfd-pipeline.yml
@@ -6,10 +6,15 @@
   hosts: all
   become: true
   remote_user: ec2-user
-  gather_facts: no
+  gather_facts: yes
   vars:
     ansible_ssh_pipelining: no
     env: "test"
+  
+  # only gather os family facts
+  pre_tasks:
+   - setup:
+       filter: ansible_os_family
 
   tasks:
     - name: Include global variables

--- a/ops/ansible/playbooks-ccs/build_bfd-pipeline.yml
+++ b/ops/ansible/playbooks-ccs/build_bfd-pipeline.yml
@@ -6,15 +6,10 @@
   hosts: all
   become: true
   remote_user: ec2-user
-  gather_facts: no
+  gather_facts: yes
   vars:
     ansible_ssh_pipelining: no
     env: "test"
-  
-  # only gather os family facts
-  pre_tasks:
-   - setup:
-       filter: ansible_os_family
 
   tasks:
     - name: Include global variables

--- a/ops/ansible/playbooks-ccs/roles/amazon-efs-utils/defaults/main.yml
+++ b/ops/ansible/playbooks-ccs/roles/amazon-efs-utils/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+stunnel_version: '5.58'

--- a/ops/ansible/playbooks-ccs/roles/amazon-efs-utils/tasks/main.yml
+++ b/ops/ansible/playbooks-ccs/roles/amazon-efs-utils/tasks/main.yml
@@ -52,7 +52,7 @@
   become: yes
   shell: |
     mkdir stunnel && cd stunnel
-    wget https://www.stunnel.org/downloads/stunnel-5.58.tar.gz
+    wget https://www.stunnel.org/downloads/stunnel-{{ stunnel_version }}.tar.gz
     tar -xvzf stunnel-{{ stunnel_version }}.tar.gz
     cd stunnel-{{ stunnel_version }}/
     # remove previous stunnel bin if it's still there

--- a/ops/ansible/playbooks-ccs/roles/amazon-efs-utils/tasks/main.yml
+++ b/ops/ansible/playbooks-ccs/roles/amazon-efs-utils/tasks/main.yml
@@ -12,7 +12,7 @@
   yum:
     name:
       - amazon-efs-utils
-  state: absent
+    state: absent
 
 # TODO: determine if rpm-build is compatible with amazon linux
 - name: Install EFS util requirements

--- a/ops/ansible/playbooks-ccs/roles/amazon-efs-utils/tasks/main.yml
+++ b/ops/ansible/playbooks-ccs/roles/amazon-efs-utils/tasks/main.yml
@@ -5,19 +5,13 @@
 
 
 # remove if installed so we can configure a fips compatible version
+# note: no need to remove old stunnel as installing amazon-efs-utils will
+# simply reinstall it :/
 - name: Remove default amazon-efs-utils
   become: yes
   yum:
     - amazon-efs-utils
   state: absent
-
-# rhel has an old stunnel that is not compatible with efs
-- name: Remove outdated stunnel
-  become: yes
-  yum:
-    - stunnel
-  state: absent
-  when: ansible_os_family == "RedHat"
 
 # TODO: determine if rpm-build is compatible with amazon linux
 - name: Install EFS util requirements
@@ -39,9 +33,25 @@
     lock_timeout: 180
   when: ansible_os_family == "RedHat"
 
+- name: Ensure amazon-efs-utils is FIPS-compliant
+  become: yes
+  shell: |
+    git clone https://github.com/aws/efs-utils
+    cd efs-utils
+    sed -i -E "s/'fips': 'no'/'fips': 'yes'/" ./src/mount_efs/__init__.py
+    make rpm
+    yum -y install --nogpgcheck build/amazon-efs-utils*rpm
+    cd /tmp
+    rm -rf /tmp/efs-utils
+  args:
+    chdir: /tmp
+    warn: false
+
+# replace old stunnel with a recent version
 - name: Build fips enabled stunnel
   become: yes
   shell: |
+    mkdir stunnel && cd stunnel
     wget https://www.stunnel.org/downloads/stunnel-5.58.tar.gz
     tar -xvzf stunnel-{{ stunnel_version }}.tar.gz
     cd stunnel-{{ stunnel_version }}/
@@ -65,18 +75,8 @@
     ln -sf /usr/local/etc/stunnel/stunnel.conf /etc/stunnel/stunnel.conf
     # make sure stunnel is in fips mode
     sed -i '/^;fips.*/s/^;//' /usr/local/etc/stunnel/stunnel.conf
+    cd /tmp
+    rm -rf /tmp/stunnel
   args:
     chdir: /tmp
   when: ansible_os_family == "RedHat"
-
-- name: Ensure amazon-efs-utils is FIPS-compliant
-  become: yes
-  shell: |
-    git clone https://github.com/aws/efs-utils
-    cd efs-utils
-    sed -i -E "s/'fips': 'no'/'fips': 'yes'/" ./src/mount_efs/__init__.py
-    make rpm
-    yum -y install --nogpgcheck build/amazon-efs-utils*rpm
-  args:
-    chdir: /tmp
-    warn: false

--- a/ops/ansible/playbooks-ccs/roles/amazon-efs-utils/tasks/main.yml
+++ b/ops/ansible/playbooks-ccs/roles/amazon-efs-utils/tasks/main.yml
@@ -10,7 +10,8 @@
 - name: Remove default amazon-efs-utils
   become: yes
   yum:
-    - amazon-efs-utils
+    name:
+      - amazon-efs-utils
   state: absent
 
 # TODO: determine if rpm-build is compatible with amazon linux

--- a/ops/ansible/playbooks-ccs/roles/amazon-efs-utils/tasks/main.yml
+++ b/ops/ansible/playbooks-ccs/roles/amazon-efs-utils/tasks/main.yml
@@ -1,0 +1,82 @@
+---
+# This role will install and configure fips compatible amazon-efs-utils
+# on rhel compatible distributions.
+# TODO: determine ansible_os_family for amazon linux if/when we migrate
+
+
+# remove if installed so we can configure a fips compatible version
+- name: Remove default amazon-efs-utils
+  become: yes
+  yum:
+    - amazon-efs-utils
+  state: absent
+
+# rhel has an old stunnel that is not compatible with efs
+- name: Remove outdated stunnel
+  become: yes
+  yum:
+    - stunnel
+  state: absent
+  when: ansible_os_family == "RedHat"
+
+# TODO: determine if rpm-build is compatible with amazon linux
+- name: Install EFS util requirements
+  become: yes
+  yum:
+    name:
+      - git
+      - rpm-build
+
+- name: Install stunnel requirements
+  become: yes
+  yum:
+    name:
+      - wget
+      - gcc
+      - openssl-devel
+      - tcp_wrappers-devel
+    state: present
+    lock_timeout: 180
+  when: ansible_os_family == "RedHat"
+
+- name: Build fips enabled stunnel
+  become: yes
+  shell: |
+    wget https://www.stunnel.org/downloads/stunnel-5.58.tar.gz
+    tar -xvzf stunnel-{{ stunnel_version }}.tar.gz
+    cd stunnel-{{ stunnel_version }}/
+    # remove previous stunnel bin if it's still there
+    if [[ -f /bin/stunnel ]]; then
+        sudo mv /bin/stunnel /bin/stunnel.bak
+    fi
+    # remove previous stunnel config if it's still there
+    if [[ -f /etc/stunnel/stunnel.conf ]]; then
+        sudo mv /etc/stunnel/stunnel.conf //etc/stunnel/stunnel.conf.bak
+    fi
+    # build and install stunnel 5 with fips (installs to /usr/local/* by default)
+    ./configure --enable-fips
+    make
+    make install
+    # link to /bin in case /usr/local/bin is not in the path
+    ln -sf /usr/local/bin/stunnel /bin/stunnel
+    # copy our configs
+    mkdir -p /etc/stunnel
+    cp /usr/local/etc/stunnel/stunnel.conf-sample /usr/local/etc/stunnel/stunnel.conf
+    ln -sf /usr/local/etc/stunnel/stunnel.conf /etc/stunnel/stunnel.conf
+    # make sure stunnel is in fips mode
+    sed -i '/^;fips.*/s/^;//' /usr/local/etc/stunnel/stunnel.conf
+  args:
+    chdir: /tmp
+  when: ansible_os_family == "RedHat"
+
+- name: Ensure amazon-efs-utils is FIPS-compliant
+  become: yes
+  shell: |
+    git clone https://github.com/aws/efs-utils
+    cd efs-utils
+    sed -i -E "s/'fips': 'no'/'fips': 'yes'/" ./src/mount_efs/__init__.py
+    make rpm
+    yum -y install --nogpgcheck build/amazon-efs-utils*rpm
+  args:
+    chdir: /tmp
+    warn: false

--- a/ops/ansible/roles/bfd-pipeline/tasks/main.yml
+++ b/ops/ansible/roles/bfd-pipeline/tasks/main.yml
@@ -1,5 +1,11 @@
 ---
 
+- name: Configure AWS EFS Utils
+  import_role:
+    name: ../../../playbooks-ccs/roles/amazon-efs-utils
+  tags:
+    - pre-ami
+
 - name: Install Pre-requisites
   yum:
     name: "{{ item }}"
@@ -7,9 +13,6 @@
   with_items:
     # Needed to run the ETL service.
     - java-1.8.0-openjdk
-    # Needed for working with AWS EFS file systems (when using IAM roles/policies, KMS for crypto, etc)
-    # See https://docs.aws.amazon.com/efs/latest/ug/using-amazon-efs-utils.html
-    - amazon-efs-utils
   become: true
   tags: 
     - pre-ami

--- a/ops/ansible/roles/bfd-pipeline/tasks/main.yml
+++ b/ops/ansible/roles/bfd-pipeline/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Configure AWS EFS Utils
   import_role:
-    name: ../../../playbooks-ccs/roles/amazon-efs-utils
+    name: ../../playbooks-ccs/roles/amazon-efs-utils
   tags:
     - pre-ami
 


### PR DESCRIPTION
### Change Details
The default amazon-efs-utils on rhel 7 is not capable of creating secure tunnels to amazon's efs service for several reasons:
1. The version of stunnel in rhel 7 (version 4 something) is wildly  outdated
2. The default amazon-efs-utils is not running in fips mode
3. The default stunnel is not configured for fips mode

This commit adds an ansible role that replaces the outdated stunnel with a manually compiled (with fips) version, installs a fips compatible version of amazon-efs-utils, and configures the server accordingly.

This role is imported into our ETL pipeline build so that our ETL instances can securely mount EFS file systems using IAM.

### Acceptance Validation
- No glaring issues
- A successful deployment to test has been performed and efs mount verified

<!-- What should reviewers look for to determine completeness -->

<!-- Insert screenshots if applicable (drag images here) -->

### Feedback Requested

<!-- What type of feedback you want from your reviewers? -->

### External References

<!-- For example: replace xxx with the JIRA ticket number: -->

- [BFD-692](https://jira.cms.gov/browse/BFD-692)
- [BFD-477](https://jira.cms.gov/browse/BFD-477)

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] altered security controls

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications
<!-- Use this to indicate you're unsure how this change may impact system security and would like to solicit the team's feedback. Optionally, provide background information regarding your questions and concerns. -->

