### PR TITLE
BFD-702: Add native development environment setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ A: Anyone can coordinate with you and the core team to take over the work.
 
 Going to work on this project? Great! There are currently two documented methods for getting a local environment up and running to get you setup for development. 
 
-[Getting started on BFD via Docker](README.md) 
+[Getting started on BFD](README.md) 
 
 #### Opening A PR
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,54 @@ mkdir -p ~/workspaces/bfd/
 git clone git@github.com:CMSgov/beneficiary-fhir-data.git ~/workspaces/bfd/beneficiary-fhir-data.git
 ```
 
-### Setting up the FHIR server and DB with Docker
+### Native Setup
+1. Install JDK 8. You'll need Java 8 to run BFD. You can install OpenJDK 8 however you prefer. Problems currently arise after the 8.0.252 release. 
+2. Install Maven 3. Project tasks are handled by Apache Maven. Install it however you prefer.
+3. Configure your toolchain. You'll want to configure your `~/.m2/toolchains.xml` file to look like the following:
+```xml
+<?xml version="1.0" encoding="UTF8"?>
+<toolchains>
+  <!-- JDK toolchains -->
+  <toolchain>
+    <type>jdk</type>
+    <provides>
+      <version>1.8</version>
+      <vendor>sun</vendor>
+    </provides>
+    <configuration>
+      <jdkHome>/path/to/your/jdk</jdkHome>
+    </configuration>
+  </toolchain>
+</toolchains>
+```
+4. Change to the `apps/` directory and `mvn clean install -DskipITs`. The flag to skip the integration tests is important here. You will need to have AWS access for the integration tests to work correctly.
+5. Set up a Postgres 9 database. The major version matters here—some newer versions will not work. The easiest way to set up a local database is with the following command. Data will be persisted between starts and stops in the `pgdata` volume.
+```sh
+docker run \
+  -d \
+  --name 'bfd-db' \
+  -e 'POSTGRES_USER=bfd' \
+  -e 'POSTGRES_PASSWORD=InsecureLocalDev' \
+  -p '5432:5432' \
+  -v 'pgdata:/var/lib/postgresql/data' \
+  postgres:9.6
+```
+6. To load one test beneficiary, with your database running, change directories into `apps/bfd-pipeline/bfd-pipeline-ccw-rif` and run `mvn -Dits.db.url="jdbc:postgresql://localhost:5432/bfd" -Dits.db.username=bfd -Dits.db.password=InsecureLocalDev -Dit.test=RifLoaderIT#loadSampleA clean verify`. This will kick off the integration test `loadSampleA`. After the job completes, you can verify that it ran properly with `docker exec bfd-db psql 'postgresql://bfd:InsecureLocalDev@localhost:5432/bfd' -c 'SELECT "beneficiaryId" FROM "Beneficiaries" LIMIT 1;'`
+7. Run `export BFD_PORT=6500` and add it to your profile, too. The actual port is not important, but without it the `start-server` script will pick a different one each time, which gets annoying later.
+8. Now it's time to start the server up. Change to `apps/bfd-server` and run `mvn -X -Dits.db.url="jdbc:postgresql://localhost:5432/bfd?user=bfd&password=InsecureLocalDev" --projects bfd-server-war package dependency:copy antrun:run org.codehaus.mojo:exec-maven-plugin:exec@server-start`. After it starts up, you can tail the logs with `tail -f bfd-server-war/target/server-work/server-console.log`.
+9. We're finally going to make a request. BFD requires that clients authenticate themselves with a certificate. Those certs live in the `apps/bfd-server/dev/ssl-stores` directory. We can curl the server using a cert with this command `curl --cert $BFD_PATH/apps/bfd-server/dev/ssl-stores/client-unsecured.pem -s https://localhost:$BFD_PORT/v2/fhir/ExplanationOfBenefit/?patient=-20140000001827&_format=json`, where `$BFD_PATH` is that path to the `beneficiary-fhir-data` repo on your system. It may be helpful to have that set in your profile, too. To configure Postman, go to `Settings -> Certificates -> Add certificate` and load in `apps/bfd-server/dev/ssl-stores/client-trusted-keystore.pfx` under the PFX File option. The passphrase is `changeit`. Under `Settings -> General` you'll also want to turn off "SSL Certificate Verification."
+10. Total success (probably)!. You have a working call. But you'll probably want more data. Move on to the next section to see how to load 30,000 synthetic beneficiaries. 
+
+### Load Full Synthetic Dataset
+1. Change to the top-level `contributing` directory and run `make synthetic-data/*.rif`. This will fetch RIF files (the raw incoming data) from a public S3 bucket.
+2. Run `export LOCAL_SYNTHETIC_DATA=$BFD_PATH/contributing/synthetic-data`. You may want this one in your profile, too.
+3. Apply the patched files with `git apply contributing/patches/load_local_synthetic_data.patch` from the root of the project. This will change three files: `StaticRifResource.java`, `StaticRifResourceGroup.java` and `RifLoaderIT.java`. The changes effectively create an integration test that point to the local RIF files that you just pulled down.
+4. Change to the `apps` directory and run `mvn clean install -DskipITs` again to recompile with the newly changed files.
+5. Make sure you have an active MFA session with AWS. The integration tests will need to be allowed to create an S3 bucket.
+6. Change to `apps/bfd-pipeline/bfd-pipeline-ccw-rif` and run `mvn -Dits.db.url="jdbc:postgresql://localhost:5432/bfd" -Dits.db.username=bfd -Dits.db.password=InsecureLocalDev -Dit.test=RifLoaderIT#loadLocalSyntheticData clean verify`. This could take around an hour to complete.
+7. Verify everything loaded with `docker exec bfd-db psql 'postgresql://bfd:InsecureLocalDev@localhost:5432/bfd' -c 'SELECT COUNT("beneficiaryId") FROM "Beneficiaries";'`. You should see a count of 30,000.
+
+### Docker Setup
 
 Requirements: Docker
 

--- a/contributing/patches/load_local_synthetic_data.patch
+++ b/contributing/patches/load_local_synthetic_data.patch
@@ -1,19 +1,19 @@
-From 58e3f4eaa6f9f9290720a9fbaaaa5969cddc9a8a Mon Sep 17 00:00:00 2001
-From: jzulim <john.zulim@adhocteam.us>
-Date: Thu, 7 May 2020 10:47:42 -0700
-Subject: [PATCH] load local synthetic
+From 30a4253cbf60a7800613ef5c782b7eb113a98762 Mon Sep 17 00:00:00 2001
+From: Ryan Travitz <rtravitz@gmail.com>
+Date: Mon, 22 Mar 2021 14:44:37 -0700
+Subject: [PATCH] Update files that load local synthetic data to new directory
 
 ---
  .../model/rif/samples/StaticRifResource.java  | 180 ++++++++++++++++++
  .../rif/samples/StaticRifResourceGroup.java   |  33 ++++
- .../bfd/pipeline/rif/load/RifLoaderIT.java    |  15 ++
- 3 files changed, 228 insertions(+)
+ .../pipeline/ccw/rif/load/RifLoaderIT.java    |  11 ++
+ 3 files changed, 224 insertions(+)
 
 diff --git a/apps/bfd-model/bfd-model-rif-samples/src/main/java/gov/cms/bfd/model/rif/samples/StaticRifResource.java b/apps/bfd-model/bfd-model-rif-samples/src/main/java/gov/cms/bfd/model/rif/samples/StaticRifResource.java
-index 59c78855..8a097b96 100644
+index 9c0f140a..d45acb36 100644
 --- a/apps/bfd-model/bfd-model-rif-samples/src/main/java/gov/cms/bfd/model/rif/samples/StaticRifResource.java
 +++ b/apps/bfd-model/bfd-model-rif-samples/src/main/java/gov/cms/bfd/model/rif/samples/StaticRifResource.java
-@@ -302,6 +302,161 @@ public enum StaticRifResource {
+@@ -323,6 +323,161 @@ public enum StaticRifResource {
        RifFileType.OUTPATIENT,
        27955),
  
@@ -175,7 +175,7 @@ index 59c78855..8a097b96 100644
    SAMPLE_MCT_BENES(
        resourceUrl("rif-static-samples/sample-mct-beneficiaries.txt"), RifFileType.BENEFICIARY, 8),
  
-@@ -390,6 +545,31 @@ public enum StaticRifResource {
+@@ -411,6 +566,31 @@ public enum StaticRifResource {
      };
    }
  
@@ -208,12 +208,12 @@ index 59c78855..8a097b96 100644
     * @param dataSetLocation the {@link TestDataSetLocation} of the file to get a local copy of
     * @param fileName the name of the specific file in the specified {@link TestDataSetLocation} to
 diff --git a/apps/bfd-model/bfd-model-rif-samples/src/main/java/gov/cms/bfd/model/rif/samples/StaticRifResourceGroup.java b/apps/bfd-model/bfd-model-rif-samples/src/main/java/gov/cms/bfd/model/rif/samples/StaticRifResourceGroup.java
-index a1401b55..a44fca81 100644
+index fbc6727a..40f50380 100644
 --- a/apps/bfd-model/bfd-model-rif-samples/src/main/java/gov/cms/bfd/model/rif/samples/StaticRifResourceGroup.java
 +++ b/apps/bfd-model/bfd-model-rif-samples/src/main/java/gov/cms/bfd/model/rif/samples/StaticRifResourceGroup.java
-@@ -47,6 +47,39 @@ public enum StaticRifResourceGroup {
-   SAMPLE_U_BENES_UNCHANGED(
-       StaticRifResource.SAMPLE_U_BENES_UNCHANGED, StaticRifResource.SAMPLE_U_CARRIER),
+@@ -86,6 +86,39 @@ public enum StaticRifResourceGroup {
+       StaticRifResource.SYNTHETIC_OUTPATIENT_2015_2014,
+       StaticRifResource.SYNTHETIC_OUTPATIENT_2016_2014),
  
 +  LOCAL_SYNTHETIC(
 +      StaticRifResource.LOCAL_SYNTHETIC_BENEFICIARY_1999,
@@ -248,21 +248,18 @@ index a1401b55..a44fca81 100644
 +      StaticRifResource.LOCAL_SYNTHETIC_OUTPATIENT_2015_2014,
 +      StaticRifResource.LOCAL_SYNTHETIC_OUTPATIENT_2016_2014),
 +
-   SYNTHETIC_DATA(
-       StaticRifResource.SYNTHETIC_BENEFICIARY_1999,
-       StaticRifResource.SYNTHETIC_BENEFICIARY_2000,
-diff --git a/apps/bfd-pipeline/bfd-pipeline-rif-load/src/test/java/gov/cms/bfd/pipeline/rif/load/RifLoaderIT.java b/apps/bfd-pipeline/bfd-pipeline-rif-load/src/test/java/gov/cms/bfd/pipeline/rif/load/RifLoaderIT.java
-index a163268d..5378d8ce 100644
---- a/apps/bfd-pipeline/bfd-pipeline-rif-load/src/test/java/gov/cms/bfd/pipeline/rif/load/RifLoaderIT.java
-+++ b/apps/bfd-pipeline/bfd-pipeline-rif-load/src/test/java/gov/cms/bfd/pipeline/rif/load/RifLoaderIT.java
-@@ -316,6 +316,20 @@ public final class RifLoaderIT {
-       if (entityManager != null) entityManager.close();
-     }
+   SAMPLE_MCT(StaticRifResource.SAMPLE_MCT_BENES, StaticRifResource.SAMPLE_MCT_PDE),
+ 
+   SAMPLE_MCT_UPDATE_1(StaticRifResource.SAMPLE_MCT_UPDATE_1_BENES),
+diff --git a/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/test/java/gov/cms/bfd/pipeline/ccw/rif/load/RifLoaderIT.java b/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/test/java/gov/cms/bfd/pipeline/ccw/rif/load/RifLoaderIT.java
+index 8d049012..e792afc7 100644
+--- a/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/test/java/gov/cms/bfd/pipeline/ccw/rif/load/RifLoaderIT.java
++++ b/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/test/java/gov/cms/bfd/pipeline/ccw/rif/load/RifLoaderIT.java
+@@ -1130,4 +1130,15 @@ public final class RifLoaderIT {
+               return true;
+             });
    }
-+  /**
-+   * Runs {@link gov.cms.bfd.pipeline.rif.load.RifLoader} against the {@link
-+   * StaticRifResourceGroup#LOCAL_SYNTHETIC} data.
-+   */
++
 +  @Test
 +  public void loadLocalSyntheticData() {
 +    /*Assume.assumeTrue(
@@ -273,9 +270,7 @@ index a163268d..5378d8ce 100644
 +    DataSource dataSource = DatabaseTestHelper.getTestDatabaseAfterClean();
 +    loadSample(dataSource, Arrays.asList(StaticRifResourceGroup.LOCAL_SYNTHETIC.getResources()));
 +  }
-   /**
-    * Runs {@link gov.cms.bfd.pipeline.rif.load.RifLoader} against the {@link
-    * StaticRifResourceGroup#SAMPLE_B} data.
+ }
 -- 
-2.19.0
+2.30.0
 


### PR DESCRIPTION
### Change Details
- Update top-level README to include native development environment setup instructions
- Update `loadLocalSynthethicData` patch to account for the reorganization of the `bfd-pipeline` app.

### Acceptance Validation
You should be able to follow these instructions and have them work for with a totally new setup (pending things like AWS access that are assumed). 

### Feedback Requested
Do these instructions work for you? Anything else you'd like to see?

### External References
- [BFD-702](https://jira.cms.gov/browse/BFD-702)

### Security Implications
This change updates documentation and updates a previously existing patch's filepaths. It would surprise me if this triggered security concerns.



