### PR TITLE
BFD-659: Remediate-Performance-Regression_Patient_Endpoint

### DIFF
--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
@@ -568,10 +568,26 @@ public final class PatientResourceProvider implements IResourceProvider, CommonH
   private TypedQuery<Beneficiary> queryBeneficiariesBy(
       String field, String value, PatientLinkBuilder paging, RequestHeaders requestHeader) {
     String joinsClause = "";
-    if (requestHeader.isMBIinIncludeIdentifiers())
+    boolean passDistinctThrough = false;
+
+    /*
+      Because the DISTINCT JPQL keyword has two meanings based on the underlying query type, it’s important
+      to pass it through to the SQL statement only for scalar queries where the result set requires duplicates
+      to be removed by the database engine.
+
+      For parent-child entity queries where the child collection is using JOIN FETCH, the DISTINCT keyword should
+      only be applied after the ResultSet is got from JDBC, therefore avoiding passing DISTINCT to the SQL statement
+      that gets executed.
+    */
+
+    if (requestHeader.isMBIinIncludeIdentifiers()) {
       joinsClause += "left join fetch b.medicareBeneficiaryIdHistories ";
-    if (requestHeader.isHICNinIncludeIdentifiers())
+      passDistinctThrough = true;
+    }
+    if (requestHeader.isHICNinIncludeIdentifiers()) {
       joinsClause += "left join fetch b.beneficiaryHistories ";
+      passDistinctThrough = true;
+    }
 
     if (paging.isPagingRequested() && !paging.isFirstPage()) {
       String query =
@@ -585,7 +601,8 @@ public final class PatientResourceProvider implements IResourceProvider, CommonH
       return entityManager
           .createQuery(query, Beneficiary.class)
           .setParameter("value", value)
-          .setParameter("cursor", paging.getCursor());
+          .setParameter("cursor", paging.getCursor())
+          .setHint("hibernate.query.passDistinctThrough", passDistinctThrough);
     } else {
       String query =
           "select distinct b from Beneficiary b "
@@ -595,7 +612,10 @@ public final class PatientResourceProvider implements IResourceProvider, CommonH
               + " = :value "
               + "order by b.beneficiaryId asc";
 
-      return entityManager.createQuery(query, Beneficiary.class).setParameter("value", value);
+      return entityManager
+          .createQuery(query, Beneficiary.class)
+          .setParameter("value", value)
+          .setHint("hibernate.query.passDistinctThrough", passDistinctThrough);
     }
   }
 
@@ -648,10 +668,15 @@ public final class PatientResourceProvider implements IResourceProvider, CommonH
       PatientLinkBuilder paging,
       RequestHeaders requestHeader) {
     String joinsClause = "inner join b.beneficiaryMonthlys bm ";
-    if (requestHeader.isMBIinIncludeIdentifiers())
+    boolean passDistinctThrough = false;
+    if (requestHeader.isMBIinIncludeIdentifiers()) {
       joinsClause += "left join fetch b.medicareBeneficiaryIdHistories ";
-    if (requestHeader.isHICNinIncludeIdentifiers())
+      passDistinctThrough = true;
+    }
+    if (requestHeader.isHICNinIncludeIdentifiers()) {
       joinsClause += "left join fetch b.beneficiaryHistories ";
+      passDistinctThrough = true;
+    }
 
     if (paging.isPagingRequested() && !paging.isFirstPage()) {
       String query =
@@ -666,7 +691,8 @@ public final class PatientResourceProvider implements IResourceProvider, CommonH
           .createQuery(query, Beneficiary.class)
           .setParameter("contractCode", contractCode)
           .setParameter("yearMonth", yearMonth)
-          .setParameter("cursor", paging.getCursor());
+          .setParameter("cursor", paging.getCursor())
+          .setHint("hibernate.query.passDistinctThrough", passDistinctThrough);
     } else {
       String query =
           "select distinct b from Beneficiary b "
@@ -678,7 +704,8 @@ public final class PatientResourceProvider implements IResourceProvider, CommonH
       return entityManager
           .createQuery(query, Beneficiary.class)
           .setParameter("contractCode", contractCode)
-          .setParameter("yearMonth", yearMonth);
+          .setParameter("yearMonth", yearMonth)
+          .setHint("hibernate.query.passDistinctThrough", passDistinctThrough);
     }
   }
 
@@ -728,17 +755,25 @@ public final class PatientResourceProvider implements IResourceProvider, CommonH
   private TypedQuery<Beneficiary> queryBeneficiariesByIds(
       List<String> ids, RequestHeaders requestHeader) {
     String joinsClause = "";
-    if (requestHeader.isMBIinIncludeIdentifiers())
+    boolean passDistinctThrough = false;
+    if (requestHeader.isMBIinIncludeIdentifiers()) {
       joinsClause += "left join fetch b.medicareBeneficiaryIdHistories ";
-    if (requestHeader.isHICNinIncludeIdentifiers())
+      passDistinctThrough = true;
+    }
+    if (requestHeader.isHICNinIncludeIdentifiers()) {
       joinsClause += "left join fetch b.beneficiaryHistories ";
+      passDistinctThrough = true;
+    }
 
     String query =
         "select distinct b from Beneficiary b "
             + joinsClause
             + "where b.beneficiaryId in :ids "
             + "order by b.beneficiaryId asc";
-    return entityManager.createQuery(query, Beneficiary.class).setParameter("ids", ids);
+    return entityManager
+        .createQuery(query, Beneficiary.class)
+        .setParameter("ids", ids)
+        .setHint("hibernate.query.passDistinctThrough", passDistinctThrough);
   }
   /**
    * Build a criteria for a beneficiary query using the passed in list of ids
@@ -750,17 +785,25 @@ public final class PatientResourceProvider implements IResourceProvider, CommonH
   private TypedQuery<Beneficiary> queryBeneficiariesByIdsWithBeneficiaryMonthlys(
       List<String> ids, RequestHeaders requestHeader) {
     String joinsClause = "inner join b.beneficiaryMonthlys bm ";
-    if (requestHeader.isMBIinIncludeIdentifiers())
+    boolean passDistinctThrough = false;
+    if (requestHeader.isMBIinIncludeIdentifiers()) {
       joinsClause += "left join fetch b.medicareBeneficiaryIdHistories ";
-    if (requestHeader.isHICNinIncludeIdentifiers())
+      passDistinctThrough = true;
+    }
+    if (requestHeader.isHICNinIncludeIdentifiers()) {
       joinsClause += "left join fetch b.beneficiaryHistories ";
+      passDistinctThrough = true;
+    }
 
     String query =
         "select distinct b from Beneficiary b "
             + joinsClause
             + "where b.beneficiaryId in :ids "
             + "order by b.beneficiaryId asc";
-    return entityManager.createQuery(query, Beneficiary.class).setParameter("ids", ids);
+    return entityManager
+        .createQuery(query, Beneficiary.class)
+        .setParameter("ids", ids)
+        .setHint("hibernate.query.passDistinctThrough", passDistinctThrough);
   }
 
   /**


### PR DESCRIPTION
### Change Details

Because the DISTINCT JPQL keyword has two meanings based on the underlying query type, it’s important
to pass it through to the SQL statement only for scalar queries where the result set requires duplicates
to be removed by the database engine.

For parent-child entity queries where the child collection is using JOIN FETCH, the DISTINCT keyword should
only be applied after the ResultSet is got from JDBC, therefore avoiding passing DISTINCT to the SQL statement
that gets executed.

Added boolean logic to optimize distinct processing.

 .setHint("hibernate.query.passDistinctThrough", passDistinctThrough); 

This PR does not address changes to V2 patientResource handling of HICN or MBI headers; those will be addressed in another ticket.

### Acceptance Validation

Minimum acceptable processing is to marginally improve JPA Patient data retrieval; it does this by disabling 'select distinct' if IncludeIdentifiers does not include 'hicn' or 'mbi'.

Ideally, running Hibernate ExplainPlan would be used to assert performance improvement.

### Feedback Requested

Verify that code changes do not change basic JPA data retrieval.

### External References

- [BFD-659](https://jira.cms.gov/browse/BFD-659)

### Security Implications

N/A

- [ ] new software dependencies

- [ ] altered security controls

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

