### PR TITLE
[BFD-713] Fix for `lastUpdated` time being inconsistent across BFD instances

### DIFF
--- a/apps/bfd-server/bfd-server-launcher/src/main/resources/logback.xml
+++ b/apps/bfd-server/bfd-server-launcher/src/main/resources/logback.xml
@@ -34,37 +34,6 @@
 		<appender-ref ref="HTTP_ACCESS" />
 	</logger>
 
-
-	<appender name="LOADED_FILTER_MANAGER" class="ch.qos.logback.core.FileAppender">
-		<file>${bfdServer.logs.dir:-./target/server-work/}loadedFilterManagerLog.json</file>
-		<encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
-			<!-- We output the log as newline-delimited JSON objects (NDJSON).
-				This allows us to easily parse and search it. More importantly, it
-				pairs very nicely with Logback's MDC: values added to the MDC will be available
-				as separate keys in the JSON log events, which makes it super easy to extract
-				them from the logs. -->
-			<layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
-				<jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
-					<!-- If you need things pretty-printed, pipe the log into jq or something like that. -->
-					<prettyPrint>false</prettyPrint>
-				</jsonFormatter>
-
-				<!-- Add line breaks between each entry, to make tailing the log simpler. -->
-				<appendLineSeparator>true</appendLineSeparator>
-
-				<!-- Format timestamps per ISO8601. -->
-				<timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSZ</timestampFormat>
-				<timestampFormatTimezoneId>UTC</timestampFormatTimezoneId>
-			</layout>
-		</encoder>
-	</appender>
-
-	<!-- Route all events from the JSON access log to the correct output. The additivity
-		setting here ensures that the events don't also land in the other file. -->
-	<logger name="LOADED_FILTER_MANAGER" level="DEBUG" additivity="false">
-		<appender-ref ref="LOADED_FILTER_MANAGER" />
-	</logger>
-
 	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
 		<encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
 			<!-- We output the application log as newline-delimited JSON objects (NDJSON).

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/commons/LoadedFilterManager.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/commons/LoadedFilterManager.java
@@ -30,7 +30,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class LoadedFilterManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(LoadedFilterManager.class);
-  private static final Logger REFRESHLOGGER = LoggerFactory.getLogger("LOADED_FILTER_MANAGER");
 
   // A date before the lastUpdate feature was rolled out
   private static final Date BEFORE_LAST_UPDATED_FEATURE =
@@ -215,65 +214,43 @@ public class LoadedFilterManager {
      * past refresh period. If no files have been loaded, this refresh should take less than a
      * millisecond.
      */
-    REFRESHLOGGER.debug("LoadedFilterManger.refreshFilters(): 1. entering method");
     try {
       // If new batches are present, then build new filters for the affected files
-      REFRESHLOGGER.debug(
-          "LoadedFilterManger.refreshFilters(): 2. Set currentLastBatchCreated variable");
       final Date currentLastBatchCreated =
           fetchLastLoadedBatchCreated().orElse(BEFORE_LAST_UPDATED_FEATURE);
-      REFRESHLOGGER.debug(
-          "LoadedFilterManger.refreshFilters(): 3. Set currentLastBatchCreated to: "
-              + currentLastBatchCreated.toString());
-      if (this.lastBatchCreated == null || this.lastBatchCreated.before(currentLastBatchCreated)) {
+
+      if (this.lastBatchCreated == null
+          || this.lastBatchCreated.toInstant().isBefore(currentLastBatchCreated.toInstant())) {
         LOGGER.info(
             "Refreshing LoadedFile filters with new filters from {} to {}",
             lastBatchCreated,
             currentLastBatchCreated);
-        REFRESHLOGGER.debug(
-            "LoadedFilterManger.refreshFilters(): 4. Refreshing LoadedFile filters with new filters from {} to {}",
-            lastBatchCreated,
-            currentLastBatchCreated);
 
-        REFRESHLOGGER.debug("LoadedFilterManger.refreshFilters(): 5. starting fetch loaded tuples");
         List<LoadedTuple> loadedTuples = fetchLoadedTuples(this.lastBatchCreated);
-        REFRESHLOGGER.debug("LoadedFilterManger.refreshFilters(): 6. Creating new filters");
         List<LoadedFileFilter> newFilters =
             updateFilters(this.filters, loadedTuples, this::fetchLoadedBatches);
 
         // If batches been trimmed, then remove filters which are no longer present
-        REFRESHLOGGER.debug(
-            "LoadedFilterManger.refreshFilters(): 6. setting currentFirstBatchUpdate");
         final Date currentFirstBatchUpdate =
             fetchFirstLoadedBatchCreated().orElse(BEFORE_LAST_UPDATED_FEATURE);
-        REFRESHLOGGER.debug(
-            "LoadedFilterManger.refreshFilters(): 7. currentFirstBatchUpdate is :"
-                + currentFirstBatchUpdate.toString());
+
         if (this.firstBatchCreated == null
             || this.firstBatchCreated.before(currentFirstBatchUpdate)) {
-          REFRESHLOGGER.debug(
-              "LoadedFilterManger.refreshFilters(): 8. Trimmed LoadedFile filters before {}",
-              currentFirstBatchUpdate.toString());
           LOGGER.info("Trimmed LoadedFile filters before {}", currentFirstBatchUpdate);
           List<LoadedFile> loadedFiles = fetchLoadedFiles();
-          REFRESHLOGGER.debug("LoadedFilterManger.refreshFilters(): 9. Trimfilters");
           newFilters = trimFilters(newFilters, loadedFiles);
         }
-        REFRESHLOGGER.debug("LoadedFilterManger.refreshFilters(): 10. setting function");
+
+        LOGGER.info(
+            "Updating timestamps. currentFirstBatchUpdate={} currentLastBatchCreated={}",
+            currentFirstBatchUpdate,
+            currentLastBatchCreated);
+
         set(newFilters, currentFirstBatchUpdate, currentLastBatchCreated);
       }
-    } catch (Exception ex) {
-      REFRESHLOGGER.debug(
-          "LoadedFilterManger.refreshFilters(): Exception Error found refreshing LoadedFile filters",
-          ex);
-      LOGGER.error("Error found refreshing LoadedFile filters", ex);
     } catch (Throwable ex) {
-      REFRESHLOGGER.debug(
-          "LoadedFilterManger.refreshFilters(): Throwable Error found refreshing LoadedFile filters",
-          ex);
       LOGGER.error("Error found refreshing LoadedFile filters", ex);
     }
-    REFRESHLOGGER.debug("LoadedFilterManger.refreshFilters(): 11. exiting method");
   }
 
   /**


### PR DESCRIPTION
### Change Details

* Changed the way that the last and current update times are compared in `LoadedFilterManager`
* Added unit tests that show the issue and protects against possible behavioral changes in future versions of Java.

### Acceptance Validation

A detailed explanation of the issue along with testing notes is available in JIRA: [BFD-713](https://jira.cms.gov/browse/BFD-713)

From a high level, the issue is that the `Date` objects being compared in `LoadedFilterManager` are actually `java.sql.Timestamp` instances.  `java.sql.Timestamp` splits the time into Seconds and Nanos, instead of keeping a complete millisecond timestamp.  This causes  `Date.before` to return `false` when the times are different because only the seconds were compared and not the milliseconds.  This meant that if the last update in the database happened on the same second, but after the last time `refreshFilters()` run, the BFD instance would never have the correct date.  This explains why when discrepancies were seen they were always only milliseconds off and never seconds+.

Reference: https://docs.oracle.com/javase/8/docs/api/java/sql/Timestamp.html

### Feedback Requested

Please verify that I removed all the pieces that were associated with the `LOADED_FILTER_MANAGER` and `REFRESHLOGGER`

### External References

<!-- For example: replace xxx with the JIRA ticket number: -->

- [BFD-713](https://jira.cms.gov/browse/BFD-713)

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] altered security controls

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications
<!-- Use this to indicate you're unsure how this change may impact system security and would like to solicit the team's feedback. Optionally, provide background information regarding your questions and concerns. -->

