### PR TITLE
BFD-717: Send Dropwizard Metrics to New Relic

### DIFF
--- a/apps/bfd-server/bfd-server-war/pom.xml
+++ b/apps/bfd-server/bfd-server-war/pom.xml
@@ -158,12 +158,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>io.dropwizard.metrics</groupId>
-			<artifactId>metrics-jmx</artifactId>
-			<version>${metrics.version}</version>
-		</dependency>
-
-		<dependency>
 			<!-- Allows us to provide New Relic with additional information on requests. -->
 			<groupId>com.newrelic.agent.java</groupId>
 			<artifactId>newrelic-api</artifactId>

--- a/apps/bfd-server/bfd-server-war/pom.xml
+++ b/apps/bfd-server/bfd-server-war/pom.xml
@@ -157,11 +157,29 @@
 			<version>${metrics.version}</version>
 		</dependency>
 
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-jmx</artifactId>
+      <version>${metrics.version}</version>
+    </dependency>
+
 		<dependency>
 			<!-- Allows us to provide New Relic with additional information on requests. -->
 			<groupId>com.newrelic.agent.java</groupId>
 			<artifactId>newrelic-api</artifactId>
 			<version>5.9.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.newrelic.telemetry</groupId>
+			<artifactId>dropwizard-metrics-newrelic</artifactId>
+			<version>0.5.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.newrelic.telemetry</groupId>
+			<artifactId>telemetry-http-okhttp</artifactId>
+			<version>0.6.1</version>
 		</dependency>
 		
 		<dependency>

--- a/apps/bfd-server/bfd-server-war/pom.xml
+++ b/apps/bfd-server/bfd-server-war/pom.xml
@@ -157,11 +157,11 @@
 			<version>${metrics.version}</version>
 		</dependency>
 
-    <dependency>
-      <groupId>io.dropwizard.metrics</groupId>
-      <artifactId>metrics-jmx</artifactId>
-      <version>${metrics.version}</version>
-    </dependency>
+		<dependency>
+			<groupId>io.dropwizard.metrics</groupId>
+			<artifactId>metrics-jmx</artifactId>
+			<version>${metrics.version}</version>
+		</dependency>
 
 		<dependency>
 			<!-- Allows us to provide New Relic with additional information on requests. -->

--- a/apps/pom.xml
+++ b/apps/pom.xml
@@ -83,7 +83,7 @@
 		<sonar.jacoco.reportPath>target/jacoco.exec</sonar.jacoco.reportPath>
 		<sonar.jacoco.itReportPath>target/jacoco-it.exec</sonar.jacoco.itReportPath>
 
-		<metrics.version>3.1.2</metrics.version>
+		<metrics.version>4.1.2</metrics.version>
 		<hibernate.version>5.2.10.Final</hibernate.version>
 		
 		<!-- The default DB that will be used in integration tests. -->


### PR DESCRIPTION
### Change Details
This PR addresses [BFD-717](https://jira.cms.gov/browse/BFD-717). It adds a `NewRelicReporter` that takes existing measurements from Dropwizard, transforms them into a format that New Relic will understand, and then ships them off. It also upgrades the Dropwizard Metrics major version to 4.1.2. There is an enum introduced in v4 that the New Relic integration package relies on. This also required adding a separate `metrics-jmx` artifact, which was split out in the migration from v3 to v4.

The reporter will only be configured as part of the `MetricRegistry` Spring Bean if the `NEW_RELIC_METRIC_KEY` environment variable is set. This is a new key that differs from the existing license key. 

A writeup on how to query and analyze the new Dropwizard metrics in New Relic is forthcoming.

_Special note on Codahale_: You'll see [timers in the code](https://github.com/CMSgov/beneficiary-fhir-data/blob/d5700eb2f4d2502c9356b90a4871ceab544f84b9/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/OutpatientClaimTransformerV2.java#L3-L4) that come from a project called "codahale" that's not referenced in any of the pom files. This is the old name for a project that Dropwizard took over. Those classes all come from Dropwizard.

### Acceptance Validation
<!-- What should reviewers look for to determine completeness -->
- If you add the correct key from the New Relic Insights keys UI, you should start to see events appear. You can validate that they are arriving with the following NRQL: `SELECT * from Metric WHERE appName = 'BFD Server (local)'`, where `BFD Server (local)` can be substituted to whatever you have the `NEW_RELIC_APP_NAME` env var set as locally. 
- If you don't have the metric key set, it shouldn't be attempting to send the metrics over the wire. If you tail the logs after server startup, you shouldn't see failure messages every 15 seconds that it failed to send a metric batch. (If you want to see failure logs, feel free to put in a garbled key—you'll see them real quick!)

### Feedback Requested

<!-- What type of feedback you want from your reviewers? -->
- Is my use of `System.getenv` fair for sourcing the configuration?
- Are we happy with a 15 second batch interval? Pulled it straight from the examples.
- Do we actually need the `JmxReporter` in there for anything? If we're not using it, it would be nice to remove. It's now a separate package. I'm also not sure where it's disabled when in production, though @mackec1 indicates that if it _was_ enabled it would bring the server to its knees.

### External References

- [BFD-717](https://jira.cms.gov/browse/BFD-717)
- [Dropwizard Metrics](https://github.com/dropwizard/metrics)
- [Dropwizard New Relic Integration](https://github.com/newrelic/dropwizard-metrics-newrelic)

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [x] new software dependencies

These changes add the [New Relic Dropwizard Reporter](https://github.com/newrelic/dropwizard-metrics-newrelic). It is an official library published by New Relic to integrate with Dropwizard. The changes also increment the major version of Dropwizard to an [actively maintained version](https://github.com/dropwizard/metrics#versions).

- [ ] altered security controls

<!-- If yes, what security controls or supporting software are affected? -->

- [x] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->
These changes would transmit telemetry to New Relic that currently gets stored in memory on the app server and offered up via a `/metrics/metrics` endpoint. This is not PII or PHI. It is counters and timers around certain blocks of our code that will be used to better understand usage and performance.

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications
<!-- Use this to indicate you're unsure how this change may impact system security and would like to solicit the team's feedback. Optionally, provide background information regarding your questions and concerns. -->

