### PR TITLE
BFD-745: Add unit tests for OutpatientClaimTransformerV2

### DIFF
--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/OutpatientClaimTransformerV2Test.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/OutpatientClaimTransformerV2Test.java
@@ -598,8 +598,8 @@ public final class OutpatientClaimTransformerV2Test {
   @Test
   public void shouldHaveLineItemAdjudicationRevCntr1stAnsiCd() {
     AdjudicationComponent adjudication =
-        TransformerTestUtilsV2.findAdjudicationByCategory(
-            "denialreason", eob.getItemFirstRep().getAdjudication());
+        TransformerTestUtilsV2.findAdjudicationByReason(
+            "CO120", eob.getItemFirstRep().getAdjudication());
 
     AdjudicationComponent compare =
         new AdjudicationComponent()
@@ -618,6 +618,34 @@ public final class OutpatientClaimTransformerV2Test {
                             new Coding(
                                 "https://bluebutton.cms.gov/resources/variables/rev_cntr_1st_ansi_cd",
                                 "CO120",
+                                null))));
+
+    Assert.assertTrue(compare.equalsDeep(adjudication));
+  }
+
+  @Test
+  public void shouldHaveLineItemAdjudicationRevCntr2ndAnsiCd() {
+    AdjudicationComponent adjudication =
+        TransformerTestUtilsV2.findAdjudicationByReason(
+            "CR121", eob.getItemFirstRep().getAdjudication());
+
+    AdjudicationComponent compare =
+        new AdjudicationComponent()
+            .setCategory(
+                new CodeableConcept()
+                    .setCoding(
+                        Arrays.asList(
+                            new Coding(
+                                "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBAdjudicationDiscriminator",
+                                "denialreason",
+                                "Denial Reason"))))
+            .setReason(
+                new CodeableConcept()
+                    .setCoding(
+                        Arrays.asList(
+                            new Coding(
+                                "https://bluebutton.cms.gov/resources/variables/rev_cntr_2nd_ansi_cd",
+                                "CR121",
                                 null))));
 
     Assert.assertTrue(compare.equalsDeep(adjudication));

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/OutpatientClaimTransformerV2Test.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/OutpatientClaimTransformerV2Test.java
@@ -2,23 +2,47 @@ package gov.cms.bfd.server.war.r4.providers;
 
 import ca.uhn.fhir.context.FhirContext;
 import com.codahale.metrics.MetricRegistry;
-import gov.cms.bfd.model.rif.InpatientClaim;
 import gov.cms.bfd.model.rif.OutpatientClaim;
-import gov.cms.bfd.model.rif.samples.StaticRifResource;
 import gov.cms.bfd.model.rif.samples.StaticRifResourceGroup;
 import gov.cms.bfd.server.war.ServerTestUtils;
-import gov.cms.bfd.server.war.commons.MedicareSegment;
+import gov.cms.bfd.server.war.commons.ProfileConstants;
+import gov.cms.bfd.server.war.commons.TransformerConstants;
+import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.r4.model.Address;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.DateType;
+import org.hl7.fhir.r4.model.DecimalType;
 import org.hl7.fhir.r4.model.ExplanationOfBenefit;
+import org.hl7.fhir.r4.model.ExplanationOfBenefit.AdjudicationComponent;
+import org.hl7.fhir.r4.model.ExplanationOfBenefit.BenefitComponent;
+import org.hl7.fhir.r4.model.ExplanationOfBenefit.CareTeamComponent;
+import org.hl7.fhir.r4.model.ExplanationOfBenefit.DiagnosisComponent;
+import org.hl7.fhir.r4.model.ExplanationOfBenefit.ExplanationOfBenefitStatus;
+import org.hl7.fhir.r4.model.ExplanationOfBenefit.InsuranceComponent;
+import org.hl7.fhir.r4.model.ExplanationOfBenefit.PaymentComponent;
+import org.hl7.fhir.r4.model.ExplanationOfBenefit.ProcedureComponent;
+import org.hl7.fhir.r4.model.ExplanationOfBenefit.SupportingInformationComponent;
+import org.hl7.fhir.r4.model.ExplanationOfBenefit.TotalComponent;
+import org.hl7.fhir.r4.model.ExplanationOfBenefit.Use;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.Money;
+import org.hl7.fhir.r4.model.Quantity;
+import org.hl7.fhir.r4.model.Reference;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
 public final class OutpatientClaimTransformerV2Test {
+  OutpatientClaim claim;
+  ExplanationOfBenefit eob;
+
   /**
    * Generates the Claim object to be used in multiple tests
    *
@@ -41,24 +65,1144 @@ public final class OutpatientClaimTransformerV2Test {
     return claim;
   }
 
-  /**
-   * Verifies that {@link
-   * gov.cms.bfd.server.war.r4.providers.OutpatientClaimTransformer#transform(Object)} works as
-   * expected when run against the {@link StaticRifResource#SAMPLE_A_INPATIENT} {@link
-   * InpatientClaim}.
-   *
-   * @throws FHIRException (indicates test failure)
-   */
-  @Test
-  public void transformSampleARecord() throws FHIRException {
-    OutpatientClaim claim = generateClaim();
-
-    assertMatches(
-        claim,
-        OutpatientClaimTransformerV2.transform(new MetricRegistry(), claim, Optional.of(false)));
+  @Before
+  public void before() {
+    claim = generateClaim();
+    eob = OutpatientClaimTransformerV2.transform(new MetricRegistry(), claim, Optional.empty());
   }
 
   private static final FhirContext fhirContext = FhirContext.forR4();
+
+  @Test
+  public void shouldSetID() {
+    Assert.assertEquals("outpatient-" + claim.getClaimId(), eob.getId());
+  }
+
+  @Test
+  public void shouldSetLastUpdated() {
+    Assert.assertNotNull(eob.getMeta().getLastUpdated());
+  }
+
+  @Test
+  public void shouldSetCorrectProfile() {
+    // The base CanonicalType doesn't seem to compare correctly so lets convert it
+    // to a string
+    Assert.assertTrue(
+        eob.getMeta().getProfile().stream()
+            .map(ct -> ct.getValueAsString())
+            .anyMatch(v -> v.equals(ProfileConstants.C4BB_EOB_OUTPATIENT_PROFILE_URL)));
+  }
+
+  @Test
+  public void shouldSetUse() {
+    Assert.assertEquals(Use.CLAIM, eob.getUse());
+  }
+
+  @Test
+  public void shouldSetFinalAction() {
+    Assert.assertEquals(ExplanationOfBenefitStatus.ACTIVE, eob.getStatus());
+  }
+
+  @Test
+  public void shouldSetBillablePeriod() throws Exception {
+    // We just want to make sure it is set
+    Assert.assertNotNull(eob.getBillablePeriod());
+    Assert.assertEquals(
+        (new SimpleDateFormat("yyy-MM-dd")).parse("2011-01-24"),
+        eob.getBillablePeriod().getStart());
+    Assert.assertEquals(
+        (new SimpleDateFormat("yyy-MM-dd")).parse("2011-01-24"), eob.getBillablePeriod().getEnd());
+  }
+
+  @Test
+  public void shouldReferencePatient() {
+    Assert.assertNotNull(eob.getPatient());
+    Assert.assertEquals("Patient/567834", eob.getPatient().getReference());
+  }
+
+  @Test
+  public void shouldHaveCreatedDate() {
+    Assert.assertNotNull(eob.getCreated());
+  }
+
+  @Test
+  public void shouldHaveFacilityTypeExtension() {
+    Assert.assertNotNull(eob.getFacility());
+    Assert.assertEquals(1, eob.getFacility().getExtension().size());
+
+    Extension ex =
+        TransformerTestUtilsV2.findExtensionByUrl(
+            "https://bluebutton.cms.gov/resources/variables/clm_fac_type_cd",
+            eob.getFacility().getExtension());
+
+    Extension compare =
+        new Extension(
+            "https://bluebutton.cms.gov/resources/variables/clm_fac_type_cd",
+            new Coding(
+                "https://bluebutton.cms.gov/resources/variables/clm_fac_type_cd", "1", "Hospital"));
+
+    Assert.assertTrue(compare.equalsDeep(ex));
+  }
+
+  /**
+   * CareTeam list
+   *
+   * <p>Based on how the code currently works, we can assume that the same CareTeam members always
+   * are added in the same order. This means we can look them up by sequence number.
+   */
+  @Test
+  public void shouldHaveCareTeamList() {
+    Assert.assertEquals(4, eob.getCareTeam().size());
+  }
+
+  /**
+   * Testing all of these in one test, just because there isn't a distinct identifier really for
+   * each
+   */
+  @Test
+  public void shouldHaveCareTeamMembers() {
+    // First member
+    CareTeamComponent member1 = TransformerTestUtilsV2.findCareTeamBySequence(1, eob.getCareTeam());
+    CareTeamComponent compare1 =
+        TransformerTestUtilsV2.createNpiCareTeamMember(
+            1,
+            "2222222222",
+            "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBClaimCareTeamRole",
+            "attending",
+            "Attending");
+
+    Assert.assertTrue(compare1.equalsDeep(member1));
+
+    // Second member
+    CareTeamComponent member2 = TransformerTestUtilsV2.findCareTeamBySequence(2, eob.getCareTeam());
+    CareTeamComponent compare2 =
+        TransformerTestUtilsV2.createNpiCareTeamMember(
+            2,
+            "3333333333",
+            "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBClaimCareTeamRole",
+            "operating",
+            "Operating");
+
+    Assert.assertTrue(compare2.equalsDeep(member2));
+
+    // Third member
+    CareTeamComponent member3 = TransformerTestUtilsV2.findCareTeamBySequence(3, eob.getCareTeam());
+    CareTeamComponent compare3 =
+        TransformerTestUtilsV2.createNpiCareTeamMember(
+            3,
+            "4444",
+            "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBClaimCareTeamRole",
+            "otheroperating",
+            "Other Operating");
+
+    Assert.assertTrue(compare3.equalsDeep(member3));
+
+    // Fourth member
+    CareTeamComponent member4 = TransformerTestUtilsV2.findCareTeamBySequence(4, eob.getCareTeam());
+    CareTeamComponent compare4 =
+        TransformerTestUtilsV2.createNpiCareTeamMember(
+            4,
+            "345345345",
+            "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBClaimCareTeamRole",
+            "performing",
+            "Performing provider");
+
+    Assert.assertTrue(compare4.equalsDeep(member4));
+  }
+
+  /** SupportingInfo items */
+  @Test
+  public void shouldHaveSupportingInfoList() {
+    Assert.assertEquals(5, eob.getSupportingInfo().size());
+  }
+
+  @Test
+  public void shouldHaveClaimReceivedDateSupInfo() {
+    SupportingInformationComponent sic =
+        TransformerTestUtilsV2.findSupportingInfoByCode("clmrecvddate", eob.getSupportingInfo());
+
+    SupportingInformationComponent compare =
+        TransformerTestUtilsV2.createSupportingInfo(
+                // We don't care what the sequence number is here
+                sic.getSequence(),
+                // Category
+                Arrays.asList(
+                    new Coding(
+                        "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBSupportingInfoType",
+                        "clmrecvddate",
+                        "Claim Received Date"),
+                    new Coding(
+                        "https://bluebutton.cms.gov/resources/codesystem/information",
+                        "https://bluebutton.cms.gov/resources/variables/nch_wkly_proc_dt",
+                        "NCH Weekly Claim Processing Date")))
+            // timingDate
+            .setTiming(new DateType("2011-02-26"));
+
+    Assert.assertTrue(compare.equalsDeep(sic));
+  }
+
+  @Test
+  public void shouldHaveClmMcoPdSwSupInfo() {
+    SupportingInformationComponent sic =
+        TransformerTestUtilsV2.findSupportingInfoByCode(
+            "https://bluebutton.cms.gov/resources/variables/clm_mco_pd_sw",
+            eob.getSupportingInfo());
+
+    SupportingInformationComponent compare =
+        TransformerTestUtilsV2.createSupportingInfo(
+            // We don't care what the sequence number is here
+            sic.getSequence(),
+            // Category
+            Arrays.asList(
+                new Coding(
+                    "http://terminology.hl7.org/CodeSystem/claiminformationcategory",
+                    "info",
+                    "Information"),
+                new Coding(
+                    "https://bluebutton.cms.gov/resources/codesystem/information",
+                    "https://bluebutton.cms.gov/resources/variables/clm_mco_pd_sw",
+                    "Claim MCO Paid Switch")),
+            // Code
+            new Coding(
+                "https://bluebutton.cms.gov/resources/variables/clm_mco_pd_sw",
+                "0",
+                "No managed care organization (MCO) payment"));
+
+    Assert.assertTrue(compare.equalsDeep(sic));
+  }
+
+  @Test
+  public void shouldHaveTypeOfBillSupInfo() {
+    SupportingInformationComponent sic =
+        TransformerTestUtilsV2.findSupportingInfoByCode("typeofbill", eob.getSupportingInfo());
+
+    SupportingInformationComponent compare =
+        TransformerTestUtilsV2.createSupportingInfo(
+            // We don't care what the sequence number is here
+            sic.getSequence(),
+            // Category
+            Arrays.asList(
+                new Coding(
+                    "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBSupportingInfoType",
+                    "typeofbill",
+                    "Type of Bill")),
+            // Code
+            new Coding(
+                "https://bluebutton.cms.gov/resources/variables/clm_freq_cd",
+                "1",
+                "Admit thru discharge claim"));
+
+    Assert.assertTrue(compare.equalsDeep(sic));
+  }
+
+  @Test
+  public void shouldHaveDischargeStatusSupInfo() {
+    SupportingInformationComponent sic =
+        TransformerTestUtilsV2.findSupportingInfoByCode(
+            "discharge-status", eob.getSupportingInfo());
+
+    SupportingInformationComponent compare =
+        TransformerTestUtilsV2.createSupportingInfo(
+            // We don't care what the sequence number is here
+            sic.getSequence(),
+            // Category
+            Arrays.asList(
+                new Coding(
+                    "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBSupportingInfoType",
+                    "discharge-status",
+                    "Discharge Status")),
+            // Code
+            new Coding(
+                "https://bluebutton.cms.gov/resources/variables/ptnt_dschrg_stus_cd", "1", null));
+
+    Assert.assertTrue(compare.equalsDeep(sic));
+  }
+
+  @Test
+  public void shouldHaveNchPrmryPyrCdSupInfo() {
+    SupportingInformationComponent sic =
+        TransformerTestUtilsV2.findSupportingInfoByCode(
+            "https://bluebutton.cms.gov/resources/variables/nch_prmry_pyr_cd",
+            eob.getSupportingInfo());
+
+    SupportingInformationComponent compare =
+        TransformerTestUtilsV2.createSupportingInfo(
+            // We don't care what the sequence number is here
+            sic.getSequence(),
+            // Category
+            Arrays.asList(
+                new Coding(
+                    "http://terminology.hl7.org/CodeSystem/claiminformationcategory",
+                    "info",
+                    "Information"),
+                new Coding(
+                    "https://bluebutton.cms.gov/resources/codesystem/information",
+                    "https://bluebutton.cms.gov/resources/variables/nch_prmry_pyr_cd",
+                    "NCH Primary Payer Code (if not Medicare)")),
+            // Code
+            new Coding(
+                "https://bluebutton.cms.gov/resources/variables/nch_prmry_pyr_cd",
+                "A",
+                "Employer group health plan (EGHP) insurance for an aged beneficiary"));
+
+    Assert.assertTrue(compare.equalsDeep(sic));
+  }
+
+  /** Diagnosis elements */
+  @Test
+  public void shouldHaveDiagnosesList() {
+    Assert.assertEquals(5, eob.getDiagnosis().size());
+  }
+
+  @Test
+  public void shouldHaveDiagnosesMembers() {
+    DiagnosisComponent diag1 =
+        TransformerTestUtilsV2.findDiagnosisByCode("R5555", eob.getDiagnosis());
+
+    DiagnosisComponent cmp1 =
+        TransformerTestUtilsV2.createDiagnosis(
+            // Order doesn't matter
+            diag1.getSequence(),
+            new Coding("http://hl7.org/fhir/sid/icd-10", "R5555", null),
+            new Coding(
+                "http://terminology.hl7.org/CodeSystem/ex-diagnosistype",
+                "principal",
+                "Principal Diagnosis"),
+            null,
+            null);
+
+    Assert.assertTrue(cmp1.equalsDeep(diag1));
+
+    DiagnosisComponent diag2 =
+        TransformerTestUtilsV2.findDiagnosisByCode("I9999", eob.getDiagnosis());
+
+    DiagnosisComponent cmp2 =
+        TransformerTestUtilsV2.createDiagnosis(
+            // Order doesn't matter
+            diag2.getSequence(),
+            new Coding("http://hl7.org/fhir/sid/icd-10", "I9999", null),
+            new Coding(
+                "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBClaimDiagnosisType",
+                "other",
+                "Other"),
+            null,
+            null);
+
+    Assert.assertTrue(cmp2.equalsDeep(diag2));
+
+    DiagnosisComponent diag3 =
+        TransformerTestUtilsV2.findDiagnosisByCode("R2222", eob.getDiagnosis());
+
+    DiagnosisComponent cmp3 =
+        TransformerTestUtilsV2.createDiagnosis(
+            // Order doesn't matter
+            diag3.getSequence(),
+            new Coding("http://hl7.org/fhir/sid/icd-10", "R2222", null),
+            new Coding(
+                "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBClaimDiagnosisType",
+                "externalcauseofinjury",
+                "External Cause of Injury"),
+            null,
+            null);
+
+    Assert.assertTrue(cmp3.equalsDeep(diag3));
+
+    DiagnosisComponent diag4 =
+        TransformerTestUtilsV2.findDiagnosisByCode("R3333", eob.getDiagnosis());
+
+    DiagnosisComponent cmp4 =
+        TransformerTestUtilsV2.createDiagnosis(
+            // Order doesn't matter
+            diag4.getSequence(),
+            new Coding("http://hl7.org/fhir/sid/icd-10", "R3333", null),
+            new Coding(
+                "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBClaimDiagnosisType",
+                "externalcauseofinjury",
+                "External Cause of Injury"),
+            null,
+            null);
+
+    Assert.assertTrue(cmp4.equalsDeep(diag4));
+
+    DiagnosisComponent diag5 =
+        TransformerTestUtilsV2.findDiagnosisByCode("R1122", eob.getDiagnosis());
+
+    DiagnosisComponent cmp5 =
+        TransformerTestUtilsV2.createDiagnosis(
+            // Order doesn't matter
+            diag5.getSequence(),
+            new Coding("http://hl7.org/fhir/sid/icd-10", "R1122", null),
+            new Coding(
+                "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBClaimDiagnosisType",
+                "patientreasonforvisit",
+                "Patient Reason for Visit"),
+            null,
+            null);
+
+    Assert.assertTrue(cmp5.equalsDeep(diag5));
+  }
+
+  /** Procedures */
+  @Test
+  public void shouldHaveProcedureList() {
+    Assert.assertEquals(1, eob.getProcedure().size());
+  }
+
+  @Test
+  public void shouldHaveProcedureMembers() {
+    ProcedureComponent proc1 =
+        TransformerTestUtilsV2.findProcedureByCode("0AABBZZ", eob.getProcedure());
+
+    ProcedureComponent cmp1 =
+        TransformerTestUtilsV2.createProcedure(
+            proc1.getSequence(),
+            new Coding("http://hl7.org/fhir/sid/icd-10", "0AABBZZ", null),
+            "2016-01-16T00:00:00-08:00");
+
+    Assert.assertTrue("Comparing Procedure code 0AABBZZ", cmp1.equalsDeep(proc1));
+  }
+
+  /** Insurance */
+  @Test
+  public void shouldReferenceCoverageInInsurance() {
+    // Only one insurance object
+    Assert.assertEquals(1, eob.getInsurance().size());
+
+    InsuranceComponent insurance = eob.getInsuranceFirstRep();
+
+    InsuranceComponent compare =
+        new InsuranceComponent()
+            .setCoverage(new Reference().setReference("Coverage/part-b-567834"));
+
+    Assert.assertTrue(compare.equalsDeep(insurance));
+  }
+
+  /** Line Items */
+  @Test
+  public void shouldHaveLineItems() {
+    Assert.assertEquals(1, eob.getItem().size());
+  }
+
+  @Test
+  public void shouldHaveLineItemSequence() {
+    Assert.assertEquals(25, eob.getItemFirstRep().getSequence());
+  }
+
+  @Test
+  public void shouldHaveLineItemCareTeamRef() {
+    // The order isn't important but this should reference a care team member
+    Assert.assertNotNull(eob.getItemFirstRep().getCareTeamSequence());
+    Assert.assertEquals(1, eob.getItemFirstRep().getCareTeamSequence().size());
+  }
+
+  @Test
+  public void shouldHaveLineItemRevenue() {
+    CodeableConcept revenue = eob.getItemFirstRep().getRevenue();
+
+    CodeableConcept compare =
+        new CodeableConcept()
+            .setCoding(
+                Arrays.asList(
+                    new Coding(
+                        "https://bluebutton.cms.gov/resources/variables/rev_cntr", "1", null)));
+
+    Assert.assertTrue(compare.equalsDeep(revenue));
+  }
+
+  @Test
+  public void shouldHaveLineItemProductOrServiceCoding() {
+    CodeableConcept pos = eob.getItemFirstRep().getProductOrService();
+
+    CodeableConcept compare =
+        new CodeableConcept()
+            .setCoding(
+                Arrays.asList(
+                    new Coding(
+                        "https://bluebutton.cms.gov/resources/codesystem/hcpcs", "M99", null)));
+
+    compare.setExtension(
+        Arrays.asList(
+            new Extension(
+                "http://hl7.org/fhir/sid/ndc",
+                new Coding("http://hl7.org/fhir/sid/ndc", "987654321", null))));
+
+    Assert.assertTrue(compare.equalsDeep(pos));
+  }
+
+  @Test
+  public void shouldHaveLineItemProductOrServiceExtension() {
+    Assert.assertNotNull(eob.getItemFirstRep().getProductOrService());
+    Assert.assertEquals(1, eob.getItemFirstRep().getProductOrService().getExtension().size());
+
+    Extension ex =
+        TransformerTestUtilsV2.findExtensionByUrl(
+            "http://hl7.org/fhir/sid/ndc",
+            eob.getItemFirstRep().getProductOrService().getExtension());
+
+    Extension compare =
+        new Extension(
+            "http://hl7.org/fhir/sid/ndc",
+            new Coding("http://hl7.org/fhir/sid/ndc", "987654321", null));
+
+    Assert.assertTrue(compare.equalsDeep(ex));
+  }
+
+  @Test
+  public void shouldHaveLineItemModifier() {
+    Assert.assertEquals(2, eob.getItemFirstRep().getModifier().size());
+
+    CodeableConcept modifier = eob.getItemFirstRep().getModifierFirstRep();
+
+    CodeableConcept compare =
+        new CodeableConcept()
+            .setCoding(
+                Arrays.asList(
+                    new Coding(
+                        "https://bluebutton.cms.gov/resources/codesystem/hcpcs", "XX", null)));
+
+    Assert.assertTrue(compare.equalsDeep(modifier));
+  }
+
+  @Test
+  public void shouldHaveLineItemServicedDate() {
+    DateType servicedDate = eob.getItemFirstRep().getServicedDateType();
+
+    DateType compare = new DateType("1942-01-03");
+
+    Assert.assertEquals(servicedDate.toString(), compare.toString());
+  }
+
+  @Test
+  public void shouldHaveLineItemLocation() {
+    Address address = eob.getItemFirstRep().getLocationAddress();
+
+    Address compare = new Address().setState("KY");
+
+    Assert.assertTrue(compare.equalsDeep(address));
+  }
+
+  @Test
+  public void shouldHaveLineItemQuantity() {
+    Quantity quantity = eob.getItemFirstRep().getQuantity();
+
+    Quantity compare = new Quantity(111);
+
+    Assert.assertTrue(compare.equalsDeep(quantity));
+  }
+
+  @Test
+  public void shouldHaveLineItemAdjudications() {
+    Assert.assertEquals(15, eob.getItemFirstRep().getAdjudication().size());
+  }
+
+  @Test
+  public void shouldHaveLineItemAdjudicationRevCntr1stAnsiCd() {
+    AdjudicationComponent adjudication =
+        TransformerTestUtilsV2.findAdjudicationByCategory(
+            "denialreason", eob.getItemFirstRep().getAdjudication());
+
+    AdjudicationComponent compare =
+        new AdjudicationComponent()
+            .setCategory(
+                new CodeableConcept()
+                    .setCoding(
+                        Arrays.asList(
+                            new Coding(
+                                "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBAdjudicationDiscriminator",
+                                "denialreason",
+                                "Denial Reason"))))
+            .setReason(
+                new CodeableConcept()
+                    .setCoding(
+                        Arrays.asList(
+                            new Coding(
+                                "https://bluebutton.cms.gov/resources/variables/rev_cntr_1st_ansi_cd",
+                                "CO120",
+                                null))));
+
+    Assert.assertTrue(compare.equalsDeep(adjudication));
+  }
+
+  @Test
+  public void shouldHaveLineItemAdjudicationRevCntrRateAmt() {
+    AdjudicationComponent adjudication =
+        TransformerTestUtilsV2.findAdjudicationByCategory(
+            "https://bluebutton.cms.gov/resources/variables/rev_cntr_rate_amt",
+            eob.getItemFirstRep().getAdjudication());
+
+    AdjudicationComponent compare =
+        new AdjudicationComponent()
+            .setCategory(
+                new CodeableConcept()
+                    .setCoding(
+                        Arrays.asList(
+                            new Coding(
+                                "http://terminology.hl7.org/CodeSystem/adjudication",
+                                "submitted",
+                                "Submitted Amount"),
+                            new Coding(
+                                "https://bluebutton.cms.gov/resources/codesystem/adjudication",
+                                "https://bluebutton.cms.gov/resources/variables/rev_cntr_rate_amt",
+                                "Revenue Center Rate Amount"))))
+            .setAmount(new Money().setValue(5).setCurrency(TransformerConstants.CODED_MONEY_USD));
+
+    Assert.assertTrue(compare.equalsDeep(adjudication));
+  }
+
+  @Test
+  public void shouldHaveLineItemAdjudicationRevCntrTotChrgAmt() {
+    AdjudicationComponent adjudication =
+        TransformerTestUtilsV2.findAdjudicationByCategory(
+            "https://bluebutton.cms.gov/resources/variables/rev_cntr_tot_chrg_amt",
+            eob.getItemFirstRep().getAdjudication());
+
+    AdjudicationComponent compare =
+        new AdjudicationComponent()
+            .setCategory(
+                new CodeableConcept()
+                    .setCoding(
+                        Arrays.asList(
+                            new Coding(
+                                "http://terminology.hl7.org/CodeSystem/adjudication",
+                                "submitted",
+                                "Submitted Amount"),
+                            new Coding(
+                                "https://bluebutton.cms.gov/resources/codesystem/adjudication",
+                                "https://bluebutton.cms.gov/resources/variables/rev_cntr_tot_chrg_amt",
+                                "Revenue Center Total Charge Amount"))))
+            .setAmount(
+                new Money().setValue(999.85).setCurrency(TransformerConstants.CODED_MONEY_USD));
+
+    Assert.assertTrue(compare.equalsDeep(adjudication));
+  }
+
+  @Test
+  public void shouldHaveLineItemAdjudicationRevCntrNcvrdChrgAmt() {
+    AdjudicationComponent adjudication =
+        TransformerTestUtilsV2.findAdjudicationByCategory(
+            "https://bluebutton.cms.gov/resources/variables/rev_cntr_ncvrd_chrg_amt",
+            eob.getItemFirstRep().getAdjudication());
+
+    AdjudicationComponent compare =
+        new AdjudicationComponent()
+            .setCategory(
+                new CodeableConcept()
+                    .setCoding(
+                        Arrays.asList(
+                            new Coding(
+                                "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBAdjudication",
+                                "noncovered",
+                                "Noncovered"),
+                            new Coding(
+                                "https://bluebutton.cms.gov/resources/codesystem/adjudication",
+                                "https://bluebutton.cms.gov/resources/variables/rev_cntr_ncvrd_chrg_amt",
+                                "Revenue Center Non-Covered Charge Amount"))))
+            .setAmount(new Money().setValue(134).setCurrency(TransformerConstants.CODED_MONEY_USD));
+
+    Assert.assertTrue(compare.equalsDeep(adjudication));
+  }
+
+  @Test
+  public void shouldHaveLineItemAdjudicationRevCntrBloddDdctblAmt() {
+    AdjudicationComponent adjudication =
+        TransformerTestUtilsV2.findAdjudicationByCategory(
+            "https://bluebutton.cms.gov/resources/variables/rev_cntr_blood_ddctbl_amt",
+            eob.getItemFirstRep().getAdjudication());
+
+    AdjudicationComponent compare =
+        new AdjudicationComponent()
+            .setCategory(
+                new CodeableConcept()
+                    .setCoding(
+                        Arrays.asList(
+                            new Coding(
+                                "http://terminology.hl7.org/CodeSystem/adjudication",
+                                "deductible",
+                                "Deductible"),
+                            new Coding(
+                                "https://bluebutton.cms.gov/resources/codesystem/adjudication",
+                                "https://bluebutton.cms.gov/resources/variables/rev_cntr_blood_ddctbl_amt",
+                                "Revenue Center Blood Deductible Amount"))))
+            .setAmount(
+                new Money().setValue(10.45).setCurrency(TransformerConstants.CODED_MONEY_USD));
+
+    Assert.assertTrue(compare.equalsDeep(adjudication));
+  }
+
+  @Test
+  public void shouldHaveLineItemAdjudicationRevCntrCashDdctblAmt() {
+    AdjudicationComponent adjudication =
+        TransformerTestUtilsV2.findAdjudicationByCategory(
+            "https://bluebutton.cms.gov/resources/variables/rev_cntr_cash_ddctbl_amt",
+            eob.getItemFirstRep().getAdjudication());
+
+    AdjudicationComponent compare =
+        new AdjudicationComponent()
+            .setCategory(
+                new CodeableConcept()
+                    .setCoding(
+                        Arrays.asList(
+                            new Coding(
+                                "http://terminology.hl7.org/CodeSystem/adjudication",
+                                "deductible",
+                                "Deductible"),
+                            new Coding(
+                                "https://bluebutton.cms.gov/resources/codesystem/adjudication",
+                                "https://bluebutton.cms.gov/resources/variables/rev_cntr_cash_ddctbl_amt",
+                                "Revenue Center Cash Deductible Amount"))))
+            .setAmount(
+                new Money().setValue(12.89).setCurrency(TransformerConstants.CODED_MONEY_USD));
+
+    Assert.assertTrue(compare.equalsDeep(adjudication));
+  }
+
+  @Test
+  public void shouldHaveLineItemAdjudicationRevCntrCoinsrncWgeAdjstdC() {
+    AdjudicationComponent adjudication =
+        TransformerTestUtilsV2.findAdjudicationByCategory(
+            "https://bluebutton.cms.gov/resources/variables/rev_cntr_coinsrnc_wge_adjstd_c",
+            eob.getItemFirstRep().getAdjudication());
+
+    AdjudicationComponent compare =
+        new AdjudicationComponent()
+            .setCategory(
+                new CodeableConcept()
+                    .setCoding(
+                        Arrays.asList(
+                            new Coding(
+                                "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBAdjudication",
+                                "coinsurance",
+                                "Co-insurance"),
+                            new Coding(
+                                "https://bluebutton.cms.gov/resources/codesystem/adjudication",
+                                "https://bluebutton.cms.gov/resources/variables/rev_cntr_coinsrnc_wge_adjstd_c",
+                                "Revenue Center Coinsurance/Wage Adjusted Coinsurance Amount"))))
+            .setAmount(
+                new Money().setValue(15.23).setCurrency(TransformerConstants.CODED_MONEY_USD));
+
+    Assert.assertTrue(compare.equalsDeep(adjudication));
+  }
+
+  @Test
+  public void shouldHaveLineItemAdjudicationRevCntrRdcdCoinsrncAmt() {
+    AdjudicationComponent adjudication =
+        TransformerTestUtilsV2.findAdjudicationByCategory(
+            "https://bluebutton.cms.gov/resources/variables/rev_cntr_rdcd_coinsrnc_amt",
+            eob.getItemFirstRep().getAdjudication());
+
+    AdjudicationComponent compare =
+        new AdjudicationComponent()
+            .setCategory(
+                new CodeableConcept()
+                    .setCoding(
+                        Arrays.asList(
+                            new Coding(
+                                "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBAdjudication",
+                                "coinsurance",
+                                "Co-insurance"),
+                            new Coding(
+                                "https://bluebutton.cms.gov/resources/codesystem/adjudication",
+                                "https://bluebutton.cms.gov/resources/variables/rev_cntr_rdcd_coinsrnc_amt",
+                                "Revenue Center Reduced Coinsurance Amount"))))
+            .setAmount(
+                // Because of the .00, this has to be specified as a string or it will only have
+                // .0 and fail
+                new Money()
+                    .setValueElement(new DecimalType("11.00"))
+                    .setCurrency(TransformerConstants.CODED_MONEY_USD));
+
+    Assert.assertTrue(compare.equalsDeep(adjudication));
+  }
+
+  @Test
+  public void shouldHaveLineItemAdjudicationRevCntr1stMspPdAmt() {
+    AdjudicationComponent adjudication =
+        TransformerTestUtilsV2.findAdjudicationByCategory(
+            "https://bluebutton.cms.gov/resources/variables/rev_cntr_1st_msp_pd_amt",
+            eob.getItemFirstRep().getAdjudication());
+
+    AdjudicationComponent compare =
+        new AdjudicationComponent()
+            .setCategory(
+                new CodeableConcept()
+                    .setCoding(
+                        Arrays.asList(
+                            new Coding(
+                                "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBAdjudication",
+                                "priorpayerpaid",
+                                "Prior payer paid"),
+                            new Coding(
+                                "https://bluebutton.cms.gov/resources/codesystem/adjudication",
+                                "https://bluebutton.cms.gov/resources/variables/rev_cntr_1st_msp_pd_amt",
+                                "Revenue Center 1st Medicare Secondary Payer (MSP) Paid Amount"))))
+            .setAmount(new Money().setValue(0).setCurrency(TransformerConstants.CODED_MONEY_USD));
+
+    Assert.assertTrue(compare.equalsDeep(adjudication));
+  }
+
+  @Test
+  public void shouldHaveLineItemAdjudicationRevCntr2ndMspPdAmt() {
+    AdjudicationComponent adjudication =
+        TransformerTestUtilsV2.findAdjudicationByCategory(
+            "https://bluebutton.cms.gov/resources/variables/rev_cntr_2nd_msp_pd_amt",
+            eob.getItemFirstRep().getAdjudication());
+
+    AdjudicationComponent compare =
+        new AdjudicationComponent()
+            .setCategory(
+                new CodeableConcept()
+                    .setCoding(
+                        Arrays.asList(
+                            new Coding(
+                                "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBAdjudication",
+                                "priorpayerpaid",
+                                "Prior payer paid"),
+                            new Coding(
+                                "https://bluebutton.cms.gov/resources/codesystem/adjudication",
+                                "https://bluebutton.cms.gov/resources/variables/rev_cntr_2nd_msp_pd_amt",
+                                "Revenue Center 2nd Medicare Secondary Payer (MSP) Paid Amount"))))
+            .setAmount(new Money().setValue(0).setCurrency(TransformerConstants.CODED_MONEY_USD));
+
+    Assert.assertTrue(compare.equalsDeep(adjudication));
+  }
+
+  @Test
+  public void shouldHaveLineItemAdjudicationRevCntrPrvdrPmtAmt() {
+    AdjudicationComponent adjudication =
+        TransformerTestUtilsV2.findAdjudicationByCategory(
+            "https://bluebutton.cms.gov/resources/variables/rev_cntr_prvdr_pmt_amt",
+            eob.getItemFirstRep().getAdjudication());
+
+    AdjudicationComponent compare =
+        new AdjudicationComponent()
+            .setCategory(
+                new CodeableConcept()
+                    .setCoding(
+                        Arrays.asList(
+                            new Coding(
+                                "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBAdjudication",
+                                "paidtoprovider",
+                                "Paid to provider"),
+                            new Coding(
+                                "https://bluebutton.cms.gov/resources/codesystem/adjudication",
+                                "https://bluebutton.cms.gov/resources/variables/rev_cntr_prvdr_pmt_amt",
+                                "Revenue Center (Medicare) Provider Payment Amount"))))
+            .setAmount(new Money().setValue(200).setCurrency(TransformerConstants.CODED_MONEY_USD));
+
+    Assert.assertTrue(compare.equalsDeep(adjudication));
+  }
+
+  @Test
+  public void shouldHaveLineItemAdjudicationRevCntrBenePmtAmt() {
+    AdjudicationComponent adjudication =
+        TransformerTestUtilsV2.findAdjudicationByCategory(
+            "https://bluebutton.cms.gov/resources/variables/rev_cntr_bene_pmt_amt",
+            eob.getItemFirstRep().getAdjudication());
+
+    AdjudicationComponent compare =
+        new AdjudicationComponent()
+            .setCategory(
+                new CodeableConcept()
+                    .setCoding(
+                        Arrays.asList(
+                            new Coding(
+                                "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBAdjudication",
+                                "paidtopatient",
+                                "Paid to patient"),
+                            new Coding(
+                                "https://bluebutton.cms.gov/resources/codesystem/adjudication",
+                                "https://bluebutton.cms.gov/resources/variables/rev_cntr_bene_pmt_amt",
+                                "Revenue Center Payment Amount to Beneficiary"))))
+            .setAmount(new Money().setValue(300).setCurrency(TransformerConstants.CODED_MONEY_USD));
+
+    Assert.assertTrue(compare.equalsDeep(adjudication));
+  }
+
+  @Test
+  public void shouldHaveLineItemAdjudicationRevCntrPtntRspnbltyPmt() {
+    AdjudicationComponent adjudication =
+        TransformerTestUtilsV2.findAdjudicationByCategory(
+            "https://bluebutton.cms.gov/resources/variables/rev_cntr_ptnt_rspnsblty_pmt",
+            eob.getItemFirstRep().getAdjudication());
+
+    AdjudicationComponent compare =
+        new AdjudicationComponent()
+            .setCategory(
+                new CodeableConcept()
+                    .setCoding(
+                        Arrays.asList(
+                            new Coding(
+                                "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBAdjudication",
+                                "paidbypatient",
+                                "Paid by patient"),
+                            new Coding(
+                                "https://bluebutton.cms.gov/resources/codesystem/adjudication",
+                                "https://bluebutton.cms.gov/resources/variables/rev_cntr_ptnt_rspnsblty_pmt",
+                                "Revenue Center Patient Responsibility Payment Amount"))))
+            .setAmount(new Money().setValue(500).setCurrency(TransformerConstants.CODED_MONEY_USD));
+
+    Assert.assertTrue(compare.equalsDeep(adjudication));
+  }
+
+  @Test
+  public void shouldHaveLineItemAdjudicationRevCntrPmtAmtAmt() {
+    AdjudicationComponent adjudication =
+        TransformerTestUtilsV2.findAdjudicationByCategory(
+            "https://bluebutton.cms.gov/resources/variables/rev_cntr_pmt_amt_amt",
+            eob.getItemFirstRep().getAdjudication());
+
+    AdjudicationComponent compare =
+        new AdjudicationComponent()
+            .setCategory(
+                new CodeableConcept()
+                    .setCoding(
+                        Arrays.asList(
+                            new Coding(
+                                "http://terminology.hl7.org/CodeSystem/adjudication",
+                                "submitted",
+                                "Submitted Amount"),
+                            new Coding(
+                                "https://bluebutton.cms.gov/resources/codesystem/adjudication",
+                                "https://bluebutton.cms.gov/resources/variables/rev_cntr_pmt_amt_amt",
+                                "Revenue Center (Medicare) Payment Amount"))))
+            .setAmount(
+                new Money().setValue(5000).setCurrency(TransformerConstants.CODED_MONEY_USD));
+
+    Assert.assertTrue(compare.equalsDeep(adjudication));
+  }
+
+  @Test
+  public void shouldHaveClmTotChrgAmtTotal() {
+    // Only one so just pull it directly and compare
+    TotalComponent total = eob.getTotalFirstRep();
+
+    TotalComponent compare =
+        new TotalComponent()
+            .setCategory(
+                new CodeableConcept()
+                    .setCoding(
+                        Arrays.asList(
+                            new Coding(
+                                "http://terminology.hl7.org/CodeSystem/adjudication",
+                                "submitted",
+                                "Submitted Amount"),
+                            new Coding(
+                                "https://bluebutton.cms.gov/resources/codesystem/adjudication",
+                                "https://bluebutton.cms.gov/resources/variables/clm_tot_chrg_amt",
+                                "Claim Total Charge Amount"))))
+            .setAmount(
+                new Money().setValue(8888.85).setCurrency(TransformerConstants.CODED_MONEY_USD));
+
+    Assert.assertTrue(compare.equalsDeep(total));
+  }
+
+  /** Payment */
+  @Test
+  public void shouldHavePayment() {
+    PaymentComponent compare =
+        new PaymentComponent()
+            .setAmount(
+                new Money().setValue(693.11).setCurrency(TransformerConstants.CODED_MONEY_USD));
+
+    Assert.assertTrue(compare.equalsDeep(eob.getPayment()));
+  }
+
+  /** Total */
+  @Test
+  public void shouldHaveTotal() {
+    Assert.assertEquals(1, eob.getTotal().size());
+  }
+
+  /** Benefit Balance */
+  @Test
+  public void shouldHaveBenefitBalance() {
+    Assert.assertEquals(1, eob.getBenefitBalance().size());
+
+    // Test Category here
+    CodeableConcept compare =
+        new CodeableConcept()
+            .setCoding(
+                Arrays.asList(
+                    new Coding(
+                        "http://terminology.hl7.org/CodeSystem/ex-benefitcategory",
+                        "1",
+                        "Medical Care")));
+
+    Assert.assertTrue(compare.equalsDeep(eob.getBenefitBalanceFirstRep().getCategory()));
+  }
+
+  @Test
+  public void shouldHaveBenefitBalanceFinancial() {
+    Assert.assertEquals(7, eob.getBenefitBalanceFirstRep().getFinancial().size());
+  }
+
+  @Test
+  public void shouldHaveNchProfnlCmpntChrgAmtFinancial() {
+    BenefitComponent benefit =
+        TransformerTestUtilsV2.findFinancial(
+            "https://bluebutton.cms.gov/resources/variables/nch_profnl_cmpnt_chrg_amt",
+            eob.getBenefitBalanceFirstRep().getFinancial());
+
+    BenefitComponent compare =
+        new BenefitComponent()
+            .setType(
+                new CodeableConcept()
+                    .setCoding(
+                        Arrays.asList(
+                            new Coding(
+                                "https://bluebutton.cms.gov/resources/codesystem/benefit-balance",
+                                "https://bluebutton.cms.gov/resources/variables/nch_profnl_cmpnt_chrg_amt",
+                                "Professional Component Charge Amount"))))
+            .setUsed(new Money().setValue(66.89).setCurrency(TransformerConstants.CODED_MONEY_USD));
+
+    Assert.assertTrue(compare.equalsDeep(benefit));
+  }
+
+  @Test
+  public void shouldHaveNchBenePtbDdctblAmtFinancial() {
+    BenefitComponent benefit =
+        TransformerTestUtilsV2.findFinancial(
+            "https://bluebutton.cms.gov/resources/variables/nch_bene_ptb_ddctbl_amt",
+            eob.getBenefitBalanceFirstRep().getFinancial());
+
+    BenefitComponent compare =
+        new BenefitComponent()
+            .setType(
+                new CodeableConcept()
+                    .setCoding(
+                        Arrays.asList(
+                            new Coding(
+                                "https://bluebutton.cms.gov/resources/codesystem/benefit-balance",
+                                "https://bluebutton.cms.gov/resources/variables/nch_bene_ptb_ddctbl_amt",
+                                "NCH Beneficiary Part B Deductible Amount"))))
+            .setUsed(
+                new Money()
+                    .setValueElement(new DecimalType("112.00"))
+                    .setCurrency(TransformerConstants.CODED_MONEY_USD));
+
+    Assert.assertTrue(compare.equalsDeep(benefit));
+  }
+
+  @Test
+  public void shouldHaveNchBenePtbCoinsrncAmtFinancial() {
+    BenefitComponent benefit =
+        TransformerTestUtilsV2.findFinancial(
+            "https://bluebutton.cms.gov/resources/variables/nch_bene_ptb_coinsrnc_amt",
+            eob.getBenefitBalanceFirstRep().getFinancial());
+
+    BenefitComponent compare =
+        new BenefitComponent()
+            .setType(
+                new CodeableConcept()
+                    .setCoding(
+                        Arrays.asList(
+                            new Coding(
+                                "https://bluebutton.cms.gov/resources/codesystem/benefit-balance",
+                                "https://bluebutton.cms.gov/resources/variables/nch_bene_ptb_coinsrnc_amt",
+                                "NCH Beneficiary Part B Coinsurance Amount"))))
+            .setUsed(
+                new Money().setValue(175.73).setCurrency(TransformerConstants.CODED_MONEY_USD));
+
+    Assert.assertTrue(compare.equalsDeep(benefit));
+  }
+
+  @Test
+  public void shouldHaveClmOpPrvdrPmtAmtFinancial() {
+    BenefitComponent benefit =
+        TransformerTestUtilsV2.findFinancial(
+            "https://bluebutton.cms.gov/resources/variables/clm_op_prvdr_pmt_amt",
+            eob.getBenefitBalanceFirstRep().getFinancial());
+
+    BenefitComponent compare =
+        new BenefitComponent()
+            .setType(
+                new CodeableConcept()
+                    .setCoding(
+                        Arrays.asList(
+                            new Coding(
+                                "https://bluebutton.cms.gov/resources/codesystem/benefit-balance",
+                                "https://bluebutton.cms.gov/resources/variables/clm_op_prvdr_pmt_amt",
+                                "Claim Outpatient Provider Payment Amount"))))
+            .setUsed(
+                new Money().setValue(693.92).setCurrency(TransformerConstants.CODED_MONEY_USD));
+
+    Assert.assertTrue(compare.equalsDeep(benefit));
+  }
+
+  @Test
+  public void shouldHaveClmOpBenePmtAmtFinancial() {
+    BenefitComponent benefit =
+        TransformerTestUtilsV2.findFinancial(
+            "https://bluebutton.cms.gov/resources/variables/clm_op_bene_pmt_amt",
+            eob.getBenefitBalanceFirstRep().getFinancial());
+
+    BenefitComponent compare =
+        new BenefitComponent()
+            .setType(
+                new CodeableConcept()
+                    .setCoding(
+                        Arrays.asList(
+                            new Coding(
+                                "https://bluebutton.cms.gov/resources/codesystem/benefit-balance",
+                                "https://bluebutton.cms.gov/resources/variables/clm_op_bene_pmt_amt",
+                                "Claim Outpatient Payment Amount to Beneficiary"))))
+            .setUsed(
+                new Money()
+                    .setValueElement(new DecimalType("44.00"))
+                    .setCurrency(TransformerConstants.CODED_MONEY_USD));
+
+    Assert.assertTrue(compare.equalsDeep(benefit));
+  }
+
+  @Test
+  public void shouldHaveNchBeneBloodDdctblLbltyAmFinancial() {
+    BenefitComponent benefit =
+        TransformerTestUtilsV2.findFinancial(
+            "https://bluebutton.cms.gov/resources/variables/nch_bene_blood_ddctbl_lblty_am",
+            eob.getBenefitBalanceFirstRep().getFinancial());
+
+    BenefitComponent compare =
+        new BenefitComponent()
+            .setType(
+                new CodeableConcept()
+                    .setCoding(
+                        Arrays.asList(
+                            new Coding(
+                                "https://bluebutton.cms.gov/resources/codesystem/benefit-balance",
+                                "https://bluebutton.cms.gov/resources/variables/nch_bene_blood_ddctbl_lblty_am",
+                                "NCH Beneficiary Blood Deductible Liability Amount"))))
+            .setUsed(
+                new Money()
+                    .setValueElement(new DecimalType("6.00"))
+                    .setCurrency(TransformerConstants.CODED_MONEY_USD));
+
+    Assert.assertTrue(compare.equalsDeep(benefit));
+  }
+
+  @Test
+  public void shouldHavePrpayAmtFinancial() {
+    BenefitComponent benefit =
+        TransformerTestUtilsV2.findFinancial(
+            "https://bluebutton.cms.gov/resources/variables/prpayamt",
+            eob.getBenefitBalanceFirstRep().getFinancial());
+
+    BenefitComponent compare =
+        new BenefitComponent()
+            .setType(
+                new CodeableConcept()
+                    .setCoding(
+                        Arrays.asList(
+                            new Coding(
+                                "https://bluebutton.cms.gov/resources/codesystem/benefit-balance",
+                                "https://bluebutton.cms.gov/resources/variables/prpayamt",
+                                "NCH Primary Payer (if not Medicare) Claim Paid Amount"))))
+            .setUsed(
+                new Money()
+                    .setValueElement(new DecimalType("11.00"))
+                    .setCurrency(TransformerConstants.CODED_MONEY_USD));
+
+    Assert.assertTrue(compare.equalsDeep(benefit));
+  }
 
   /**
    * Serializes the EOB and prints to the command line
@@ -72,33 +1216,5 @@ public final class OutpatientClaimTransformerV2Test {
         OutpatientClaimTransformerV2.transform(
             new MetricRegistry(), generateClaim(), Optional.of(false));
     System.out.println(fhirContext.newJsonParser().encodeResourceToString(eob));
-  }
-
-  /**
-   * Verifies that the {@link ExplanationOfBenefit} "looks like" it should, if it were produced from
-   * the specified {@link InpatientClaim}.
-   *
-   * @param claim the {@link OutpatientClaim} that the {@link ExplanationOfBenefit} was generated
-   *     from
-   * @param eob the {@link ExplanationOfBenefit} that was generated from the specified {@link
-   *     InpatientClaim}
-   * @throws FHIRException (indicates test failure)
-   */
-  static void assertMatches(OutpatientClaim claim, ExplanationOfBenefit eob) throws FHIRException {
-    // Test to ensure group level fields between all claim types match
-    TransformerTestUtilsV2.assertEobCommonClaimHeaderData(
-        eob,
-        claim.getClaimId(),
-        claim.getBeneficiaryId(),
-        ClaimTypeV2.OUTPATIENT,
-        claim.getClaimGroupId().toPlainString(),
-        MedicareSegment.PART_B,
-        Optional.of(claim.getDateFrom()),
-        Optional.of(claim.getDateThrough()),
-        Optional.of(claim.getPaymentAmount()),
-        claim.getFinalAction());
-
-    // TODO: Double check the assumed value
-    Assert.assertEquals(5, eob.getDiagnosis().size());
   }
 }

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/TransformerTestUtilsV2.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/TransformerTestUtilsV2.java
@@ -1308,6 +1308,30 @@ public final class TransformerTestUtilsV2 {
   }
 
   /**
+   * Finds an {@link AdjudicationComponent} using a code in the reason
+   *
+   * @param code
+   * @param components
+   * @return
+   */
+  static AdjudicationComponent findAdjudicationByReason(
+      String code, List<AdjudicationComponent> components) {
+    Optional<AdjudicationComponent> adjudication =
+        components.stream()
+            .filter(
+                cmp ->
+                    cmp.getReason().getCoding().stream()
+                            .filter(c -> code.equals(c.getCode()))
+                            .count()
+                        > 0)
+            .findFirst();
+
+    Assert.assertTrue(adjudication.isPresent());
+
+    return adjudication.get();
+  }
+
+  /**
    * Finds a {@link BenefitComponent} in a list based on a Code in the component's Type
    *
    * @param code


### PR DESCRIPTION
### Change Details
This PR addresses [BFD-745](https://jira.cms.gov/browse/BFD-745). It adds unit tests for the `OutpatientClaimTransformerV2` in the style created in #521.

### Acceptance Validation
- Tests all pass
- The test coverage of serialized Sample A Outpatient Claims is complete enough for our purposes

### Feedback Requested

### External References
- [BFD-745](https://jira.cms.gov/browse/BFD-745)

### Security Implications

- [ ] new software dependencies
- [ ] altered security controls
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
