### PR TITLE
[BFD-778] Upgrade Flyway and HSQL

### DIFF
--- a/apps/bfd-model/bfd-model-rif/pom.xml
+++ b/apps/bfd-model/bfd-model-rif/pom.xml
@@ -137,7 +137,7 @@
 				class. -->
 			<groupId>org.flywaydb</groupId>
 			<artifactId>flyway-core</artifactId>
-			<version>4.2.0</version>
+			<version>7.8.1</version>
 		</dependency>
 
 		<dependency>

--- a/apps/bfd-model/bfd-model-rif/src/main/java/gov/cms/bfd/model/rif/schema/DatabaseSchemaManager.java
+++ b/apps/bfd-model/bfd-model-rif/src/main/java/gov/cms/bfd/model/rif/schema/DatabaseSchemaManager.java
@@ -52,7 +52,7 @@ public final class DatabaseSchemaManager {
     flywayBuilder.cleanDisabled(true);
 
     // The default name for the schema table changed in Flyway 5.
-    // We need to specify the original table name for backwards compatability.
+    // We need to specify the original table name for backwards compatibility.
     flywayBuilder.table("schema_version");
 
     Flyway flyway = flywayBuilder.load();

--- a/apps/bfd-model/bfd-model-rif/src/main/java/gov/cms/bfd/model/rif/schema/DatabaseSchemaManager.java
+++ b/apps/bfd-model/bfd-model-rif/src/main/java/gov/cms/bfd/model/rif/schema/DatabaseSchemaManager.java
@@ -7,12 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.sql.DataSource;
 import org.flywaydb.core.Flyway;
-import org.flywaydb.core.internal.dbsupport.DbSupport;
-import org.flywaydb.core.internal.dbsupport.DbSupportFactory;
-import org.flywaydb.core.internal.dbsupport.SqlScript;
-import org.flywaydb.core.internal.util.PlaceholderReplacer;
-import org.flywaydb.core.internal.util.jdbc.JdbcUtils;
-import org.flywaydb.core.internal.util.scanner.classpath.ClassPathResource;
+import org.flywaydb.core.api.configuration.FluentConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,41 +31,28 @@ public final class DatabaseSchemaManager {
   public static void createOrUpdateSchema(DataSource dataSource) {
     LOGGER.info("Schema create/upgrade: running...");
 
-    Flyway flyway = new Flyway();
-
-    // Trying to prevent career-limiting mistakes.
-    flyway.setCleanDisabled(true);
-
-    flyway.setDataSource(dataSource);
-    flyway.setPlaceholders(createScriptPlaceholdersMap(dataSource));
+    Flyway flyway = createFlyway(dataSource);
     flyway.migrate();
 
     LOGGER.info("Schema create/upgrade: complete.");
   }
 
   /**
-   * <strong>WARNING:</strong> This method should never be run against a production database that is
-   * in-service. Any queries against the database will take over ten minutes to complete. This
-   * method is only intended for (very careful) use when initially loading an empty database. Drops
-   * all indexes in the specified database.
-   *
-   * @param dataSource the JDBC {@link DataSource} for the database whose schema should be modified
+   * @param dataSource the {@link DataSource} to run {@link Flyway} against
+   * @return a {@link Flyway} instance that can be used for the specified {@link DataSource}
    */
-  public static void dropIndexes(DataSource dataSource) {
-    Connection connectionMetaDataTable = JdbcUtils.openConnection(dataSource);
-    DbSupport dbSupport = DbSupportFactory.createDbSupport(connectionMetaDataTable, true);
+  private static Flyway createFlyway(DataSource dataSource) {
+    FluentConfiguration flywayBuilder = Flyway.configure().dataSource(dataSource);
+    flywayBuilder.placeholders(createScriptPlaceholdersMap(dataSource));
 
-    String source =
-        new ClassPathResource(
-                "db/scripts/Drop_all_constraints.sql", DatabaseSchemaManager.class.getClassLoader())
-            .loadAsString("UTF-8");
-    source =
-        new PlaceholderReplacer(createScriptPlaceholdersMap(dataSource), "${", "}")
-            .replacePlaceholders(source);
+    // Seems to be required in our tests for some reason that I couldn't debug.
+    flywayBuilder.connectRetries(5);
 
-    SqlScript disableConstraintsScript = new SqlScript(source, dbSupport);
+    // Trying to prevent career-limiting mistakes.
+    flywayBuilder.cleanDisabled(true);
 
-    disableConstraintsScript.execute(dbSupport.getJdbcTemplate());
+    Flyway flyway = flywayBuilder.load();
+    return flyway;
   }
 
   /**

--- a/apps/bfd-model/bfd-model-rif/src/main/java/gov/cms/bfd/model/rif/schema/DatabaseSchemaManager.java
+++ b/apps/bfd-model/bfd-model-rif/src/main/java/gov/cms/bfd/model/rif/schema/DatabaseSchemaManager.java
@@ -51,6 +51,10 @@ public final class DatabaseSchemaManager {
     // Trying to prevent career-limiting mistakes.
     flywayBuilder.cleanDisabled(true);
 
+    // The default name for the schema table changed in Flyway 5.
+    // We need to specify the original table name for backwards compatability.
+    flywayBuilder.table("schema_version");
+
     Flyway flyway = flywayBuilder.load();
     return flyway;
   }

--- a/apps/bfd-model/bfd-model-rif/src/main/java/gov/cms/bfd/model/rif/schema/DatabaseTestHelper.java
+++ b/apps/bfd-model/bfd-model-rif/src/main/java/gov/cms/bfd/model/rif/schema/DatabaseTestHelper.java
@@ -105,8 +105,7 @@ public final class DatabaseTestHelper {
     }
 
     // Clean the DB so that it's fresh and ready for a new test case.
-    Flyway flyway = new Flyway();
-    flyway.setDataSource(dataSource);
+    Flyway flyway = Flyway.configure().dataSource(dataSource).connectRetries(5).load();
     flyway.clean();
     return dataSource;
   }

--- a/apps/bfd-model/pom.xml
+++ b/apps/bfd-model/pom.xml
@@ -42,13 +42,6 @@
 				<scope>test</scope>
 			</dependency>
 			<dependency>
-				<!-- In-memory database that is used in some tests to speed things up. -->
-				<groupId>org.hsqldb</groupId>
-				<artifactId>hsqldb</artifactId>
-				<version>2.2.4</version>
-				<scope>test</scope>
-			</dependency>
-			<dependency>
 				<!-- JDBC driver for working with PostgreSQL DBs on Java 8 (JDBC 4.2). -->
 				<groupId>org.postgresql</groupId>
 				<artifactId>postgresql</artifactId>

--- a/apps/pom.xml
+++ b/apps/pom.xml
@@ -220,7 +220,9 @@
 				<!-- In-memory database that is used in some tests to speed things up. -->
 				<groupId>org.hsqldb</groupId>
 				<artifactId>hsqldb</artifactId>
-				<version>2.4.1</version>
+				<!-- The 2.5.x series is the last to support Java 8. -->
+				<version>2.5.2</version>
+				<scope>test</scope>
 			</dependency>
 			<dependency>
 				<!-- Used to provide DB connection pooling. See https://github.com/brettwooldridge/HikariCP 


### PR DESCRIPTION
### Change Details
This PR finishes [BFD-778](https://jira.cms.gov/browse/BFD-778). It upgrades Flyway and HSQL versions. This PR is another attempt following work that was done in #541 and the reversion of that work in #546. After the first attempt we received the following error:
```
org.flywaydb.core.api.FlywayException: Found non-empty schema(s) "public" but no schema history table. Use baseline() or
set baselineOnMigrate to true to initialize the schema history table.
```

This exception occurred because in Flyway v5 the default name of the schema table was changed from `schema_history` to `flyway_schema_history`. This is the  table where Flyway records which migrations it previously applied. Because we are upgrading from Flyway v4 to v7, we need to specify the old table name for backwards compatibility.

This error was not noticed during the first attempt because the tests run a Flyway Clean, which wipes out the database and creates a clean slate.

### Acceptance Validation
- When starting the BFD Server against a database with an existing `schema_history` table created with an older version of Flyway, there should be no Flyway errors in the server log.

### Feedback Requested

### External References
- [BFD-778](https://jira.cms.gov/browse/BFD-778)

### Security Implications
- [ ] new software dependencies
- [ ] altered security controls
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

