### PR TITLE
[BFD-883] Ignore malformed drug codes

### DIFF
--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/TransformerUtilsV2.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/TransformerUtilsV2.java
@@ -1446,20 +1446,24 @@ public final class TransformerUtilsV2 {
       ndcProductsIn.readLine();
       while ((line = ndcProductsIn.readLine()) != null) {
         String ndcProductColumns[] = line.split("\t");
-        String nationalDrugCodeManufacturer =
-            StringUtils.leftPad(
-                ndcProductColumns[1].substring(0, ndcProductColumns[1].indexOf("-")), 5, '0');
-        String nationalDrugCodeIngredient =
-            StringUtils.leftPad(
-                ndcProductColumns[1].substring(
-                    ndcProductColumns[1].indexOf("-") + 1, ndcProductColumns[1].length()),
-                4,
-                '0');
-        // ndcProductColumns[3] - Proprietary Name
-        // ndcProductColumns[13] - Substance Name
-        ndcProductHashMap.put(
-            String.format("%s-%s", nationalDrugCodeManufacturer, nationalDrugCodeIngredient),
-            ndcProductColumns[3] + " - " + ndcProductColumns[13]);
+        try {
+          String nationalDrugCodeManufacturer =
+              StringUtils.leftPad(
+                  ndcProductColumns[1].substring(0, ndcProductColumns[1].indexOf("-")), 5, '0');
+          String nationalDrugCodeIngredient =
+              StringUtils.leftPad(
+                  ndcProductColumns[1].substring(
+                      ndcProductColumns[1].indexOf("-") + 1, ndcProductColumns[1].length()),
+                  4,
+                  '0');
+          // ndcProductColumns[3] - Proprietary Name
+          // ndcProductColumns[13] - Substance Name
+          ndcProductHashMap.put(
+              String.format("%s-%s", nationalDrugCodeManufacturer, nationalDrugCodeIngredient),
+              ndcProductColumns[3] + " - " + ndcProductColumns[13]);
+        } catch (StringIndexOutOfBoundsException e) {
+          continue;
+        }
       }
     } catch (IOException e) {
       throw new UncheckedIOException("Unable to read NDC code data.", e);

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtils.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtils.java
@@ -3090,20 +3090,24 @@ public final class TransformerUtils {
       ndcProductsIn.readLine();
       while ((line = ndcProductsIn.readLine()) != null) {
         String ndcProductColumns[] = line.split("\t");
-        String nationalDrugCodeManufacturer =
-            StringUtils.leftPad(
-                ndcProductColumns[1].substring(0, ndcProductColumns[1].indexOf("-")), 5, '0');
-        String nationalDrugCodeIngredient =
-            StringUtils.leftPad(
-                ndcProductColumns[1].substring(
-                    ndcProductColumns[1].indexOf("-") + 1, ndcProductColumns[1].length()),
-                4,
-                '0');
-        // ndcProductColumns[3] - Proprietary Name
-        // ndcProductColumns[13] - Substance Name
-        ndcProductHashMap.put(
-            String.format("%s-%s", nationalDrugCodeManufacturer, nationalDrugCodeIngredient),
-            ndcProductColumns[3] + " - " + ndcProductColumns[13]);
+        try {
+          String nationalDrugCodeManufacturer =
+              StringUtils.leftPad(
+                  ndcProductColumns[1].substring(0, ndcProductColumns[1].indexOf("-")), 5, '0');
+          String nationalDrugCodeIngredient =
+              StringUtils.leftPad(
+                  ndcProductColumns[1].substring(
+                      ndcProductColumns[1].indexOf("-") + 1, ndcProductColumns[1].length()),
+                  4,
+                  '0');
+          // ndcProductColumns[3] - Proprietary Name
+          // ndcProductColumns[13] - Substance Name
+          ndcProductHashMap.put(
+              String.format("%s-%s", nationalDrugCodeManufacturer, nationalDrugCodeIngredient),
+              ndcProductColumns[3] + " - " + ndcProductColumns[13]);
+        } catch (StringIndexOutOfBoundsException e) {
+          continue;
+        }
       }
     } catch (IOException e) {
       throw new UncheckedIOException("Unable to read NDC code data.", e);


### PR DESCRIPTION
### Change Details
The file fda_products_cp1252.tsv holds codes that the app expects in a certain format. One of the codes did not have a hyphen, which caused unit test failures. This commit ignores malformed ids.

### Acceptance Validation

### Feedback Requested


### External References


- [BFD-883](https://jira.cms.gov/browse/BFD-883)

### Security Implications
- [ ] new software dependencies
- [ ] altered security controls
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
