### PR TITLE
MISC - fixes intermittent IT test failures due to timezone and race conditions

### DIFF
--- a/apps/bfd-pipeline/bfd-pipeline-app/src/test/java/gov/cms/bfd/pipeline/app/PipelineManagerIT.java
+++ b/apps/bfd-pipeline/bfd-pipeline-app/src/test/java/gov/cms/bfd/pipeline/app/PipelineManagerIT.java
@@ -36,7 +36,7 @@ public final class PipelineManagerIT {
     // Start the pipeline against a bucket that doesn't exist.
     MockDataSetMonitorListener listener = new MockDataSetMonitorListener();
     PipelineManager pipeline =
-        new PipelineManager(new MetricRegistry(), new ExtractionOptions("foo"), 1, listener);
+        new PipelineManager(new MetricRegistry(), new ExtractionOptions("foo"), 100, listener);
     pipeline.start();
 
     // Wait for the pipeline to error out.
@@ -63,7 +63,7 @@ public final class PipelineManagerIT {
 
       // Start the pipeline and then stop it.
       MockDataSetMonitorListener listener = new MockDataSetMonitorListener();
-      PipelineManager pipeline = new PipelineManager(new MetricRegistry(), options, 1, listener);
+      PipelineManager pipeline = new PipelineManager(new MetricRegistry(), options, 100, listener);
       pipeline.start();
       Awaitility.await()
           .atMost(Duration.TEN_SECONDS)
@@ -136,7 +136,7 @@ public final class PipelineManagerIT {
 
       // Start the pipeline up.
       MockDataSetMonitorListener listener = new MockDataSetMonitorListener();
-      PipelineManager pipeline = new PipelineManager(new MetricRegistry(), options, 1, listener);
+      PipelineManager pipeline = new PipelineManager(new MetricRegistry(), options, 100, listener);
       pipeline.start();
 
       // Wait for the job to generate events for the three data sets.

--- a/apps/bfd-pipeline/bfd-pipeline-app/src/test/java/gov/cms/bfd/pipeline/app/PipelineManagerIT.java
+++ b/apps/bfd-pipeline/bfd-pipeline-app/src/test/java/gov/cms/bfd/pipeline/app/PipelineManagerIT.java
@@ -36,7 +36,7 @@ public final class PipelineManagerIT {
     // Start the pipeline against a bucket that doesn't exist.
     MockDataSetMonitorListener listener = new MockDataSetMonitorListener();
     PipelineManager pipeline =
-        new PipelineManager(new MetricRegistry(), new ExtractionOptions("foo"), 100, listener);
+        new PipelineManager(new MetricRegistry(), new ExtractionOptions("foo"), 1, listener);
     pipeline.start();
 
     // Wait for the pipeline to error out.
@@ -63,7 +63,7 @@ public final class PipelineManagerIT {
 
       // Start the pipeline and then stop it.
       MockDataSetMonitorListener listener = new MockDataSetMonitorListener();
-      PipelineManager pipeline = new PipelineManager(new MetricRegistry(), options, 100, listener);
+      PipelineManager pipeline = new PipelineManager(new MetricRegistry(), options, 1, listener);
       pipeline.start();
       Awaitility.await()
           .atMost(Duration.TEN_SECONDS)
@@ -136,7 +136,7 @@ public final class PipelineManagerIT {
 
       // Start the pipeline up.
       MockDataSetMonitorListener listener = new MockDataSetMonitorListener();
-      PipelineManager pipeline = new PipelineManager(new MetricRegistry(), options, 100, listener);
+      PipelineManager pipeline = new PipelineManager(new MetricRegistry(), options, 1, listener);
       pipeline.start();
 
       // Wait for the job to generate events for the three data sets.

--- a/apps/bfd-pipeline/bfd-pipeline-ccw-rif/pom.xml
+++ b/apps/bfd-pipeline/bfd-pipeline-ccw-rif/pom.xml
@@ -161,6 +161,11 @@
 							<goal>integration-test</goal>
 							<goal>verify</goal>
 						</goals>
+						<configuration>
+							<environmentVariables>
+								<TZ>UTC</TZ>
+							</environmentVariables>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/apps/bfd-server/bfd-server-war/pom.xml
+++ b/apps/bfd-server/bfd-server-war/pom.xml
@@ -379,6 +379,10 @@
 
 							<!-- Don't start/stop the server if the ITs are being skipped. -->
 							<skip>${skipITs}</skip>
+
+                                                        <environmentVariables>
+                                                                <TZ>UTC</TZ>
+                                                        </environmentVariables>
 						</configuration>
 					</execution>
 					<execution>
@@ -414,6 +418,11 @@
 							<goal>integration-test</goal>
 							<goal>verify</goal>
 						</goals>
+                                                <configuration>
+                                                        <environmentVariables>
+                                                                <TZ>UTC</TZ>
+                                                        </environmentVariables>
+                                                </configuration>
 					</execution>
 				</executions>
 			</plugin>
@@ -456,6 +465,9 @@
 									<value>${http.nonProxyHosts}</value>
 								</systemProperty>
 							</systemProperties>
+                                                        <environmentVariables>
+                                                                <TZ>UTC</TZ>
+                                                        </environmentVariables>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
### Change Details

This PR addresses two issues that cause intermittent IT test failures:

- ~~`PipelineManagerIT` sometimes fails due to a `RejectedExecutionException`.  This was caused by the extremely short (1ms) execution interval leading to a race condition as the test shuts down the `ScheduledExcecutor`.  Increasing that to 100ms makes the race condition far less likely to happen.~~
- Various tests in `bfd-server-war` and `bfd-pipeline-ccw-rif` fail with `lastUpdated` related error messages.  These are due to the logic in the tests assuming that the timezone is set to UTC.  Adding a `TZ` environment variable to the execution environment in the pom.xml assures the timezone is set as expected by the test.

### Acceptance Validation

Unit tests should pass more reliably than before.

### Feedback Requested

Nothing specific.

### External References

None.

### Security Implications

- [ ] new software dependencies

no

- [ ] altered security controls

no

- [ ] new data stored or transmitted

no

- [ ] security checklist is completed for this change

no

- [ ] requires more information or team discussion to evaluate security implications

no
