### PR TITLE
DCGEO-88 (DRAFT): RDA API FISS/MCS claim schema updates

### DIFF
--- a/apps/bfd-model/bfd-model-rda/pom.xml
+++ b/apps/bfd-model/bfd-model-rda/pom.xml
@@ -39,6 +39,31 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <!-- provides DatabaseSchemaManager to apply flyway migrations -->
+            <groupId>gov.cms.bfd</groupId>
+            <artifactId>bfd-model-rif</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <!-- In-memory database that can be used for testing. -->
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <!-- Logback is used as the logging target/backend for SLF4J during tests:
+                    all logging events will be sent to it. -->
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/apps/bfd-model/bfd-model-rda/src/main/java/gov/cms/bfd/model/rda/PreAdjFissClaim.java
+++ b/apps/bfd-model/bfd-model-rda/src/main/java/gov/cms/bfd/model/rda/PreAdjFissClaim.java
@@ -23,9 +23,8 @@ import lombok.experimental.FieldNameConstants;
 @Setter
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @FieldNameConstants
-@Table(name = "`FissClaims`", schema = "pre_adj")
+@Table(name = "`FissClaims`", schema = "`pre_adj`")
 public class PreAdjFissClaim {
-
   @Id
   @Column(name = "`dcn`", length = 23, nullable = false)
   @EqualsAndHashCode.Include
@@ -46,7 +45,7 @@ public class PreAdjFissClaim {
   @Column(name = "`medaProvId`", length = 13)
   private String medaProvId;
 
-  @Column(name = "`totalChargeAmount`")
+  @Column(name = "`totalChargeAmount`", columnDefinition = "decimal(11,2)")
   private BigDecimal totalChargeAmount;
 
   @Column(name = "`receivedDate`")
@@ -76,10 +75,32 @@ public class PreAdjFissClaim {
   @Column(name = "`lastUpdated`")
   private Instant lastUpdated;
 
+  @Column(name = "`pracLocAddr1`")
+  private String pracLocAddr1;
+
+  @Column(name = "`pracLocAddr2`")
+  private String pracLocAddr2;
+
+  @Column(name = "`pracLocCity`")
+  private String pracLocCity;
+
+  @Column(name = "`pracLocState`", length = 2)
+  private String pracLocState;
+
+  @Column(name = "`pracLocZip`", length = 15)
+  private String pracLocZip;
+
   @OneToMany(
       mappedBy = "dcn",
       fetch = FetchType.EAGER,
       orphanRemoval = true,
       cascade = CascadeType.ALL)
   private Set<PreAdjFissProcCode> procCodes = new HashSet<>();
+
+  @OneToMany(
+      mappedBy = "dcn",
+      fetch = FetchType.EAGER,
+      orphanRemoval = true,
+      cascade = CascadeType.ALL)
+  private Set<PreAdjFissDiagnosisCode> diagCodes = new HashSet<>();
 }

--- a/apps/bfd-model/bfd-model-rda/src/main/java/gov/cms/bfd/model/rda/PreAdjFissDiagnosisCode.java
+++ b/apps/bfd-model/bfd-model-rda/src/main/java/gov/cms/bfd/model/rda/PreAdjFissDiagnosisCode.java
@@ -1,8 +1,6 @@
 package gov.cms.bfd.model.rda;
 
 import java.io.Serializable;
-import java.time.Instant;
-import java.time.LocalDate;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -16,15 +14,14 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.FieldNameConstants;
 
-/** JPA class for the FissProcCodes table */
 @Entity
 @Getter
 @Setter
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @FieldNameConstants
 @IdClass(PreAdjFissProcCode.PK.class)
-@Table(name = "`FissProcCodes`", schema = "`pre_adj`")
-public class PreAdjFissProcCode {
+@Table(name = "`FissDiagnosisCodes`", schema = "`pre_adj`")
+public class PreAdjFissDiagnosisCode {
   @Id
   @Column(name = "`dcn`", length = 23, nullable = false)
   @EqualsAndHashCode.Include
@@ -35,22 +32,19 @@ public class PreAdjFissProcCode {
   @EqualsAndHashCode.Include
   private short priority;
 
-  @Column(name = "`procCode`", length = 10, nullable = false)
-  private String procCode;
+  @Column(name = "`diagCd2`", length = 7, nullable = false)
+  private String diagCd2;
 
-  @Column(name = "`procFlag`", length = 4)
-  private String procFlag;
+  @Column(name = "`diagPoaInd`", length = 1, nullable = false)
+  private String diagPoaInd;
 
-  @Column(name = "`procDate`")
-  private LocalDate procDate;
-
-  @Column(name = "`lastUpdated`")
-  private Instant lastUpdated;
+  @Column(name = "`bitFlags`", length = 4)
+  private String bitFlags;
 
   @Data
   @NoArgsConstructor
   @AllArgsConstructor
-  /* PK class for the FissProcCodes table */
+  /* PK class for the FissDiagnosisCodes table */
   public static class PK implements Serializable {
     private String dcn;
     private short priority;

--- a/apps/bfd-model/bfd-model-rda/src/main/java/gov/cms/bfd/model/rda/PreAdjMcsClaim.java
+++ b/apps/bfd-model/bfd-model-rda/src/main/java/gov/cms/bfd/model/rda/PreAdjMcsClaim.java
@@ -1,0 +1,106 @@
+package gov.cms.bfd.model.rda;
+
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.Set;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.FieldNameConstants;
+
+@Entity
+@Getter
+@Setter
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@FieldNameConstants
+@Table(name = "`McsClaims`", schema = "`pre_adj`")
+public class PreAdjMcsClaim {
+  @Id
+  @Column(name = "`idrClmHdIcn`", length = 15, nullable = false)
+  @EqualsAndHashCode.Include
+  private String idrClmHdIcn;
+
+  @Column(name = "`idrContrId`", length = 5, nullable = false)
+  private String idrContrId;
+
+  @Column(name = "`idrHic`", length = 12, nullable = false)
+  private String idrHic;
+
+  @Column(name = "`idrClaimType`", length = 1, nullable = false)
+  private String idrClaimType;
+
+  @Column(name = "`idrDtlCnt`")
+  private Short idrDtlCnt;
+
+  @Column(name = "`idrBeneLast_1_6`", length = 6)
+  private String idrBeneLast_1_6;
+
+  @Column(name = "`idrBeneFirstInit`", length = 1)
+  private String idrBeneFirstInit;
+
+  @Column(name = "`idrBeneMidInit`", length = 1)
+  private String idrBeneMidInit;
+
+  @Column(name = "`idrBeneSex`", length = 1)
+  private String idrBeneSex;
+
+  @Column(name = "`idrStatusCode`", length = 1)
+  private String idrStatusCode;
+
+  @Column(name = "`idrStatusDate`")
+  private LocalDate idrStatusDate;
+
+  @Column(name = "`idrBillProvNp_1_6`", length = 10)
+  private String idrBillProvNp_1_6;
+
+  @Column(name = "`idrBillProvNum`", length = 10)
+  private String idrBillProvNum;
+
+  @Column(name = "`idrBillProvEin`", length = 10)
+  private String idrBillProvEin;
+
+  @Column(name = "`idrBillProvType`", length = 2)
+  private String idrBillProvType;
+
+  @Column(name = "`idrBillProvSpec`", length = 2)
+  private String idrBillProvSpec;
+
+  @Column(name = "`idrBillProvGroup_ind`", length = 1)
+  private String idrBillProvGroup_ind;
+
+  @Column(name = "`idrBillProvPriceSpec`", length = 2)
+  private String idrBillProvPriceSpec;
+
+  @Column(name = "`idrBillProvCounty`", length = 2)
+  private String idrBillProvCounty;
+
+  @Column(name = "`idrBillProvLoc`", length = 2)
+  private String idrBillProvLoc;
+
+  @Column(name = "`idrBillProvStatusCd`", length = 1)
+  private String idrBillProvStatusCd;
+
+  @Column(name = "`idrClaimReceiptDate`")
+  private LocalDate idrClaimReceiptDate;
+
+  @OneToMany(
+      mappedBy = "idrClmHdIcn",
+      fetch = FetchType.EAGER,
+      orphanRemoval = true,
+      cascade = CascadeType.ALL)
+  private Set<PreAdjMcsDetail> details = new HashSet<>();
+
+  @OneToMany(
+      mappedBy = "idrClmHdIcn",
+      fetch = FetchType.EAGER,
+      orphanRemoval = true,
+      cascade = CascadeType.ALL)
+  private Set<PreAdjMcsDiagnosisCode> diagCodes = new HashSet<>();
+}

--- a/apps/bfd-model/bfd-model-rda/src/main/java/gov/cms/bfd/model/rda/PreAdjMcsDetail.java
+++ b/apps/bfd-model/bfd-model-rda/src/main/java/gov/cms/bfd/model/rda/PreAdjMcsDetail.java
@@ -1,0 +1,101 @@
+package gov.cms.bfd.model.rda;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.FieldNameConstants;
+
+@Entity
+@Getter
+@Setter
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@FieldNameConstants
+@IdClass(PreAdjMcsDetail.PK.class)
+@Table(name = "`McsDetails`", schema = "`pre_adj`")
+public class PreAdjMcsDetail {
+  @Id
+  @Column(name = "`idrClmHdIcn`", length = 15, nullable = false)
+  @EqualsAndHashCode.Include
+  private String idrClmHdIcn;
+
+  @Id
+  @Column(name = "`priority`", nullable = false)
+  @EqualsAndHashCode.Include
+  private short priority;
+
+  @Column(name = "`idrDtlStatus`", length = 1)
+  private String idrDtlStatus;
+
+  @Column(name = "`idrDtlFromDate`")
+  private LocalDate idrDtlFromDate;
+
+  @Column(name = "`idrDtlToDate`")
+  private LocalDate idrDtlToDate;
+
+  @Column(name = "`idrProcCode`", length = 5)
+  private String idrProcCode;
+
+  @Column(name = "`idrModOne`", length = 2)
+  private String idrModOne;
+
+  @Column(name = "`idrModTwo`", length = 2)
+  private String idrModTwo;
+
+  @Column(name = "`idrModThree`", length = 2)
+  private String idrModThree;
+
+  @Column(name = "`idrModFour`", length = 2)
+  private String idrModFour;
+
+  @Column(name = "`idrDtlDiagIcdType`", length = 1)
+  private String idrDtlDiagIcdType;
+
+  @Column(name = "`idrDtlPrimaryDiagCode`", length = 7)
+  private String idrDtlPrimaryDiagCode;
+
+  @Column(name = "`idrKPosLnameOrg`", length = 60)
+  private String idrKPosLnameOrg;
+
+  @Column(name = "`idrKPosFname`", length = 35)
+  private String idrKPosFname;
+
+  @Column(name = "`idrKPosMname`", length = 25)
+  private String idrKPosMname;
+
+  @Column(name = "`idrKPosAddr1`", length = 55)
+  private String idrKPosAddr1;
+
+  @Column(name = "`idrKPosAddr2_1st`", length = 30)
+  private String idrKPosAddr2_1st;
+
+  @Column(name = "`idrKPosAddr2_2nd`", length = 25)
+  private String idrKPosAddr2_2nd;
+
+  @Column(name = "`idrKPosCity`", length = 30)
+  private String idrKPosCity;
+
+  @Column(name = "`idrKPosState`", length = 2)
+  private String idrKPosState;
+
+  @Column(name = "`idrKPosZip`", length = 15)
+  private String idrKPosZip;
+
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  /* PK class for the McsDetails table */
+  public static class PK implements Serializable {
+    private String idrClmHdIcn;
+    private short priority;
+  }
+}

--- a/apps/bfd-model/bfd-model-rda/src/main/java/gov/cms/bfd/model/rda/PreAdjMcsDiagnosisCode.java
+++ b/apps/bfd-model/bfd-model-rda/src/main/java/gov/cms/bfd/model/rda/PreAdjMcsDiagnosisCode.java
@@ -1,8 +1,6 @@
 package gov.cms.bfd.model.rda;
 
 import java.io.Serializable;
-import java.time.Instant;
-import java.time.LocalDate;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -16,43 +14,36 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.FieldNameConstants;
 
-/** JPA class for the FissProcCodes table */
 @Entity
 @Getter
 @Setter
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @FieldNameConstants
-@IdClass(PreAdjFissProcCode.PK.class)
-@Table(name = "`FissProcCodes`", schema = "`pre_adj`")
-public class PreAdjFissProcCode {
+@IdClass(PreAdjMcsDiagnosisCode.PK.class)
+@Table(name = "`McsDiagnosisCodes`", schema = "`pre_adj`")
+public class PreAdjMcsDiagnosisCode {
   @Id
-  @Column(name = "`dcn`", length = 23, nullable = false)
+  @Column(name = "`idrClmHdIcn`", length = 15, nullable = false)
   @EqualsAndHashCode.Include
-  private String dcn;
+  private String idrClmHdIcn;
 
   @Id
   @Column(name = "`priority`", nullable = false)
   @EqualsAndHashCode.Include
   private short priority;
 
-  @Column(name = "`procCode`", length = 10, nullable = false)
-  private String procCode;
+  @Column(name = "`diagIcdType`", length = 1)
+  private String diagIcdType;
 
-  @Column(name = "`procFlag`", length = 4)
-  private String procFlag;
-
-  @Column(name = "`procDate`")
-  private LocalDate procDate;
-
-  @Column(name = "`lastUpdated`")
-  private Instant lastUpdated;
+  @Column(name = "`diagCode`", length = 7)
+  private String diagCode;
 
   @Data
   @NoArgsConstructor
   @AllArgsConstructor
-  /* PK class for the FissProcCodes table */
+  /* PK class for the McsDiagnosisCodes table */
   public static class PK implements Serializable {
-    private String dcn;
+    private String idrClmHdIcn;
     private short priority;
   }
 }

--- a/apps/bfd-model/bfd-model-rda/src/main/resources/META-INF/persistence.xml
+++ b/apps/bfd-model/bfd-model-rda/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,14 @@
+<persistence version="2.1"
+             xmlns="http://xmlns.jcp.org/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://www.oracle.com/webfolder/technetwork/jsc/xml/ns/persistence/persistence_2_1.xsd">
+
+    <persistence-unit name="gov.cms.bfd.rda">
+        <!-- A persistence unit for use in RDA model specific unit and IT tests that do not
+         have an uberjar to allow cross project entity discovery. -->
+        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+        <properties>
+            <!-- The Hibernate properties are all supplied at runtime when calling
+                    Persistence.createEntityManagerFactory(...). -->
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/apps/bfd-model/bfd-model-rda/src/test/java/gov/cms/bfd/model/rda/SchemaMigrationIT.java
+++ b/apps/bfd-model/bfd-model-rda/src/test/java/gov/cms/bfd/model/rda/SchemaMigrationIT.java
@@ -1,62 +1,231 @@
 package gov.cms.bfd.model.rda;
 
+import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import gov.cms.bfd.model.rif.schema.DatabaseSchemaManager;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.persistence.EntityManager;
 import javax.persistence.Persistence;
-import javax.persistence.TypedQuery;
 import org.hibernate.tool.schema.Action;
 import org.hsqldb.jdbc.JDBCDataSource;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 public class SchemaMigrationIT {
   public static final String PERSISTENCE_UNIT_NAME = "gov.cms.bfd.rda";
 
-  @Test
-  public void createLoadAndVerifyEntities() {
+  private EntityManager entityManager;
+
+  @Before
+  public void setUp() {
     final JDBCDataSource dataSource = createInMemoryDataSource();
     DatabaseSchemaManager.createOrUpdateSchema(dataSource);
+    entityManager = createEntityManager(dataSource);
+  }
 
-    final EntityManager entityManager = createEntityManager(dataSource);
+  @After
+  public void tearDown() {
+    if (entityManager != null && entityManager.isOpen()) {
+      entityManager.close();
+    }
+    entityManager = null;
+  }
 
+  /**
+   * Quick persist and query to verify the entities are compatible with hibernate. Also verify the
+   * cascaded updates work correctly.
+   */
+  @Test
+  public void fissClaimEntities() {
     final PreAdjFissClaim claim = new PreAdjFissClaim();
     claim.setDcn("1");
     claim.setHicNo("h1");
     claim.setCurrStatus('1');
     claim.setCurrLoc1('A');
     claim.setCurrLoc2("1A");
+    claim.setPracLocCity("city name can be very long indeed");
 
-    final PreAdjFissProcCode procCode = new PreAdjFissProcCode();
-    procCode.setDcn("1");
-    procCode.setPriority((short) 0);
-    procCode.setProcCode("P");
-    procCode.setProcFlag("F");
-    procCode.setProcDate(LocalDate.now());
-    procCode.setLastUpdated(Instant.now());
-    claim.getProcCodes().add(procCode);
+    final PreAdjFissProcCode procCode0 = new PreAdjFissProcCode();
+    procCode0.setDcn(claim.getDcn());
+    procCode0.setPriority((short) 0);
+    procCode0.setProcCode("P");
+    procCode0.setProcFlag("F");
+    procCode0.setProcDate(LocalDate.now());
+    procCode0.setLastUpdated(Instant.now());
+    claim.getProcCodes().add(procCode0);
+
+    final PreAdjFissProcCode procCode1 = new PreAdjFissProcCode();
+    procCode1.setDcn(claim.getDcn());
+    procCode1.setPriority((short) 1);
+    procCode1.setProcCode("P");
+    procCode1.setProcFlag("G");
+    procCode1.setProcDate(LocalDate.now());
+    procCode1.setLastUpdated(Instant.now());
+    claim.getProcCodes().add(procCode1);
+
+    final PreAdjFissDiagnosisCode diagCode0 = new PreAdjFissDiagnosisCode();
+    diagCode0.setDcn(claim.getDcn());
+    diagCode0.setPriority((short) 0);
+    diagCode0.setDiagCd2("cd2");
+    diagCode0.setDiagPoaInd("Q");
+    claim.getDiagCodes().add(diagCode0);
+
+    final PreAdjFissDiagnosisCode diagCode1 = new PreAdjFissDiagnosisCode();
+    diagCode1.setDcn(claim.getDcn());
+    diagCode1.setPriority((short) 1);
+    diagCode1.setDiagCd2("cd2");
+    diagCode1.setDiagPoaInd("R");
+    claim.getDiagCodes().add(diagCode1);
+
+    // Insert a record and ready back to verify some columns and that the detail records were
+    // written
+    entityManager.getTransaction().begin();
+    entityManager.persist(claim);
+    entityManager.getTransaction().commit();
+
+    List<PreAdjFissClaim> claims =
+        entityManager
+            .createQuery("select c from PreAdjFissClaim c", PreAdjFissClaim.class)
+            .getResultList();
+    assertEquals(1, claims.size());
+
+    PreAdjFissClaim resultClaim = claims.get(0);
+    assertEquals("h1", resultClaim.getHicNo());
+    assertEquals("city name can be very long indeed", resultClaim.getPracLocCity());
+
+    assertEquals("0:F,1:G", summarizeFissProcCodes(resultClaim));
+    assertEquals("0:Q,1:R", summarizeFissDiagCodes(resultClaim));
+
+    // Remove a procCode and diagCode and modify the remaining ones, update, and read back to verify
+    // all records updated correctly.
+    claim.getProcCodes().remove(procCode1);
+    claim.getDiagCodes().remove(diagCode0);
+    procCode0.setProcFlag("H");
+    diagCode1.setDiagPoaInd("S");
+    entityManager.getTransaction().begin();
+    entityManager.persist(claim);
+    entityManager.getTransaction().commit();
+    resultClaim =
+        entityManager
+            .createQuery("select c from PreAdjFissClaim c", PreAdjFissClaim.class)
+            .getResultList()
+            .get(0);
+    assertEquals("0:H", summarizeFissProcCodes(resultClaim));
+    assertEquals("1:S", summarizeFissDiagCodes(resultClaim));
+  }
+
+  /**
+   * Quick persist and query to verify the entities are compatible with hibernate. Also verify the
+   * cascaded updates work correctly.
+   */
+  @Test
+  public void mcsClaimEntities() {
+    final PreAdjMcsClaim claim = new PreAdjMcsClaim();
+    claim.setIdrClmHdIcn("3");
+    claim.setIdrContrId("c1");
+    claim.setIdrHic("hc");
+    claim.setIdrClaimType("c");
+
+    claim.getDetails().add(quickMcsDetail(claim, 0, "P"));
+    PreAdjMcsDetail detail1 = quickMcsDetail(claim, 1, "Q");
+    claim.getDetails().add(detail1);
+    PreAdjMcsDetail detail2 = quickMcsDetail(claim, 2, "R");
+    claim.getDetails().add(detail2);
+
+    PreAdjMcsDiagnosisCode diag0 = quickMcsDiagCode(claim, 0, "T");
+    claim.getDiagCodes().add(diag0);
+    claim.getDiagCodes().add(quickMcsDiagCode(claim, 1, "U"));
+    PreAdjMcsDiagnosisCode diag2 = quickMcsDiagCode(claim, 2, "V");
+    claim.getDiagCodes().add(diag2);
+
+    // Insert a record and ready back to verify some columns and that the detail records were
+    // written
+    entityManager.getTransaction().begin();
+    entityManager.persist(claim);
+    entityManager.getTransaction().commit();
+
+    List<PreAdjMcsClaim> resultClaims =
+        entityManager
+            .createQuery("select c from PreAdjMcsClaim c", PreAdjMcsClaim.class)
+            .getResultList();
+    assertEquals(1, resultClaims.size());
+    PreAdjMcsClaim resultClaim = resultClaims.get(0);
+    assertEquals("0:P,1:Q,2:R", summarizeMcsDetails(resultClaim));
+    assertEquals("0:T,1:U,2:V", summarizeMcsDiagCodes(resultClaim));
+
+    // Remove a detail and diagCode and modify the remaining ones, update, and read back to verify
+    // all records updated correctly.
+    claim.getDetails().remove(detail1);
+    detail2.setIdrDtlStatus("S");
+    claim.getDiagCodes().remove(diag2);
+    diag0.setDiagIcdType("W");
 
     entityManager.getTransaction().begin();
     entityManager.persist(claim);
     entityManager.getTransaction().commit();
 
-    final TypedQuery<PreAdjFissClaim> query =
-        entityManager.createQuery("select c from PreAdjFissClaim c", PreAdjFissClaim.class);
-    List<PreAdjFissClaim> claims = query.getResultList();
-    assertEquals(1, claims.size());
+    resultClaims =
+        entityManager
+            .createQuery("select c from PreAdjMcsClaim c", PreAdjMcsClaim.class)
+            .getResultList();
+    assertEquals(1, resultClaims.size());
+    resultClaim = resultClaims.get(0);
+    assertEquals("0:P,2:S", summarizeMcsDetails(resultClaim));
+    assertEquals("0:W,1:U", summarizeMcsDiagCodes(resultClaim));
+  }
 
-    final PreAdjFissClaim resultClaim = claims.get(0);
-    assertEquals("h1", resultClaim.getHicNo());
+  private PreAdjMcsDetail quickMcsDetail(PreAdjMcsClaim claim, int priority, String dtlStatus) {
+    final PreAdjMcsDetail detail = new PreAdjMcsDetail();
+    detail.setIdrClmHdIcn(claim.getIdrClmHdIcn());
+    detail.setPriority((short) priority);
+    detail.setIdrDtlStatus(dtlStatus);
+    return detail;
+  }
 
-    final List<PreAdjFissProcCode> resultCodes = ImmutableList.copyOf(resultClaim.getProcCodes());
-    assertEquals(1, resultCodes.size());
-    assertEquals("F", resultCodes.get(0).getProcFlag());
+  private PreAdjMcsDiagnosisCode quickMcsDiagCode(
+      PreAdjMcsClaim claim, int priority, String icdType) {
+    final PreAdjMcsDiagnosisCode diagCode = new PreAdjMcsDiagnosisCode();
+    diagCode.setIdrClmHdIcn(claim.getIdrClmHdIcn());
+    diagCode.setPriority((short) priority);
+    diagCode.setDiagIcdType(icdType);
+    return diagCode;
+  }
+
+  private String summarizeFissProcCodes(PreAdjFissClaim resultClaim) {
+    return summarizeObjects(
+        resultClaim.getProcCodes().stream(),
+        d -> format("%d:%s", d.getPriority(), d.getProcFlag()));
+  }
+
+  private String summarizeFissDiagCodes(PreAdjFissClaim resultClaim) {
+    return summarizeObjects(
+        resultClaim.getDiagCodes().stream(),
+        d -> format("%d:%s", d.getPriority(), d.getDiagPoaInd()));
+  }
+
+  private String summarizeMcsDetails(PreAdjMcsClaim resultClaim) {
+    return summarizeObjects(
+        resultClaim.getDetails().stream(),
+        d -> format("%d:%s", d.getPriority(), d.getIdrDtlStatus()));
+  }
+
+  private String summarizeMcsDiagCodes(PreAdjMcsClaim resultClaim) {
+    return summarizeObjects(
+        resultClaim.getDiagCodes().stream(),
+        d -> format("%d:%s", d.getPriority(), d.getDiagIcdType()));
+  }
+
+  private <T> String summarizeObjects(Stream<T> objects, Function<T, String> mapping) {
+    return objects.map(mapping).sorted().collect(Collectors.joining(","));
   }
 
   private EntityManager createEntityManager(JDBCDataSource dataSource) {

--- a/apps/bfd-model/bfd-model-rda/src/test/java/gov/cms/bfd/model/rda/SchemaMigrationIT.java
+++ b/apps/bfd-model/bfd-model-rda/src/test/java/gov/cms/bfd/model/rda/SchemaMigrationIT.java
@@ -1,0 +1,81 @@
+package gov.cms.bfd.model.rda;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import gov.cms.bfd.model.rif.schema.DatabaseSchemaManager;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import javax.persistence.EntityManager;
+import javax.persistence.Persistence;
+import javax.persistence.TypedQuery;
+import org.hibernate.tool.schema.Action;
+import org.hsqldb.jdbc.JDBCDataSource;
+import org.junit.Test;
+
+public class SchemaMigrationIT {
+  public static final String PERSISTENCE_UNIT_NAME = "gov.cms.bfd.rda";
+
+  @Test
+  public void createLoadAndVerifyEntities() {
+    final JDBCDataSource dataSource = createInMemoryDataSource();
+    DatabaseSchemaManager.createOrUpdateSchema(dataSource);
+
+    final EntityManager entityManager = createEntityManager(dataSource);
+
+    final PreAdjFissClaim claim = new PreAdjFissClaim();
+    claim.setDcn("1");
+    claim.setHicNo("h1");
+    claim.setCurrStatus('1');
+    claim.setCurrLoc1('A');
+    claim.setCurrLoc2("1A");
+
+    final PreAdjFissProcCode procCode = new PreAdjFissProcCode();
+    procCode.setDcn("1");
+    procCode.setPriority((short) 0);
+    procCode.setProcCode("P");
+    procCode.setProcFlag("F");
+    procCode.setProcDate(LocalDate.now());
+    procCode.setLastUpdated(Instant.now());
+    claim.getProcCodes().add(procCode);
+
+    entityManager.getTransaction().begin();
+    entityManager.persist(claim);
+    entityManager.getTransaction().commit();
+
+    final TypedQuery<PreAdjFissClaim> query =
+        entityManager.createQuery("select c from PreAdjFissClaim c", PreAdjFissClaim.class);
+    List<PreAdjFissClaim> claims = query.getResultList();
+    assertEquals(1, claims.size());
+
+    final PreAdjFissClaim resultClaim = claims.get(0);
+    assertEquals("h1", resultClaim.getHicNo());
+
+    final List<PreAdjFissProcCode> resultCodes = ImmutableList.copyOf(resultClaim.getProcCodes());
+    assertEquals(1, resultCodes.size());
+    assertEquals("F", resultCodes.get(0).getProcFlag());
+  }
+
+  private EntityManager createEntityManager(JDBCDataSource dataSource) {
+    final Map<String, Object> hibernateProperties =
+        ImmutableMap.of(
+            org.hibernate.cfg.AvailableSettings.DATASOURCE,
+            dataSource,
+            org.hibernate.cfg.AvailableSettings.HBM2DDL_AUTO,
+            Action.VALIDATE,
+            org.hibernate.cfg.AvailableSettings.STATEMENT_BATCH_SIZE,
+            10);
+
+    return Persistence.createEntityManagerFactory(PERSISTENCE_UNIT_NAME, hibernateProperties)
+        .createEntityManager();
+  }
+
+  private JDBCDataSource createInMemoryDataSource() {
+    JDBCDataSource dataSource = new JDBCDataSource();
+    dataSource.setUrl("jdbc:hsqldb:mem:unit-tests");
+    return dataSource;
+  }
+}

--- a/apps/bfd-model/bfd-model-rif/src/main/java/gov/cms/bfd/model/rif/schema/DatabaseSchemaManager.java
+++ b/apps/bfd-model/bfd-model-rif/src/main/java/gov/cms/bfd/model/rif/schema/DatabaseSchemaManager.java
@@ -69,6 +69,7 @@ public final class DatabaseSchemaManager {
     try (Connection connection = dataSource.getConnection()) {
       if (connection.getMetaData().getDatabaseProductName().equals("HSQL Database Engine")) {
         placeholders.put("type.int4", "integer");
+        placeholders.put("type.text", "longvarchar");
         placeholders.put("logic.tablespaces-escape", "--");
         placeholders.put("logic.drop-tablespaces-escape", "--");
         placeholders.put("logic.alter-column-type", "");
@@ -77,6 +78,7 @@ public final class DatabaseSchemaManager {
         placeholders.put("logic.sequence-increment", "increment by");
       } else {
         placeholders.put("type.int4", "int4");
+        placeholders.put("type.text", "text");
         placeholders.put("logic.tablespaces-escape", "--");
         placeholders.put("logic.drop-tablespaces-escape", "");
         placeholders.put("logic.alter-column-type", "type");

--- a/apps/bfd-model/bfd-model-rif/src/main/resources/db/migration/V31__preadj_claim_table_updates.sql
+++ b/apps/bfd-model/bfd-model-rif/src/main/resources/db/migration/V31__preadj_claim_table_updates.sql
@@ -1,0 +1,112 @@
+/*
+ * Creates RDA MCS pre-adjudicated claims tables required by the application.
+ * https://confluenceent.cms.gov/display/MPSM/2021-04-22+Tech+Spec%3A+Specific+Schema+for+MVP+v0.2
+ *
+ * Where possible column names map directly to fields in the RDA API result message.
+ */
+
+/*
+ * Add new FISS claim fields from RDA API MVP 0.2 release.
+ */
+alter table "pre_adj"."FissClaims"
+    add "pracLocAddr1" ${type.text};
+alter table "pre_adj"."FissClaims"
+    add "pracLocAddr2" ${type.text};
+alter table "pre_adj"."FissClaims"
+    add "pracLocCity" ${type.text};
+alter table "pre_adj"."FissClaims"
+    add "pracLocState" varchar(2);
+alter table "pre_adj"."FissClaims"
+    add "pracLocZip" varchar(15);
+
+/*
+ * Add new FISS Claim diagnosis code table from RDA API 0.2 release.
+ * The priority column is used to sort the detail records and is populated using array index in RDA
+ * API response array.
+ */
+
+create table "pre_adj"."FissDiagnosisCodes" (
+    "dcn"        varchar(23) not null,
+    "priority"   smallint    not null,
+    "diagCd2"    varchar(7)  not null,
+    "diagPoaInd" varchar(1)  not null,
+    "bitFlags"   varchar(4),
+    constraint "FissDiagnosisCodes_pkey" primary key ("dcn", "priority"),
+    constraint "FissDiagnosisCodes_claim" foreign key ("dcn") references "pre_adj"."FissClaims"("dcn")
+);
+
+/*
+ * Add table for MSC claims.
+ */
+create table "pre_adj"."McsClaims" (
+    "idrClmHdIcn"          varchar(15) not null,
+    "idrContrId"           varchar(5)  not null,
+    "idrHic"               varchar(12) not null,
+    "idrClaimType"         varchar(1)  not null,
+    "idrDtlCnt"            smallint,
+    "idrBeneLast_1_6"      varchar(6),
+    "idrBeneFirstInit"     varchar(1),
+    "idrBeneMidInit"       varchar(1),
+    "idrBeneSex"           varchar(1),
+    "idrStatusCode"        varchar(1),
+    "idrStatusDate"        date,
+    "idrBillProvNp_1_6"    varchar(10),
+    "idrBillProvNum"       varchar(10),
+    "idrBillProvEin"       varchar(10),
+    "idrBillProvType"      varchar(2),
+    "idrBillProvSpec"      varchar(2),
+    "idrBillProvGroup_ind" varchar(1),
+    "idrBillProvPriceSpec" varchar(2),
+    "idrBillProvCounty"    varchar(2),
+    "idrBillProvLoc"       varchar(2),
+    "idrTotAllowed"        decimal(7, 2),
+    "idrCoinsurance"       decimal(7, 2),
+    "idrDeductible"        decimal(7, 2),
+    "idrBillProvStatusCd"  varchar(1),
+    "idrTotBilledAmt"      decimal(7, 2),
+    "idrClaimReceiptDate"  date,
+    constraint "McsClaims_pkey" primary key ("idrClmHdIcn")
+);
+
+/*
+ * The priority column is used to sort the detail records and is populated using array index in RDA
+ * API response array.
+ */
+create table "pre_adj"."McsDiagnosisCodes" (
+    "idrClmHdIcn" varchar(15) not null,
+    "priority"    smallint    not null,
+    "diagIcdType" varchar(1),
+    "diagCode"    varchar(7),
+    constraint "McsDiagnosisCodes_pkey" primary key ("idrClmHdIcn", "priority"),
+    constraint "McsDiagnosisCodes_claim" foreign key ("idrClmHdIcn") references "pre_adj"."McsClaims"("idrClmHdIcn")
+);
+
+/*
+ * The priority column is used to sort the detail records and is populated using array index in RDA
+ * API response array.
+ */
+create table "pre_adj"."McsDetails" (
+    "idrClmHdIcn"           varchar(15) not null,
+    "priority"              smallint    not null,
+    "idrDtlStatus"          varchar(1),
+    "idrDtlFromDate"        date,
+    "idrDtlToDate"          date,
+    "idrProcCode"           varchar(5),
+    "idrModOne"             varchar(2),
+    "idrModTwo"             varchar(2),
+    "idrModThree"           varchar(2),
+    "idrModFour"            varchar(2),
+    "idrDtlDiagIcdType"     varchar(1),
+    "idrDtlPrimaryDiagCode" varchar(7),
+    "idrKPosLnameOrg"       varchar(60),
+    "idrKPosFname"          varchar(35),
+    "idrKPosMname"          varchar(25),
+    "idrKPosAddr1"          varchar(55),
+    "idrKPosAddr2_1st"      varchar(30),
+    "idrKPosAddr2_2nd"      varchar(25),
+    "idrKPosCity"           varchar(30),
+    "idrKPosState"          varchar(2),
+    "idrKPosZip"            varchar(15),
+    constraint "McsDetails_pkey" primary key ("idrClmHdIcn", "priority"),
+    constraint "McsDetails_claim" foreign key ("idrClmHdIcn") references "pre_adj"."McsClaims"("idrClmHdIcn")
+);


### PR DESCRIPTION
**NOTE: This is a DRAFT and WIP and not ready for review.**

### Change Details

Adds Flyway schema migration script and associated JPA entities for the following:

- 4 new practice location related fields in FissClaims
- new FissDiagnosisCodes table for FISS claim diagnosis codes
- new McsClaims table for MCS claim data
- new McsDetails table for MCS claim details
- new McsDiagnosisCodes table for MCS diagnosis codes

Also adds some HSQLDB compatibility changes to existing entities and some an IT test class to verify basic database functionality.

### Acceptance Validation

Is the SQL migration correct and are the JPA entities compatible with the tables.

### Feedback Requested

nothing specific

### External References

<!-- For example: replace xxx with the JIRA ticket number: -->

- [DCGEO-88](https://jira.cms.gov/browse/DCGEO-88)
- [RDA API tech spec for schema](https://confluenceent.cms.gov/display/MPSM/2021-04-22+Tech+Spec%3A+Specific+Schema+for+MVP+v0.2)

### Security Implications

Adds new tables to the database.

- [ ] new software dependencies

no

- [ ] altered security controls

no

- [ ] new data stored or transmitted

new FISS fields and MCS claim records

- [ ] security checklist is completed for this change

no

- [ ] requires more information or team discussion to evaluate security implications

no
