### PR TITLE
Fixes intermittent test failures due to varying runtime of tests (mar…

### DIFF
--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/TransformerTestUtilsV2.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/TransformerTestUtilsV2.java
@@ -950,7 +950,7 @@ public final class TransformerTestUtilsV2 {
       final Duration diff = Duration.between(expectedLastUpdated, actualLastUpdated);
       Assert.assertTrue(
           "Expect the actual lastUpdated to be equal or after the loaded resources",
-          diff.compareTo(Duration.ofSeconds(1)) <= 0);
+          diff.compareTo(Duration.ofSeconds(10)) <= 0);
     } else {
       Assert.assertEquals(
           "Expect lastUpdated to be the fallback value",

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/TransformerTestUtils.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/TransformerTestUtils.java
@@ -2065,7 +2065,7 @@ final class TransformerTestUtils {
       final Duration diff = Duration.between(expectedLastUpdated, actualLastUpdated);
       Assert.assertTrue(
           "Expect the actual lastUpdated to be equal or after the loaded resources",
-          diff.compareTo(Duration.ofSeconds(1)) <= 0);
+          diff.compareTo(Duration.ofSeconds(10)) <= 0);
     } else {
       Assert.assertEquals(
           "Expect lastUpdated to be the fallback value",


### PR DESCRIPTION
### Change Details

This PR addresses two issues that cause intermittent IT test failures:

PatientResourceProviderIT sometimes fails due to a RejectedExecutionException. This was caused by the extremely short (1ms) execution interval leading to a race condition as the test shuts down the ScheduledExcecutor. Increasing that to 100ms makes the race condition far less likely to happen.

### Acceptance Validation

Unit tests should pass more reliably than before.

### Feedback Requested

Nothing specific.

### External References

None.

### External References

<!-- For example: replace xxx with the JIRA ticket number: -->

- [BFD-897](https://jira.cms.gov/browse/BFD-897)

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] altered security controls

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications
<!-- Use this to indicate you're unsure how this change may impact system security and would like to solicit the team's feedback. Optionally, provide background information regarding your questions and concerns. -->

