### PR TITLE
[BFD-1025] Fix BFD Perf Test failing IT's

### DIFF
--- a/apps/bfd-server-test-perf/pom.xml
+++ b/apps/bfd-server-test-perf/pom.xml
@@ -59,11 +59,11 @@
 					<groupId>commons-pool2</groupId>
 					<artifactId>commons-pool2</artifactId>
 				</exclusion>
-				<!-- Exclude SLF4J bindings that are causing conflicts for the logger -->
+				<!-- Exclude SLF4J bindings that are causing conflicts for the logger
 				<exclusion>
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-nop</artifactId>
-				</exclusion>
+				</exclusion> -->
 			</exclusions>
 		</dependency>
 

--- a/apps/bfd-server-test-perf/src/test/java/gov/cms/bfd/server/test/perf/utils/BenefitIdMgrTest.java
+++ b/apps/bfd-server-test-perf/src/test/java/gov/cms/bfd/server/test/perf/utils/BenefitIdMgrTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.*;
 import org.junit.*;
 
 public class BenefitIdMgrTest {
-  @Ignore
   @Test
   public void testSetCurrIndex() {
     BenefitIdMgr bim = new BenefitIdMgr(40, 20, 60, "test", "%02d");
@@ -19,7 +18,6 @@ public class BenefitIdMgrTest {
   }
 
   @Test
-  @Ignore
   public void testNextId() {
     BenefitIdMgr bim = new BenefitIdMgr(0, 20, 60, "test", "%02d");
     assertEquals("test20", bim.nextId());

--- a/apps/bfd-server-test-perf/src/test/java/gov/cms/bfd/server/test/perf/utils/BenefitIdMgrTest.java
+++ b/apps/bfd-server-test-perf/src/test/java/gov/cms/bfd/server/test/perf/utils/BenefitIdMgrTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.*;
 import org.junit.*;
 
 public class BenefitIdMgrTest {
+  @Ignore
   @Test
   public void testSetCurrIndex() {
     BenefitIdMgr bim = new BenefitIdMgr(40, 20, 60, "test", "%02d");
@@ -18,6 +19,7 @@ public class BenefitIdMgrTest {
   }
 
   @Test
+  @Ignore
   public void testNextId() {
     BenefitIdMgr bim = new BenefitIdMgr(0, 20, 60, "test", "%02d");
     assertEquals("test20", bim.nextId());


### PR DESCRIPTION
### Change Details

Removes the slf4j-nop exclusion from the defunct BFD Perf Test application so IT's may pass. 

### Acceptance Validation

Do all IT's pass?

### Feedback Requested

Who wants to reach out to @karlmdavis and see if we should nuke this code? 

### External References

<!-- For example: replace xxx with the JIRA ticket number: -->

- [BFD-1025](https://jira.cms.gov/browse/BFD-1025)

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] altered security controls

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications
<!-- Use this to indicate you're unsure how this change may impact system security and would like to solicit the team's feedback. Optionally, provide background information regarding your questions and concerns. -->

