### PR TITLE
BFD-897: Redirect all test output to separate files

### DIFF
--- a/.github/workflows/ci-java.yml
+++ b/.github/workflows/ci-java.yml
@@ -40,3 +40,11 @@ jobs:
       - name: 'Run maven ${{ matrix.mvn_commmand }}'
         run: mvn ${{ matrix.mvn_command }}
         working-directory: ./apps
+      - name: 'Upload test artifacts'
+        uses: actions/upload-artifact@v2
+        with:
+          path: |
+            **/target/surefire-reports/*
+            **/target/failsafe-reports/*
+            bfd-server/bfd-server-war/target/server-work/access.*
+            bfd-server/bfd-server-war/target/server-work/server-console.log

--- a/.github/workflows/ci-java.yml
+++ b/.github/workflows/ci-java.yml
@@ -42,6 +42,7 @@ jobs:
         working-directory: ./apps
       - name: 'Upload test artifacts'
         uses: actions/upload-artifact@v2
+        if: always()
         with:
           path: |
             **/target/surefire-reports/*

--- a/.github/workflows/ci-java.yml
+++ b/.github/workflows/ci-java.yml
@@ -1,11 +1,38 @@
 name: 'CI - Java'
 on: pull_request
 jobs:
-  mvn-job:
+  mvn-fmt-maven-plugin:
     runs-on: macos-latest
-    strategy:
-      matrix: 
-        mvn_command: ['verify', 'com.coveo:fmt-maven-plugin:check']
+    steps:
+      - name: 'Checkout repo'
+        uses: actions/checkout@v2
+      - name: 'Setup JDK'
+        uses: actions/setup-java@v1
+        with:
+          java-version: '1.8.0.252'
+          # Pinning this version as version 262 causes AuthenticationIT tests to fail
+          # See BFD-332.
+      - name: 'Generate maven toolchain config'
+        run: |
+          cat << EOF > ~/.m2/toolchains.xml
+          <toolchains>
+            <toolchain>
+              <type>jdk</type>
+              <provides>
+                <version>1.8</version>
+                <vendor>OpenJDK</vendor>
+              </provides>
+              <configuration>
+                <jdkHome>$JAVA_HOME</jdkHome>
+              </configuration>
+            </toolchain>
+          </toolchains>
+          EOF
+      - name: 'Run maven ${{ matrix.mvn_commmand }}'
+        run: mvn com.coveo:fmt-maven-plugin:check
+        working-directory: ./apps
+  mvn-verify:
+    runs-on: macos-latest
     steps:
       - name: 'Configure AWS credentials'
         uses: aws-actions/configure-aws-credentials@v1
@@ -38,13 +65,13 @@ jobs:
           </toolchains>
           EOF
       - name: 'Run maven ${{ matrix.mvn_commmand }}'
-        run: mvn ${{ matrix.mvn_command }}
+        run: mvn verify
         working-directory: ./apps
       - name: 'Upload test artifacts'
         uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: mvn-build-logs
+          name: mvn-verify-build-logs
           path: |
             **/target/surefire-reports/*
             **/target/failsafe-reports/*

--- a/.github/workflows/ci-java.yml
+++ b/.github/workflows/ci-java.yml
@@ -44,6 +44,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: always()
         with:
+          name: mvn-build-logs
           path: |
             **/target/surefire-reports/*
             **/target/failsafe-reports/*

--- a/apps/bfd-model/bfd-model-codebook-extractor/pom.xml
+++ b/apps/bfd-model/bfd-model-codebook-extractor/pom.xml
@@ -128,20 +128,6 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<!-- Will run the `*IT.java` integration tests in this project, as part
-					of the build. -->
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-failsafe-plugin</artifactId>
-				<executions>
-					<execution>
-						<goals>
-							<goal>integration-test</goal>
-							<goal>verify</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/apps/bfd-model/pom.xml
+++ b/apps/bfd-model/pom.xml
@@ -66,14 +66,6 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
-					<!-- Can be used to run any `*IT.java` integration tests in a project. -->
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-failsafe-plugin</artifactId>
-					<configuration>
-						<redirectTestOutputToFile>true</redirectTestOutputToFile>
-					</configuration>
-				</plugin>
-				<plugin>
 					<artifactId>maven-scm-plugin</artifactId>
 					<configuration>
 						<!-- This default config is used in the Jenkinsfile CI build. -->

--- a/apps/bfd-pipeline/bfd-pipeline-app/pom.xml
+++ b/apps/bfd-pipeline/bfd-pipeline-app/pom.xml
@@ -135,20 +135,6 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<!-- Will run the `*IT.java` integration tests in this project, as part 
-					of the build. -->
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-failsafe-plugin</artifactId>
-				<executions>
-					<execution>
-						<goals>
-							<goal>integration-test</goal>
-							<goal>verify</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 

--- a/apps/bfd-pipeline/bfd-pipeline-benchmarks/pom.xml
+++ b/apps/bfd-pipeline/bfd-pipeline-benchmarks/pom.xml
@@ -130,20 +130,6 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<!-- Will run the `*Benchmark.java` integration tests in this project, 
-					as part of the build. -->
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-failsafe-plugin</artifactId>
-				<executions>
-					<execution>
-						<goals>
-							<goal>integration-test</goal>
-							<goal>verify</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 

--- a/apps/bfd-pipeline/bfd-pipeline-ccw-rif/pom.xml
+++ b/apps/bfd-pipeline/bfd-pipeline-ccw-rif/pom.xml
@@ -155,19 +155,11 @@
 					of the build. -->
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
-				<executions>
-					<execution>
-						<goals>
-							<goal>integration-test</goal>
-							<goal>verify</goal>
-						</goals>
-						<configuration>
-							<environmentVariables>
-								<TZ>UTC</TZ>
-							</environmentVariables>
-						</configuration>
-					</execution>
-				</executions>
+				<configuration>
+					<environmentVariables>
+						<TZ>UTC</TZ>
+					</environmentVariables>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/apps/bfd-pipeline/bfd-pipeline-ccw-rif/pom.xml
+++ b/apps/bfd-pipeline/bfd-pipeline-ccw-rif/pom.xml
@@ -150,17 +150,6 @@
 			</plugins>
 		</pluginManagement>
 		<plugins>
-			<plugin>
-				<!-- Will run the `*IT.java` integration tests in this project, as part 
-					of the build. -->
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-failsafe-plugin</artifactId>
-				<configuration>
-					<environmentVariables>
-						<TZ>UTC</TZ>
-					</environmentVariables>
-				</configuration>
-			</plugin>
 		</plugins>
 	</build>
 

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/pom.xml
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/pom.xml
@@ -122,20 +122,6 @@
         </extensions>
         <plugins>
             <plugin>
-                <!-- Will run the `*IT.java` integration tests in this project, as part
-                        of the build. -->
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
               <groupId>org.xolstice.maven.plugins</groupId>
               <artifactId>protobuf-maven-plugin</artifactId>
               <version>0.6.1</version>

--- a/apps/bfd-pipeline/bfd-pipeline-shared-utils/pom.xml
+++ b/apps/bfd-pipeline/bfd-pipeline-shared-utils/pom.xml
@@ -56,20 +56,6 @@
 			</plugins>
 		</pluginManagement>
 		<plugins>
-			<plugin>
-				<!-- Will run the `*IT.java` integration tests in this project, as part
-					of the build. -->
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-failsafe-plugin</artifactId>
-				<executions>
-					<execution>
-						<goals>
-							<goal>integration-test</goal>
-							<goal>verify</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 

--- a/apps/bfd-pipeline/pom.xml
+++ b/apps/bfd-pipeline/pom.xml
@@ -82,14 +82,6 @@
 					</configuration>
 				</plugin>
 				<plugin>
-					<!-- Can be used to run any `*IT.java` integration tests in a project. -->
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-failsafe-plugin</artifactId>
-					<configuration>
-						<redirectTestOutputToFile>true</redirectTestOutputToFile>
-					</configuration>
-				</plugin>
-				<plugin>
 					<!-- Used to build executable JARs, with all dependencies included in 
 						them. -->
 					<groupId>com.github.chrischristo</groupId>

--- a/apps/bfd-server-test-perf/pom.xml
+++ b/apps/bfd-server-test-perf/pom.xml
@@ -183,22 +183,6 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<!-- This is to run the integration tests -->
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-failsafe-plugin</artifactId>
-				<configuration>
-					<redirectTestOutputToFile>true</redirectTestOutputToFile>
-				</configuration>
-				<executions>
-					<execution>
-						<goals>
-							<goal>integration-test</goal>
-							<goal>verify</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/apps/bfd-server/bfd-server-launcher/pom.xml
+++ b/apps/bfd-server/bfd-server-launcher/pom.xml
@@ -215,20 +215,6 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<!-- Will run the `*IT.java` integration tests in this project, as part
-					of the build. -->
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-failsafe-plugin</artifactId>
-				<executions>
-					<execution>
-						<goals>
-							<goal>integration-test</goal>
-							<goal>verify</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 	</build>
 

--- a/apps/bfd-server/bfd-server-war/pom.xml
+++ b/apps/bfd-server/bfd-server-war/pom.xml
@@ -430,21 +430,10 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
 				<configuration>
-					<redirectTestOutputToFile>true</redirectTestOutputToFile>
+					<environmentVariables>
+						<TZ>UTC</TZ>
+					</environmentVariables>
 				</configuration>
-				<executions>
-					<execution>
-						<goals>
-							<goal>integration-test</goal>
-							<goal>verify</goal>
-						</goals>
-                                                <configuration>
-                                                        <environmentVariables>
-                                                                <TZ>UTC</TZ>
-                                                        </environmentVariables>
-                                                </configuration>
-					</execution>
-				</executions>
 			</plugin>
 			<plugin>
 				<!-- Configure the plugin's 'java' goal to run the FDA Drug (NDC) Code extraction

--- a/apps/bfd-server/bfd-server-war/pom.xml
+++ b/apps/bfd-server/bfd-server-war/pom.xml
@@ -426,16 +426,6 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<!-- This is to run the integration tests -->
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-failsafe-plugin</artifactId>
-				<configuration>
-					<environmentVariables>
-						<TZ>UTC</TZ>
-					</environmentVariables>
-				</configuration>
-			</plugin>
-			<plugin>
 				<!-- Configure the plugin's 'java' goal to run the FDA Drug (NDC) Code extraction
 						process. -->
 				<groupId>org.codehaus.mojo</groupId>

--- a/apps/pom.xml
+++ b/apps/pom.xml
@@ -363,6 +363,7 @@ checkJavaFormat
 							tests run on a system. -->
 						<argLine>${maven-test.jvm-args.env-specific}</argLine>
 						<trimStackTrace>false</trimStackTrace>
+						<redirectTestOutputToFile>true</redirectTestOutputToFile>
 					</configuration>
 				</plugin>
 				<plugin>
@@ -376,6 +377,7 @@ checkJavaFormat
 							tests run on a system. -->
 						<argLine>${maven-test.jvm-args.env-specific}</argLine>
 						<trimStackTrace>false</trimStackTrace>
+						<redirectTestOutputToFile>true</redirectTestOutputToFile>
 						<systemPropertyVariables>
 							<its.db.url>${its.db.url}</its.db.url>
 							<its.db.username>${its.db.username}</its.db.username>

--- a/apps/pom.xml
+++ b/apps/pom.xml
@@ -570,6 +570,20 @@ checkJavaFormat
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<!-- Will run the `*IT.java` integration tests in the modules, as part
+					of the build. -->
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/apps/pom.xml
+++ b/apps/pom.xml
@@ -383,6 +383,11 @@ checkJavaFormat
 							<its.db.username>${its.db.username}</its.db.username>
 							<its.db.password>${its.db.password}</its.db.password>
 						</systemPropertyVariables>
+						
+						<!-- Needed to avoid test failures when comparing ETL timestamps. -->
+						<environmentVariables>
+							<TZ>UTC</TZ>
+						</environmentVariables>
 					</configuration>
 				</plugin>
 				<plugin>


### PR DESCRIPTION
### Change Details

<!-- Add detailed discussion of changes here: -->
<!-- This is likely a summary, or the complete contents, of your commit messages -->

This was already _mostly_ happening for ITs, but I moved that into the parent POM to apply it everywhere and also turned it on for unit tests. (Surefire runs our unit tests and failsafe runs our ITs.)

Should help make our build logs a bit more manageable, particularly on GH Actions and Jenkins.

In addition:
* Cleaned up the failsafe POM entries a bit, to improve consistency.
* Set GH Actions to save our test data files, e.g. `failsafe-reports`, as build artifacts.

### Acceptance Validation

<!-- What should reviewers look for to determine completeness -->
<!-- Insert screenshots if applicable (drag images here) -->

1. Do you agree this is a good idea?
2. Does it work as expected?

### Feedback Requested

<!-- What type of feedback you want from your reviewers? -->

(see above)

### External References

<!-- For example: replace xxx with the JIRA ticket number: -->

- [BFD-897](https://jira.cms.gov/browse/BFD-897)

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

This PR has no security implications.

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] altered security controls

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications
<!-- Use this to indicate you're unsure how this change may impact system security and would like to solicit the team's feedback. Optionally, provide background information regarding your questions and concerns. -->

