### PR TITLE
[BFD-907] Enable BFD API V2 in PROD

### DIFF
--- a/ops/ansible/playbooks-ccs/vars/prod/group_vars/all/env_specific.yml
+++ b/ops/ansible/playbooks-ccs/vars/prod/group_vars/all/env_specific.yml
@@ -13,7 +13,7 @@ data_pipeline_ec2_instance_type_vcpu: 16
 data_pipeline_idempotency_required: false
 
 # Whether to enable BFD API V2
-data_server_v2_enabled: false
+data_server_v2_enabled: true
 
 # New Relic Metric API
 data_server_new_relic_metric_host: 'https://gov-metric-api.newrelic.com'

--- a/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
+++ b/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
@@ -98,13 +98,29 @@ stop_service_if_failing() {
   sleep $STARTUP_TESTING_BOOT_TIMEOUT
 
   for I in $(seq $STARTUP_TESTING_RETRIES); do
-    log "Checking metadata endpoint"
+    log "Checking V1 metadata endpoint"
     STARTUP_TESTING_CHECK_METADATA=$(check_endpoint "https://localhost:7443/v1/fhir/metadata?_format=application%2Fjson%2Bfhir" "status")
     STARTUP_TESTING_CHECK_METADATA_EXIT=$?
 
-    log "Checking coverage resource endpoint for bene $STARTUP_TESTING_BENE_ID"
-    STARTUP_TESTING_CHECK_DATABASE=$(check_endpoint "https://localhost:7443/v1/fhir/Coverage?beneficiary=$STARTUP_TESTING_BENE_ID&_format=application%2Fjson%2Bfhir" "id")
-    STARTUP_TESTING_CHECK_DATABASE_EXIT=$?
+    log "Checking V2 metadata endpoint"
+    STARTUP_TESTING_CHECK_METADATA=$(check_endpoint "https://localhost:7443/v2/fhir/metadata?_format=application%2Fjson%2Bfhir" "status")
+    STARTUP_TESTING_CHECK_METADATA_EXIT=$?
+
+    log "Checking V1 Coverage resource endpoint for bene $STARTUP_TESTING_BENE_ID"
+    STARTUP_TESTING_CHECK_COVERAGE=$(check_endpoint "https://localhost:7443/v1/fhir/Coverage?beneficiary=$STARTUP_TESTING_BENE_ID&_format=application%2Fjson%2Bfhir" "id")
+    STARTUP_TESTING_CHECK_COVERAGE_EXIT=$?
+
+    log "Checking V2 Coverage resource endpoint for bene $STARTUP_TESTING_BENE_ID"
+    STARTUP_TESTING_CHECK_COVERAGE=$(check_endpoint "https://localhost:7443/v2/fhir/Coverage?beneficiary=$STARTUP_TESTING_BENE_ID&_format=application%2Fjson%2Bfhir" "id")
+    STARTUP_TESTING_CHECK_COVERAGE_EXIT=$?
+
+    log "Checking V1 EOB resource endpoint for bene $STARTUP_TESTING_BENE_ID"
+    STARTUP_TESTING_CHECK_EOB=$(check_endpoint "https://localhost:7443/v1/fhir/ExplanationOfBenefit/?_format=application%2Ffhir%2Bjson&patient=$STARTUP_TESTING_BENE_ID" "id")
+    STARTUP_TESTING_CHECK_EOB_EXIT=$?
+
+    log "Checking V2 EOB resource endpoint for bene $STARTUP_TESTING_BENE_ID"
+    STARTUP_TESTING_CHECK_EOB=$(check_endpoint "https://localhost:7443/v2/fhir/ExplanationOfBenefit/?_format=application%2Ffhir%2Bjson&patient=$STARTUP_TESTING_BENE_ID" "id")
+    STARTUP_TESTING_CHECK_EOB_EXIT=$?
 
     if [[ $STARTUP_TESTING_CHECK_METADATA_EXIT == 0 ]] && [[ $STARTUP_TESTING_CHECK_DATABASE_EXIT == 0 ]]; then
       log "Server started properly"


### PR DESCRIPTION

### Change Details

This change sets the `data_server_v2_enabled `to `true` for the BFD PROD API servers thus enabling all BFD V2 FHIR Resources and Endpoints (i.e. /v2/fhir/Patient, etc.) 

This change also adds V2 endpoints (and an additional EOB check) to the bfd-server.sh startup script. Is this a good idea?

### Acceptance Validation

Did I set the correct environment variable?

### Feedback Requested

Are we ready for this? :)
Do you all agree having a EOB API check during bfs-server startup is helpful? It would have prevented last weeks PG12 migration incident, because patient and coverage resources performed well, EOB was hosed. 

### External References

<!-- For example: replace xxx with the JIRA ticket number: -->

- [BFD-907](https://jira.cms.gov/browse/BFD-907)

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] altered security controls

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications
<!-- Use this to indicate you're unsure how this change may impact system security and would like to solicit the team's feedback. Optionally, provide background information regarding your questions and concerns. -->

