### PR TITLE
[BFD-911] Containerize BFD Server

### DIFF
--- a/apps/containers/Dockerfile
+++ b/apps/containers/Dockerfile
@@ -7,7 +7,8 @@ RUN mkdir -p /usr/share/man/man1
 RUN set -eux; \
   apt-get update; \
   apt-get install -y --no-install-recommends \
-          maven
+          maven \
+          curl
 
 #COPY .git .git
 COPY apps/containers/toolchains.xml /root/.m2/toolchains.xml
@@ -52,7 +53,7 @@ FROM openjdk:8-slim AS production
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y curl
-RUN mkdir newrelic
+RUN mkdir -p newrelic/extensions
 RUN cd /tmp \
   && curl -O https://download.newrelic.com/newrelic/java-agent/newrelic-agent/current/newrelic-java.zip \
   && unzip newrelic-java.zip
@@ -60,12 +61,12 @@ RUN cd /tmp \
 ADD /tmp/newrelic/newrelic.jar /app/newrelic/newrelic.jar
 
 COPY apps/containers/newrelic.yml newrelic/newrelic.yml
-COPY apps/containers/newrelic.yml newrelic/newrelic_tracing.xml
+COPY apps/containers/newrelic_tracing.xml newrelic/extensions/newrelic_tracing.xml
 
 COPY --from=development /app/bfd-server/bfd-server-launcher/target/bfd-server-launcher-1.0.0-SNAPSHOT-capsule-fat.jar bfd-server-launcher.jar
 COPY --from=development /app/bfd-server/bfd-server-war/target/bfd-server-war-1.0.0-SNAPSHOT.war bfd-server-war.war
 
-#Require ENV vars for production
+#Required ENV vars for production
 #-------------------------------
 #BFD_PORT
 #BFD_V2_ENABLED

--- a/apps/containers/Dockerfile
+++ b/apps/containers/Dockerfile
@@ -1,0 +1,44 @@
+FROM openjdk:8-slim AS development
+
+WORKDIR /app
+
+# installing maven on Debian requires a man directory
+RUN mkdir -p /usr/share/man/man1
+RUN set -eux; \
+  apt-get update; \
+  apt-get install -y --no-install-recommends \
+          maven
+
+COPY .git .git
+COPY apps/containers/toolchains.xml /root/.m2/toolchains.xml
+COPY apps/bfd-server-test-functions bfd-server-test-functions
+COPY apps/bfd-server-test-perf bfd-server-test-perf
+COPY apps/bfd-shared-utils bfd-shared-utils
+COPY apps/bfd-model bfd-model
+COPY apps/bfd-pipeline bfd-pipeline
+COPY apps/bfd-server bfd-server
+COPY apps/pom.xml pom.xml
+
+RUN mvn install -DskipITs
+
+ENV BFD_PORT=6500 \
+    BFD_V2_ENABLED=true \
+    BFD_KEYSTORE=bfd-server/dev/ssl-stores/server-keystore.jks \
+    BFD_TRUSTSTORE=bfd-server/dev/ssl-stores/server-keystore.jks \
+    BFD_WAR=bfd-server/bfd-server-war/target/bfd-server-war-1.0.0-SNAPSHOT.war \
+    LOGS_DIR=/app \
+    DB_URL=jdbc:bfd-test:hsqldb:mem \
+    DB_CONNECTIONS_MAX=40 \
+    TMP_DIR=/tmp
+
+#CMD ["mvn", "-X", "-DskipTests=true", "--projects", "bfd-server-war", "package", "dependency:copy", "antrun:run", "org.codehaus.mojo:exec-maven-plugin:exec@server-start"]
+CMD java \
+  "-Xmx4g" \
+  "-DbfdServer.logs.dir=$LOGS_DIR" \
+  "-DbfdServer.db.url=$DB_URL" \
+  "-DbfdServer.db.username=$DB_USERNAME" \
+  "-DbfdServer.db.password=$DB_PASSWORD" \
+  "-DbfdServer.db.connections.max=$DB_CONNECTIONS_MAX" \
+  "-DbfdServer.v2.enabled=$BFD_V2_ENABLED" \
+  "-Djava.io.tmpdir=$TMP_DIR" \
+  -jar "bfd-server/bfd-server-launcher/target/bfd-server-launcher-1.0.0-SNAPSHOT-capsule-fat.jar" 

--- a/apps/containers/Dockerfile
+++ b/apps/containers/Dockerfile
@@ -9,7 +9,7 @@ RUN set -eux; \
   apt-get install -y --no-install-recommends \
           maven
 
-COPY .git .git
+#COPY .git .git
 COPY apps/containers/toolchains.xml /root/.m2/toolchains.xml
 COPY apps/bfd-server-test-functions bfd-server-test-functions
 COPY apps/bfd-server-test-perf bfd-server-test-perf
@@ -23,16 +23,77 @@ RUN mvn install -DskipITs
 
 ENV BFD_PORT=6500 \
     BFD_V2_ENABLED=true \
-    BFD_KEYSTORE=bfd-server/dev/ssl-stores/server-keystore.jks \
-    BFD_TRUSTSTORE=bfd-server/dev/ssl-stores/server-keystore.jks \
-    BFD_WAR=bfd-server/bfd-server-war/target/bfd-server-war-1.0.0-SNAPSHOT.war \
+    BFD_KEYSTORE=/app/bfd-server/dev/ssl-stores/server-keystore.jks \
+    BFD_TRUSTSTORE=/app/bfd-server/dev/ssl-stores/server-truststore.jks \
+    BFD_WAR=/app/bfd-server/bfd-server-war/target/bfd-server-war-1.0.0-SNAPSHOT.war \
     LOGS_DIR=/app \
-    DB_URL=jdbc:bfd-test:hsqldb:mem \
+    DB_URL=jdbc:postgresql://bfd-db:5432/bfd \
+    DB_USERNAME=bfd \
+    DB_PASSWORD=InsecureLocalDev \
     DB_CONNECTIONS_MAX=40 \
+    SCHEMA_APPLY=true \
     TMP_DIR=/tmp
 
-#CMD ["mvn", "-X", "-DskipTests=true", "--projects", "bfd-server-war", "package", "dependency:copy", "antrun:run", "org.codehaus.mojo:exec-maven-plugin:exec@server-start"]
 CMD java \
+  "-Xmx4g" \
+  "-Dbfd-server-9876" \
+  "-DbfdServer.logs.dir=$LOGS_DIR" \
+  "-DbfdServer.db.url=$DB_URL" \
+  "-DbfdServer.db.username=$DB_USERNAME" \
+  "-DbfdServer.db.password=$DB_PASSWORD" \
+  "-DbfdServer.db.connections.max=$DB_CONNECTIONS_MAX" \
+  "-DbfdServer.v2.enabled=$BFD_V2_ENABLED" \
+  "-DbfdServer.db.schema.apply=true" \
+  "-Djava.io.tmpdir=$TMP_DIR" \
+  -jar "bfd-server/bfd-server-launcher/target/bfd-server-launcher-1.0.0-SNAPSHOT-capsule-fat.jar" 
+
+FROM openjdk:8-slim AS production
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y curl
+RUN mkdir newrelic
+RUN cd /tmp \
+  && curl -O https://download.newrelic.com/newrelic/java-agent/newrelic-agent/current/newrelic-java.zip \
+  && unzip newrelic-java.zip
+
+ADD /tmp/newrelic/newrelic.jar /app/newrelic/newrelic.jar
+
+COPY apps/containers/newrelic.yml newrelic/newrelic.yml
+COPY apps/containers/newrelic.yml newrelic/newrelic_tracing.xml
+
+COPY --from=development /app/bfd-server/bfd-server-launcher/target/bfd-server-launcher-1.0.0-SNAPSHOT-capsule-fat.jar bfd-server-launcher.jar
+COPY --from=development /app/bfd-server/bfd-server-war/target/bfd-server-war-1.0.0-SNAPSHOT.war bfd-server-war.war
+
+#Require ENV vars for production
+#-------------------------------
+#BFD_PORT
+#BFD_V2_ENABLED
+#BFD_KEYSTORE
+#BFD_TRUSTSTORE
+#BFD_WAR
+#LOGS_DIR
+#DB_URL
+#DB_USERNAME
+#DB_PASSWORD
+#DB_CONNECTIONS_MAX
+#TMP_DIR
+#NEW_RELIC_HOST
+#NEW_RELIC_LICENSE_KEY
+#NEW_RELIC_LOG_FILE_PATH
+#NEW_RELIC_HIGH_SECURITY
+#NEW_RELIC_EXTENSIONS_DIR
+#NEW_RELIC_PROXY_HOST
+#NEW_RELIC_PROXY_PORT
+#NEW_RELIC_APP_NAME
+#NEW_RELIC_ENVIRONMENT
+#NEW_RELIC_METRIC_KEY
+#NEW_RELIC_METRIC_HOST
+#NEW_RELIC_METRIC_PATH
+#NEW_RELIC_METRIC_PERIOD
+
+CMD java \
+  -javaagent:/app/newrelic/newrelic.jar \
   "-Xmx4g" \
   "-DbfdServer.logs.dir=$LOGS_DIR" \
   "-DbfdServer.db.url=$DB_URL" \
@@ -40,5 +101,7 @@ CMD java \
   "-DbfdServer.db.password=$DB_PASSWORD" \
   "-DbfdServer.db.connections.max=$DB_CONNECTIONS_MAX" \
   "-DbfdServer.v2.enabled=$BFD_V2_ENABLED" \
-  "-Djava.io.tmpdir=$TMP_DIR" \
-  -jar "bfd-server/bfd-server-launcher/target/bfd-server-launcher-1.0.0-SNAPSHOT-capsule-fat.jar" 
+  "-Djava.io.tmpdir=$TMP_DIR \
+  -jar "bfd-server-launcher.jar" \
+  >>"/app/bluebutton-server-app-log.json" 2>&1
+

--- a/apps/containers/newrelic.yml
+++ b/apps/containers/newrelic.yml
@@ -1,0 +1,22 @@
+# This file configures the New Relic Agent.  New Relic monitors
+# Java applications with deep visibility and low overhead.  For more details and additional
+# configuration options visit https://docs.newrelic.com/docs/agents/java-agent/configuration/java-agent-configuration-config-file.
+common: &default_settings
+  transaction_events:
+    custom_request_headers:
+      - header_name: "BlueButton-OriginalQueryId"
+      - header_name: "BlueButton-OriginalQueryCounter"
+      - header_name: "BlueButton-OriginalQueryTimestamp"
+      - header_name: "BlueButton-DeveloperId"
+      - header_name: "BlueButton-Developer"
+      - header_name: "BlueButton-ApplicationId"
+      - header_name: "BlueButton-Application"
+      - header_name: "BlueButton-UserId"
+      - header_name: "BlueButton-User"
+      - header_name: "BlueButton-BeneficiaryId"
+      - header_name: "x-forwarded-for"
+      - header_name: "BULK-CLIENTID"
+      - header_name: "BULK-JOBID"
+
+production:
+  <<: *default_settings

--- a/apps/containers/newrelic_tracing.xml
+++ b/apps/containers/newrelic_tracing.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extension
+    xmlns="https://newrelic.com/docs/java/xsd/v1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="newrelic-extension extension.xsd"
+    name="tracing"
+    version="1.0"
+    enabled="true">
+  <instrumentation>
+    <!-- The pointcut entries here tell New Relic to trace the specified library/framework methods.
+         For methods we control in our application code, we use the New Relic API's @Trace
+         annotation, instead. -->
+    <pointcut>
+      <className>ca.uhn.fhir.parser.BaseParser</className>
+      <method>
+        <name>encodeResourceToWriter</name>
+        <parameters>
+          <type>org.hl7.fhir.instance.model.api.IBaseResource</type>
+          <type>java.io.Writer</type>
+        </parameters>
+      </method>
+    </pointcut>
+  </instrumentation>
+</extension>

--- a/apps/containers/toolchains.xml
+++ b/apps/containers/toolchains.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF8"?>
+<toolchains>
+  <!-- JDK toolchains -->
+  <toolchain>
+    <type>jdk</type>
+    <provides>
+      <version>1.8</version>
+      <vendor>sun</vendor>
+    </provides>
+    <configuration>
+      <jdkHome>/usr/local/openjdk-8</jdkHome>
+    </configuration>
+  </toolchain>
+</toolchains>

--- a/apps/pom.xml
+++ b/apps/pom.xml
@@ -309,38 +309,6 @@
 					<artifactId>githook-maven-plugin</artifactId>
 					<version>1.0.4</version>
 					<configuration>
-						<hooks>
-							<pre-commit>
-#!/bin/sh
-set -e
-
-checkJavaFormat() {
-  echo 'Verifying Java source code format...'
-
-  if ! git diff --name-only --cached | grep -q '^apps/.*'; then
-    echo 'Verified Java source code format: no staged changes in app/.'
-    return 0
-  fi
-
-  cd apps
-
-  set +e
-  mvn com.coveo:fmt-maven-plugin:check >/dev/null 2>&amp;1
-  checkResult=$?
-  set -e
-
-  if [ ${checkResult} -eq 0 ]; then
-    echo 'Verified Java source code format: a-okay.'
-  else
-    echo "Verified Java source code format: inconsistencies found. Run 'mvn com.coveo:fmt-maven-plugin:check' for details or 'mvn com.coveo:fmt-maven-plugin:format' to automatically apply the required formatting."
-  fi
-
-  return ${checkResult}
-}
-
-checkJavaFormat
-							</pre-commit>
-						</hooks>
 					</configuration>
 				</plugin>
 				<plugin>
@@ -528,19 +496,6 @@ checkJavaFormat
 								on every build, which will auto-format all of our Java source code. Note
 								that we have a Git pre-commit hook that will also do this. -->
 							<goal>format</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>io.github.phillipuniverse</groupId>
-				<artifactId>githook-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<inherited>false</inherited>
-						<goals>
-							<!-- Verify source code formatting prior to commit. -->
-							<goal>install</goal>
 						</goals>
 					</execution>
 				</executions>


### PR DESCRIPTION
### Change Details
This PR supports [BFD-911](https://jira.cms.gov/browse/BFD-911). It attempts to containerize the BFD Server with multistage builds in such a way that it can be run for local development and in deployed production environments. The PR is currently in DRAFT form to get feedback on several open questions:

#### How will it log in production?
Currently logs are stored in files on the EC2 instances. If we're on Fargate or just plain ol' ECS, it may make more sense to use the [awslogs log driver](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_awslogs.html#specify-log-config). Would we want these to go to stdout? Still in files? Something like that would invalidate the need to port [these logrotate pieces](https://github.com/CMSgov/beneficiary-fhir-data/blob/827257afbff126e3c76fbfb79162a86958021caf/ops/ansible/roles/bfd-server/tasks/install.yml#L111-L127), right?

#### How do we want to fetch the server key and trust stores?
The production containers will need access to a keystore and truststore to function properly. Is putting those in an S3 bucket and fetching then in an ENTRYPOINT a viable solution? [This script was used to generate the stores previously](https://github.com/CMSgov/beneficiary-fhir-data/blob/master/ops/ccs-ops-misc/tls-certificates/make_bfd_keystores.sh), so perhaps it's also viable to inject the correct secrets at image build time and use that script to generate them fresh? Open to opinions.

#### Do we really need this formatting webhook installed?
The `githook-maven-plugin` plugin causes some annoying image build problems. Unfortunately, it completely fails maven builds of the app unless it can detect a `.git` directory. And not just `.git/hooks`—it apparently needs the whole thing. Because of how Docker's cache invalidation works, this means that any time _any_ file changes that git is tracking, Docker has to run the maven install step again, which we takes ✨_forever_✨. 

Don't get me wrong—consistent code formatting is important. But we can enforce that before merge in CI jobs rather than as a pre-commit hook and save ourselves the pain of lengthy image rebuilds. I'm also totally open to missing something here. Maybe there's a way to avoid this. Maybe there are other git hook alternatives.

Besides those questions, there are a couple of things left to do. 

#### Running server against in-memory DB
The Dockerfile currently works great when networked against a Postgres container, but doesn't start properly when trying to spawn an in-memory DB. It specifically complains about missing a test `.properties` file in `bfd-server/bfd-server-war/target/server-work`. 

#### Docker compose
I'm still going to add a `docker-compose.yml` that networks the database and server together and mounts volumes with the relevant source code for local development. Just getting the main Dockerfile ironed out first.

### Acceptance Validation

### Feedback Requested

Can you help me think through the questions in the description?

### External References

<!-- For example: replace xxx with the JIRA ticket number: -->

- [BFD-911](https://jira.cms.gov/browse/BFD-911)

### Security Implications
- [ ] new software dependencies
- [ ] altered security controls
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

This PR itself won't change anything, because this won't be running anywhere at first. This is the start of future work that _will_ change things.

