### PR TITLE
Revert "[BFD-878] Reduce Java Util Date Use (#693)"

### DIFF
--- a/apps/bfd-model/bfd-model-codegen/src/main/java/gov/cms/bfd/model/codegen/RifLayoutsProcessor.java
+++ b/apps/bfd-model/bfd-model-codegen/src/main/java/gov/cms/bfd/model/codegen/RifLayoutsProcessor.java
@@ -29,6 +29,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -64,6 +65,8 @@ import javax.persistence.OneToMany;
 import javax.persistence.OrderBy;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 import javax.persistence.Transient;
 import javax.tools.Diagnostic;
 import javax.tools.FileObject;
@@ -1120,7 +1123,12 @@ public final class RifLayoutsProcessor extends AbstractProcessor {
 
     // Add a lastUpdated field.
     final FieldSpec lastUpdatedField =
-        FieldSpec.builder(Instant.class, "lastUpdated", Modifier.PRIVATE).build();
+        FieldSpec.builder(Date.class, "lastUpdated", Modifier.PRIVATE)
+            .addAnnotation(
+                AnnotationSpec.builder(Temporal.class)
+                    .addMember("value", "$T.TIMESTAMP", TemporalType.class)
+                    .build())
+            .build();
     headerEntityClass.addField(lastUpdatedField);
 
     // Getter method
@@ -1128,7 +1136,7 @@ public final class RifLayoutsProcessor extends AbstractProcessor {
         MethodSpec.methodBuilder("getLastUpdated")
             .addModifiers(Modifier.PUBLIC)
             .addStatement("return Optional.ofNullable(lastUpdated)")
-            .returns(ParameterizedTypeName.get(Optional.class, Instant.class))
+            .returns(ParameterizedTypeName.get(Optional.class, Date.class))
             .build();
     headerEntityClass.addMethod(lastUpdatedGetter);
 
@@ -1136,7 +1144,7 @@ public final class RifLayoutsProcessor extends AbstractProcessor {
     final MethodSpec lastUpdatedSetter =
         MethodSpec.methodBuilder("setLastUpdated")
             .addModifiers(Modifier.PUBLIC)
-            .addParameter(ParameterSpec.builder(Instant.class, "lastUpdated").build())
+            .addParameter(ParameterSpec.builder(Date.class, "lastUpdated").build())
             .addStatement("this.lastUpdated = lastUpdated")
             .returns(TypeName.VOID)
             .build();

--- a/apps/bfd-model/bfd-model-rif/src/main/java/gov/cms/bfd/model/rif/LoadedBatch.java
+++ b/apps/bfd-model/bfd-model-rif/src/main/java/gov/cms/bfd/model/rif/LoadedBatch.java
@@ -1,8 +1,8 @@
 package gov.cms.bfd.model.rif;
 
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.persistence.*;
@@ -29,7 +29,8 @@ public class LoadedBatch {
   private String beneficiaries;
 
   @Column(name = "`created`", nullable = false)
-  private Instant created;
+  @Temporal(TemporalType.TIMESTAMP)
+  private Date created;
 
   /** default constructor */
   public LoadedBatch() {}
@@ -42,7 +43,7 @@ public class LoadedBatch {
    * @param beneficiaries to associate
    * @param created batch creation date
    */
-  public LoadedBatch(long loadedBatchId, long loadedFileId, String beneficiaries, Instant created) {
+  public LoadedBatch(long loadedBatchId, long loadedFileId, String beneficiaries, Date created) {
     this();
     this.loadedBatchId = loadedBatchId;
     this.loadedFileId = loadedFileId;
@@ -59,7 +60,7 @@ public class LoadedBatch {
    * @param created batch creation date
    */
   public LoadedBatch(
-      long loadedBatchId, long loadedFileId, List<String> beneficiaries, Instant created) {
+      long loadedBatchId, long loadedFileId, List<String> beneficiaries, Date created) {
     this();
     this.loadedBatchId = loadedBatchId;
     this.loadedFileId = loadedFileId;
@@ -98,12 +99,12 @@ public class LoadedBatch {
   }
 
   /** @return the creation time stamp */
-  public Instant getCreated() {
+  public Date getCreated() {
     return created;
   }
 
   /** @param created time stamp to set */
-  public void setCreated(Instant created) {
+  public void setCreated(Date created) {
     this.created = created;
   }
 
@@ -144,7 +145,7 @@ public class LoadedBatch {
             : b.beneficiaries.isEmpty()
                 ? a.beneficiaries
                 : a.beneficiaries + SEPARATOR + b.beneficiaries;
-    sum.created = (a.created.isAfter(b.created)) ? a.created : b.created;
+    sum.created = (a.created.after(b.created)) ? a.created : b.created;
     return sum;
   }
 

--- a/apps/bfd-model/bfd-model-rif/src/main/java/gov/cms/bfd/model/rif/LoadedBatchBuilder.java
+++ b/apps/bfd-model/bfd-model-rif/src/main/java/gov/cms/bfd/model/rif/LoadedBatchBuilder.java
@@ -1,14 +1,14 @@
 package gov.cms.bfd.model.rif;
 
-import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 /** Class to build a LoadedBatch. Thread safe. */
 public class LoadedBatchBuilder {
   private final List<String> beneficiaries;
   private final long loadedFileId;
-  private final Instant timestamp;
+  private final Date timestamp;
 
   /**
    * Create a builder from a particular file event
@@ -19,7 +19,7 @@ public class LoadedBatchBuilder {
   public LoadedBatchBuilder(long loadedFileId, int capacityIncrement) {
     this.loadedFileId = loadedFileId;
     this.beneficiaries = new ArrayList<>(capacityIncrement);
-    this.timestamp = Instant.now();
+    this.timestamp = new Date();
   }
 
   /**
@@ -52,7 +52,7 @@ public class LoadedBatchBuilder {
    *
    * @return the timestamp of the batch
    */
-  public Instant getTimestamp() {
+  public Date getTimestamp() {
     return timestamp;
   }
 }

--- a/apps/bfd-model/bfd-model-rif/src/main/java/gov/cms/bfd/model/rif/LoadedFile.java
+++ b/apps/bfd-model/bfd-model-rif/src/main/java/gov/cms/bfd/model/rif/LoadedFile.java
@@ -1,6 +1,6 @@
 package gov.cms.bfd.model.rif;
 
-import java.time.Instant;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 import javax.persistence.*;
@@ -21,7 +21,8 @@ public class LoadedFile {
   private String rifType;
 
   @Column(name = "`created`", nullable = false)
-  private Instant created;
+  @Temporal(TemporalType.TIMESTAMP)
+  private Date created;
 
   @OneToMany(
       mappedBy = "loadedFileId",
@@ -39,7 +40,7 @@ public class LoadedFile {
    * @param rifType RifFileType
    * @param created time stamp
    */
-  public LoadedFile(long loadedFileId, String rifType, Instant created) {
+  public LoadedFile(long loadedFileId, String rifType, Date created) {
     this();
     this.loadedFileId = loadedFileId;
     this.rifType = rifType;
@@ -77,12 +78,12 @@ public class LoadedFile {
   }
 
   /** @return the creation time stamp */
-  public Instant getCreated() {
+  public Date getCreated() {
     return created;
   }
 
   /** @param created time stamp to set */
-  public void setCreated(Instant created) {
+  public void setCreated(Date created) {
     this.created = created;
   }
 

--- a/apps/bfd-model/bfd-model-rif/src/main/java/gov/cms/bfd/model/rif/RifRecordBase.java
+++ b/apps/bfd-model/bfd-model-rif/src/main/java/gov/cms/bfd/model/rif/RifRecordBase.java
@@ -1,11 +1,11 @@
 package gov.cms.bfd.model.rif;
 
-import java.time.Instant;
+import java.util.Date;
 import java.util.Optional;
 
 /** Common interface for RifRecords */
 public interface RifRecordBase {
-  Optional<Instant> getLastUpdated();
+  Optional<Date> getLastUpdated();
 
-  void setLastUpdated(Instant lastUpdated);
+  void setLastUpdated(Date lastUpdated);
 }

--- a/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/main/java/gov/cms/bfd/pipeline/ccw/rif/load/RifLoader.java
+++ b/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/main/java/gov/cms/bfd/pipeline/ccw/rif/load/RifLoader.java
@@ -39,6 +39,7 @@ import java.time.Period;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -917,7 +918,7 @@ public final class RifLoader {
       EntityManager entityManager,
       Beneficiary newBeneficiaryRecord,
       Optional<Beneficiary> oldBeneficiaryRecord,
-      Instant batchTimestamp) {
+      Date batchTimestamp) {
     if (oldBeneficiaryRecord.isPresent()
         && !isBeneficiaryHistoryEqual(newBeneficiaryRecord, oldBeneficiaryRecord.get())) {
       BeneficiaryHistory oldBeneCopy = new BeneficiaryHistory();
@@ -1035,7 +1036,7 @@ public final class RifLoader {
 
     final LoadedFile loadedFile = new LoadedFile();
     loadedFile.setRifType(fileEvent.getFile().getFileType().toString());
-    loadedFile.setCreated(Instant.now());
+    loadedFile.setCreated(new Date());
 
     try {
       EntityManager em = appState.getEntityManagerFactory().createEntityManager();
@@ -1079,7 +1080,7 @@ public final class RifLoader {
       try {
         txn = em.getTransaction();
         txn.begin();
-        final Instant oldDate = Instant.now().minus(MAX_FILE_AGE_DAYS);
+        final Date oldDate = Date.from(Instant.now().minus(MAX_FILE_AGE_DAYS));
 
         em.clear(); // Must be done before JPQL statements
         em.flush();

--- a/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/test/java/gov/cms/bfd/pipeline/ccw/rif/load/RifLoaderIT.java
+++ b/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/test/java/gov/cms/bfd/pipeline/ccw/rif/load/RifLoaderIT.java
@@ -22,6 +22,7 @@ import java.time.LocalDate;
 import java.time.Month;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -136,7 +137,7 @@ public final class RifLoaderIT {
                   afterOldestFile.getLoadedFileId());
               Assert.assertTrue(
                   "Expected range to expand",
-                  beforeLoadedFile.getCreated().isBefore(afterLoadedFile.getCreated()));
+                  beforeLoadedFile.getCreated().before(afterLoadedFile.getCreated()));
             });
   }
 
@@ -152,16 +153,16 @@ public final class RifLoaderIT {
               final EntityTransaction txn = entityManager.getTransaction();
               txn.begin();
               LoadedFile oldFile = loadedFiles.get(loadedFiles.size() - 1);
-              oldFile.setCreated(Instant.now().minus(101, ChronoUnit.DAYS));
+              oldFile.setCreated(Date.from(Instant.now().minus(101, ChronoUnit.DAYS)));
               txn.commit();
 
               // Look at the files now
               final List<LoadedFile> beforeFiles =
                   PipelineTestUtils.get().findLoadedFiles(entityManager);
-              final Instant oldDate = Instant.now().minus(99, ChronoUnit.DAYS);
+              final Date oldDate = Date.from(Instant.now().minus(99, ChronoUnit.DAYS));
               Assert.assertTrue(
                   "Expect to have old files",
-                  beforeFiles.stream().anyMatch(file -> file.getCreated().isBefore(oldDate)));
+                  beforeFiles.stream().anyMatch(file -> file.getCreated().before(oldDate)));
 
               // Load another set that will cause the old file to be trimmed
               loadSample(dataSource, Arrays.asList(StaticRifResourceGroup.SAMPLE_U.getResources()));
@@ -171,7 +172,7 @@ public final class RifLoaderIT {
                   PipelineTestUtils.get().findLoadedFiles(entityManager);
               Assert.assertFalse(
                   "Expect to not have old files",
-                  afterFiles.stream().anyMatch(file -> file.getCreated().isBefore(oldDate)));
+                  afterFiles.stream().anyMatch(file -> file.getCreated().before(oldDate)));
             });
   }
 
@@ -229,7 +230,7 @@ public final class RifLoaderIT {
                 lastUpdated -> {
                   Assert.assertTrue(
                       "Expected a recent lastUpdated timestamp",
-                      lastUpdated.isAfter(Instant.now().minus(10, ChronoUnit.MINUTES)));
+                      lastUpdated.after(Date.from(Instant.now().minus(10, ChronoUnit.MINUTES))));
                 });
       }
       Assert.assertEquals(4, beneficiaryHistoryEntries.size());
@@ -255,7 +256,7 @@ public final class RifLoaderIT {
               lastUpdated -> {
                 Assert.assertTrue(
                     "Expected a recent lastUpdated timestamp",
-                    lastUpdated.isAfter(Instant.now().minus(1, ChronoUnit.MINUTES)));
+                    lastUpdated.after(Date.from(Instant.now().minus(1, ChronoUnit.MINUTES))));
               });
 
       CarrierClaim carrierRecordFromDb = entityManager.find(CarrierClaim.class, "9991831999");
@@ -273,7 +274,7 @@ public final class RifLoaderIT {
               lastUpdated -> {
                 Assert.assertTrue(
                     "Expected a recent lastUpdated timestamp",
-                    lastUpdated.isAfter(Instant.now().minus(1, ChronoUnit.MINUTES)));
+                    lastUpdated.after(Date.from(Instant.now().minus(1, ChronoUnit.MINUTES))));
               });
 
       CarrierClaimLine carrierLineRecordFromDb = carrierRecordFromDb.getLines().get(0);
@@ -331,7 +332,7 @@ public final class RifLoaderIT {
                 lastUpdated -> {
                   Assert.assertFalse(
                       "Expected not a recent lastUpdated timestamp",
-                      lastUpdated.isAfter(Instant.now().minusSeconds(secs)));
+                      lastUpdated.after(Date.from(Instant.now().minusSeconds(secs))));
                 });
       }
       // Make sure the size is the same and no records have been inserted if the same fields in the

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/commons/LoadedFileFilter.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/commons/LoadedFileFilter.java
@@ -2,7 +2,7 @@ package gov.cms.bfd.server.war.commons;
 
 import ca.uhn.fhir.rest.param.DateParam;
 import ca.uhn.fhir.rest.param.DateRangeParam;
-import java.time.Instant;
+import java.util.Date;
 import org.apache.spark.util.sketch.BloomFilter;
 
 /**
@@ -20,8 +20,8 @@ public class LoadedFileFilter {
   private final int batchesCount;
 
   // The interval of time when the RIF load took place
-  private final Instant firstUpdated;
-  private final Instant lastUpdated;
+  private final Date firstUpdated;
+  private final Date lastUpdated;
 
   // The beneficiaries that were updated in the RIF load
   private final BloomFilter updatedBeneficiaries;
@@ -38,8 +38,8 @@ public class LoadedFileFilter {
   public LoadedFileFilter(
       long loadedFileId,
       int batchesCount,
-      Instant firstUpdated,
-      Instant lastUpdated,
+      Date firstUpdated,
+      Date lastUpdated,
       BloomFilter updatedBeneficiaries) {
     this.loadedFileId = loadedFileId;
     this.batchesCount = batchesCount;
@@ -61,12 +61,12 @@ public class LoadedFileFilter {
     if (upperBound != null) {
       switch (upperBound.getPrefix()) {
         case LESSTHAN:
-          if (upperBound.getValue().toInstant().isBefore(getFirstUpdated())) {
+          if (upperBound.getValue().getTime() <= getFirstUpdated().getTime()) {
             return false;
           }
           break;
         case LESSTHAN_OR_EQUALS:
-          if (!upperBound.getValue().toInstant().isAfter(getFirstUpdated())) {
+          if (upperBound.getValue().getTime() < getFirstUpdated().getTime()) {
             return false;
           }
           break;
@@ -79,12 +79,12 @@ public class LoadedFileFilter {
     if (lowerBound != null) {
       switch (lowerBound.getPrefix()) {
         case GREATERTHAN:
-          if (!lowerBound.getValue().toInstant().isBefore(getLastUpdated())) {
+          if (lowerBound.getValue().getTime() >= getLastUpdated().getTime()) {
             return false;
           }
           break;
         case GREATERTHAN_OR_EQUALS:
-          if (lowerBound.getValue().toInstant().isAfter(getLastUpdated())) {
+          if (lowerBound.getValue().getTime() > getLastUpdated().getTime()) {
             return false;
           }
           break;
@@ -112,12 +112,12 @@ public class LoadedFileFilter {
   }
 
   /** @return the firstUpdated */
-  public Instant getFirstUpdated() {
+  public Date getFirstUpdated() {
     return firstUpdated;
   }
 
   /** @return the lastUpdated */
-  public Instant getLastUpdated() {
+  public Date getLastUpdated() {
     return lastUpdated;
   }
 

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/commons/LoadedFilterManager.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/commons/LoadedFilterManager.java
@@ -5,6 +5,7 @@ import gov.cms.bfd.model.rif.LoadedBatch;
 import gov.cms.bfd.model.rif.LoadedFile;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -31,7 +32,8 @@ public class LoadedFilterManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(LoadedFilterManager.class);
 
   // A date before the lastUpdate feature was rolled out
-  private static final Instant BEFORE_LAST_UPDATED_FEATURE = Instant.parse("2020-01-01T00:00:00Z");
+  private static final Date BEFORE_LAST_UPDATED_FEATURE =
+      Date.from(Instant.parse("2020-01-01T00:00:00Z"));
 
   // The size of the beneficiaryId column
   private static final int BENE_ID_SIZE = 15;
@@ -43,13 +45,13 @@ public class LoadedFilterManager {
   private List<LoadedFileFilter> filters;
 
   // The latest transaction time from the LoadedBatch files
-  private Instant transactionTime;
+  private Date transactionTime;
 
   // The last LoadedBatch.created in the filter set
-  private Instant lastBatchCreated;
+  private Date lastBatchCreated;
 
   // The first LoadedBatch.created in the filter set
-  private Instant firstBatchCreated;
+  private Date firstBatchCreated;
 
   /**
    * A tuple of values: LoadedFile.loadedFileid, LoadedFile.created, max(LoadedBatch.created). Used
@@ -57,10 +59,10 @@ public class LoadedFilterManager {
    */
   public static class LoadedTuple {
     private long loadedFileId;
-    private Instant firstUpdated;
-    private Instant lastUpdated;
+    private Date firstUpdated;
+    private Date lastUpdated;
 
-    public LoadedTuple(long loadedFileId, Instant firstUpdated, Instant lastUpdated) {
+    public LoadedTuple(long loadedFileId, Date firstUpdated, Date lastUpdated) {
       this.loadedFileId = loadedFileId;
       this.firstUpdated = firstUpdated;
       this.lastUpdated = lastUpdated;
@@ -70,11 +72,11 @@ public class LoadedFilterManager {
       return loadedFileId;
     }
 
-    public Instant getFirstUpdated() {
+    public Date getFirstUpdated() {
       return firstUpdated;
     }
 
-    public Instant getLastUpdated() {
+    public Date getLastUpdated() {
       return lastUpdated;
     }
   }
@@ -94,7 +96,7 @@ public class LoadedFilterManager {
    *
    * @return the last batch's created timestamp
    */
-  public Instant getTransactionTime() {
+  public Date getTransactionTime() {
     if (transactionTime == null) {
       throw new RuntimeException("LoadedFilterManager has not been initialized.");
     }
@@ -106,7 +108,7 @@ public class LoadedFilterManager {
    *
    * @return the first batch's created timestamp
    */
-  public Instant getLastBatchCreated() {
+  public Date getLastBatchCreated() {
     if (lastBatchCreated == null) {
       throw new RuntimeException("LoadedFilterManager has not been refreshed.");
     }
@@ -118,7 +120,7 @@ public class LoadedFilterManager {
    *
    * @return the first batch's created timestamp
    */
-  public Instant getFirstBatchCreated() {
+  public Date getFirstBatchCreated() {
     if (firstBatchCreated == null) {
       throw new RuntimeException("LoadedFilterManager has not been refreshed.");
     }
@@ -167,9 +169,8 @@ public class LoadedFilterManager {
         if (filter.mightContain(beneficiaryId)) {
           return false;
         }
-      } else if (filter
-          .getLastUpdated()
-          .isBefore(lastUpdatedRange.getLowerBoundAsInstant().toInstant())) {
+      } else if (filter.getLastUpdated().getTime()
+          < lastUpdatedRange.getLowerBoundAsInstant().getTime()) {
         // filters are sorted in descending by lastUpdated time, so we can exit early from this
         // loop
         return true;
@@ -192,9 +193,8 @@ public class LoadedFilterManager {
 
     // The manager has a "known" interval which it has information about. The known range
     // is from the firstFilterUpdate to the future.
-    final Instant lowerBound =
-        range.getLowerBoundAsInstant() != null ? range.getLowerBoundAsInstant().toInstant() : null;
-    return lowerBound != null && lowerBound.toEpochMilli() >= getFirstBatchCreated().toEpochMilli();
+    final Date lowerBound = range.getLowerBoundAsInstant();
+    return lowerBound != null && lowerBound.getTime() >= getFirstBatchCreated().getTime();
   }
 
   /**
@@ -216,11 +216,11 @@ public class LoadedFilterManager {
      */
     try {
       // If new batches are present, then build new filters for the affected files
-      final Instant currentLastBatchCreated =
+      final Date currentLastBatchCreated =
           fetchLastLoadedBatchCreated().orElse(BEFORE_LAST_UPDATED_FEATURE);
 
       if (this.lastBatchCreated == null
-          || this.lastBatchCreated.isBefore(currentLastBatchCreated)) {
+          || this.lastBatchCreated.toInstant().isBefore(currentLastBatchCreated.toInstant())) {
         LOGGER.info(
             "Refreshing LoadedFile filters with new filters from {} to {}",
             lastBatchCreated,
@@ -231,11 +231,11 @@ public class LoadedFilterManager {
             updateFilters(this.filters, loadedTuples, this::fetchLoadedBatches);
 
         // If batches been trimmed, then remove filters which are no longer present
-        final Instant currentFirstBatchUpdate =
+        final Date currentFirstBatchUpdate =
             fetchFirstLoadedBatchCreated().orElse(BEFORE_LAST_UPDATED_FEATURE);
 
         if (this.firstBatchCreated == null
-            || this.firstBatchCreated.isBefore(currentFirstBatchUpdate)) {
+            || this.firstBatchCreated.before(currentFirstBatchUpdate)) {
           LOGGER.info("Trimmed LoadedFile filters before {}", currentFirstBatchUpdate);
           List<LoadedFile> loadedFiles = fetchLoadedFiles();
           newFilters = trimFilters(newFilters, loadedFiles);
@@ -261,7 +261,7 @@ public class LoadedFilterManager {
    * @param lastBatchCreated to use
    */
   public synchronized void set(
-      List<LoadedFileFilter> filters, Instant firstBatchCreated, Instant lastBatchCreated) {
+      List<LoadedFileFilter> filters, Date firstBatchCreated, Date lastBatchCreated) {
     this.filters = filters;
     this.firstBatchCreated = firstBatchCreated;
     this.lastBatchCreated = lastBatchCreated;
@@ -354,7 +354,7 @@ public class LoadedFilterManager {
    * @return a new filter
    */
   public static LoadedFileFilter buildFilter(
-      long fileId, Instant firstUpdated, Function<Long, List<LoadedBatch>> fetchById) {
+      long fileId, Date firstUpdated, Function<Long, List<LoadedBatch>> fetchById) {
     final List<LoadedBatch> loadedBatches = fetchById.apply(fileId);
     final int batchCount = loadedBatches.size();
     if (batchCount == 0) {
@@ -368,12 +368,12 @@ public class LoadedFilterManager {
     final BloomFilter bloomFilter = LoadedFileFilter.createFilter(batchSize * batchCount);
 
     // Loop through all batches, filling the bloom filter and finding the lastUpdated
-    Instant lastUpdated = firstUpdated;
+    Date lastUpdated = firstUpdated;
     for (LoadedBatch batch : loadedBatches) {
       for (String beneficiary : batch.getBeneficiariesAsList()) {
         bloomFilter.putString(beneficiary);
       }
-      if (batch.getCreated().isAfter(lastUpdated)) {
+      if (batch.getCreated().after(lastUpdated)) {
         lastUpdated = batch.getCreated();
       }
     }
@@ -390,10 +390,10 @@ public class LoadedFilterManager {
    *
    * @return the max date
    */
-  private Optional<Instant> fetchLastLoadedBatchCreated() {
-    Instant maxCreated =
+  private Optional<Date> fetchLastLoadedBatchCreated() {
+    Date maxCreated =
         entityManager
-            .createQuery("select max(b.created) from LoadedBatch b", Instant.class)
+            .createQuery("select max(b.created) from LoadedBatch b", Date.class)
             .getSingleResult();
     return Optional.ofNullable(maxCreated);
   }
@@ -403,10 +403,10 @@ public class LoadedFilterManager {
    *
    * @return the min date
    */
-  private Optional<Instant> fetchFirstLoadedBatchCreated() {
-    Instant minBatchId =
+  private Optional<Date> fetchFirstLoadedBatchCreated() {
+    Date minBatchId =
         entityManager
-            .createQuery("select min(b.created) from LoadedBatch b", Instant.class)
+            .createQuery("select min(b.created) from LoadedBatch b", Date.class)
             .getSingleResult();
     return Optional.ofNullable(minBatchId);
   }
@@ -417,7 +417,7 @@ public class LoadedFilterManager {
    * @param after limits the query to include batches created after this timestamp
    * @return tuples that meet the after criteria or an empty list
    */
-  private List<LoadedTuple> fetchLoadedTuples(Instant after) {
+  private List<LoadedTuple> fetchLoadedTuples(Date after) {
     final CriteriaBuilder cb = entityManager.getCriteriaBuilder();
     CriteriaQuery<LoadedTuple> query = cb.createQuery(LoadedTuple.class);
     final Root<LoadedFile> f = query.from(LoadedFile.class);

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/commons/QueryUtils.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/commons/QueryUtils.java
@@ -2,6 +2,7 @@ package gov.cms.bfd.server.war.commons;
 
 import ca.uhn.fhir.rest.param.DateRangeParam;
 import java.time.Instant;
+import java.util.Date;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.Path;
 import javax.persistence.criteria.Predicate;
@@ -78,11 +79,9 @@ public class QueryUtils {
    */
   public static Predicate createLastUpdatedPredicate(
       CriteriaBuilder cb, Root<?> root, DateRangeParam range) {
-    final Path<Instant> lastUpdatedPath = root.get("lastUpdated");
-    final Instant lowerBound =
-        range.getLowerBoundAsInstant() == null ? null : range.getLowerBoundAsInstant().toInstant();
-    final Instant upperBound =
-        range.getUpperBoundAsInstant() == null ? null : range.getUpperBoundAsInstant().toInstant();
+    final Path<Date> lastUpdatedPath = root.get("lastUpdated");
+    final Date lowerBound = range.getLowerBoundAsInstant();
+    final Date upperBound = range.getUpperBoundAsInstant();
     Predicate lowerBoundPredicate;
     Predicate upperBoundPredicate;
 
@@ -134,15 +133,15 @@ public class QueryUtils {
    * @param range to base test against. Maybe null.
    * @return true iff within the range specified
    */
-  public static boolean isInRange(Instant lastUpdated, DateRangeParam range) {
+  public static boolean isInRange(Date lastUpdated, DateRangeParam range) {
     if (range == null || range.isEmpty()) {
       return true;
     }
     // The null lastUpdated is considered to be a very early time for this calculation
-    final long lastUpdatedMillis = lastUpdated == null ? 0L : lastUpdated.toEpochMilli();
+    final long lastUpdatedMillis = lastUpdated == null ? 0L : lastUpdated.getTime();
 
     if (range.getLowerBound() != null) {
-      final long lowerBoundMillis = range.getLowerBoundAsInstant().toInstant().toEpochMilli();
+      final long lowerBoundMillis = range.getLowerBoundAsInstant().getTime();
       switch (range.getLowerBound().getPrefix()) {
         case GREATERTHAN:
           if (lastUpdatedMillis <= lowerBoundMillis) {

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/commons/TransformerConstants.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/commons/TransformerConstants.java
@@ -6,6 +6,7 @@ import gov.cms.bfd.model.rif.Beneficiary;
 import gov.cms.bfd.model.rif.CarrierClaimColumn;
 import gov.cms.bfd.server.war.stu3.providers.PatientResourceProvider;
 import java.time.Instant;
+import java.util.Date;
 import org.hl7.fhir.dstu3.model.Coding;
 import org.hl7.fhir.dstu3.model.Coverage;
 import org.hl7.fhir.dstu3.model.Coverage.GroupComponent;
@@ -317,7 +318,7 @@ public final class TransformerConstants {
    * Fallback value to use when a record does not have a lastUpdated value. These records where
    * loaded before the lastUpdated feature was in place.
    */
-  public static final Instant FALLBACK_LAST_UPDATED = Instant.parse("2020-01-01T00:00:00Z");
+  public static final Date FALLBACK_LAST_UPDATED = Date.from(Instant.parse("2020-01-01T00:00:00Z"));
 
   /**
    * CARIN Code System for Patient Identifier Type <a

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/R4ExplanationOfBenefitResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/R4ExplanationOfBenefitResourceProvider.java
@@ -26,12 +26,12 @@ import gov.cms.bfd.server.war.commons.LoadedFilterManager;
 import gov.cms.bfd.server.war.commons.OffsetLinkBuilder;
 import gov.cms.bfd.server.war.commons.QueryUtils;
 import gov.cms.bfd.server.war.commons.TransformerConstants;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.ListIterator;
@@ -427,21 +427,15 @@ public final class R4ExplanationOfBenefitResourceProvider implements IResourcePr
     }
 
     if (claimEntities != null && serviceDate != null && !serviceDate.isEmpty()) {
-      final Instant lowerBound =
-          serviceDate.getLowerBoundAsInstant() != null
-              ? serviceDate.getLowerBoundAsInstant().toInstant()
-              : null;
-      final Instant upperBound =
-          serviceDate.getUpperBoundAsInstant() != null
-              ? serviceDate.getUpperBoundAsInstant().toInstant()
-              : null;
+      final Date lowerBound = serviceDate.getLowerBoundAsInstant();
+      final Date upperBound = serviceDate.getUpperBoundAsInstant();
       final java.util.function.Predicate<LocalDate> lowerBoundCheck =
           lowerBound == null
               ? (date) -> true
               : (date) ->
                   compareLocalDate(
                       date,
-                      lowerBound.atZone(ZoneId.systemDefault()).toLocalDate(),
+                      lowerBound.toInstant().atZone(ZoneId.systemDefault()).toLocalDate(),
                       serviceDate.getLowerBound().getPrefix());
       final java.util.function.Predicate<LocalDate> upperBoundCheck =
           upperBound == null
@@ -449,7 +443,7 @@ public final class R4ExplanationOfBenefitResourceProvider implements IResourcePr
               : (date) ->
                   compareLocalDate(
                       date,
-                      upperBound.atZone(ZoneId.systemDefault()).toLocalDate(),
+                      upperBound.toInstant().atZone(ZoneId.systemDefault()).toLocalDate(),
                       serviceDate.getUpperBound().getPrefix());
       return claimEntities.stream()
           .filter(

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/R4PatientResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/R4PatientResourceProvider.java
@@ -226,9 +226,7 @@ public final class R4PatientResourceProvider implements IResourceProvider, Commo
       try {
         patients =
             Optional.of(read(new IdType(logicalId.getValue()), requestDetails))
-                .filter(
-                    p ->
-                        QueryUtils.isInRange(p.getMeta().getLastUpdated().toInstant(), lastUpdated))
+                .filter(p -> QueryUtils.isInRange(p.getMeta().getLastUpdated(), lastUpdated))
                 .map(p -> Collections.singletonList((IBaseResource) p))
                 .orElse(Collections.emptyList());
       } catch (ResourceNotFoundException e) {
@@ -589,7 +587,7 @@ public final class R4PatientResourceProvider implements IResourceProvider, Commo
       }
 
       patients =
-          QueryUtils.isInRange(patient.getMeta().getLastUpdated().toInstant(), lastUpdated)
+          QueryUtils.isInRange(patient.getMeta().getLastUpdated(), lastUpdated)
               ? Collections.singletonList(patient)
               : Collections.emptyList();
     } catch (NoResultException e) {

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/TransformerUtilsV2.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/TransformerUtilsV2.java
@@ -2,7 +2,6 @@ package gov.cms.bfd.server.war.r4.providers;
 
 import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import ca.uhn.fhir.model.primitive.IdDt;
-import ca.uhn.fhir.parser.DataFormatException;
 import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import gov.cms.bfd.model.codebook.data.CcwCodebookMissingVariable;
@@ -41,7 +40,8 @@ import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.time.Instant;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Arrays;
@@ -50,7 +50,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -407,18 +406,18 @@ public final class TransformerUtilsV2 {
       CcwCodebookInterface ccwVariable, Optional<BigDecimal> dateYear) {
 
     Extension extension = null;
-    if (!dateYear.isPresent()) {
-      throw new NoSuchElementException();
-    }
     try {
-      String stringDate = dateYear.get().toString();
-      DateType dateYearValue = new DateType(stringDate);
+      String stringDate = dateYear.get().toString() + "-01-01";
+      Date date1 = new SimpleDateFormat("yyyy-MM-dd").parse(stringDate);
+      DateType dateYearValue = new DateType(date1, TemporalPrecisionEnum.YEAR);
       String extensionUrl = calculateVariableReferenceUrl(ccwVariable);
       extension = new Extension(extensionUrl, dateYearValue);
-    } catch (DataFormatException e) {
+
+    } catch (ParseException e) {
       throw new InvalidRifValueException(
-          String.format("Unable to create DateYear with reference year: '%s'.", dateYear.get()), e);
+          String.format("Unable to parse reference year: '%s'.", dateYear.get()), e);
     }
+
     return extension;
   }
 
@@ -1156,7 +1155,9 @@ public final class TransformerUtilsV2 {
    * @param date the {@link LocalDate} to set the {@link Period#getEnd()} value with/to
    */
   static void setPeriodEnd(Period period, LocalDate date) {
-    period.setEnd(convertToDate(date), TemporalPrecisionEnum.DAY);
+    period.setEnd(
+        Date.from(date.atStartOfDay(ZoneId.systemDefault()).toInstant()),
+        TemporalPrecisionEnum.DAY);
   }
 
   /**
@@ -1172,7 +1173,9 @@ public final class TransformerUtilsV2 {
    * @param date the {@link LocalDate} to set the {@link Period#getStart()} value with/to
    */
   static void setPeriodStart(Period period, LocalDate date) {
-    period.setStart(convertToDate(date), TemporalPrecisionEnum.DAY);
+    period.setStart(
+        Date.from(date.atStartOfDay(ZoneId.systemDefault()).toInstant()),
+        TemporalPrecisionEnum.DAY);
   }
 
   /**
@@ -1479,7 +1482,7 @@ public final class TransformerUtilsV2 {
    *     {@link Patient}s, which may contain multiple matching resources, or may also be empty.
    */
   public static Bundle createBundle(
-      OffsetLinkBuilder paging, List<IBaseResource> resources, Instant transactionTime) {
+      OffsetLinkBuilder paging, List<IBaseResource> resources, Date transactionTime) {
     Bundle bundle = new Bundle();
     if (paging.isPagingRequested()) {
       /*
@@ -1501,18 +1504,18 @@ public final class TransformerUtilsV2 {
      * performance reason, the resources of the bundle may be after the filter manager's version of
      * the timestamp.
      */
-    Instant maxBundleDate =
+    Date maxBundleDate =
         resources.stream()
-            .map(r -> r.getMeta().getLastUpdated().toInstant())
+            .map(r -> r.getMeta().getLastUpdated())
             .filter(Objects::nonNull)
-            .max(Instant::compareTo)
+            .max(Date::compareTo)
             .orElse(transactionTime);
     bundle
         .getMeta()
         .setLastUpdated(
-            transactionTime.isAfter(maxBundleDate)
-                ? Date.from(transactionTime)
-                : Date.from(maxBundleDate));
+            transactionTime.toInstant().isAfter(maxBundleDate.toInstant())
+                ? transactionTime
+                : maxBundleDate);
     bundle.setTotal(resources.size());
     return bundle;
   }
@@ -1528,7 +1531,7 @@ public final class TransformerUtilsV2 {
    *     {@link Patient}s, which may contain multiple matching resources, or may also be empty.
    */
   public static Bundle createBundle(
-      List<IBaseResource> resources, LinkBuilder paging, Instant transactionTime) {
+      List<IBaseResource> resources, LinkBuilder paging, Date transactionTime) {
     Bundle bundle = new Bundle();
     TransformerUtilsV2.addResourcesToBundle(bundle, resources);
     paging.addLinks(bundle);
@@ -1541,18 +1544,18 @@ public final class TransformerUtilsV2 {
      * performance reason, the resources of the bundle may be after the filter manager's version of
      * the timestamp.
      */
-    Instant maxBundleDate =
+    Date maxBundleDate =
         resources.stream()
-            .map(r -> r.getMeta().getLastUpdated().toInstant())
+            .map(r -> r.getMeta().getLastUpdated())
             .filter(Objects::nonNull)
-            .max(Instant::compareTo)
+            .max(Date::compareTo)
             .orElse(transactionTime);
     bundle
         .getMeta()
         .setLastUpdated(
-            transactionTime.isAfter(maxBundleDate)
-                ? Date.from(transactionTime)
-                : Date.from(maxBundleDate));
+            transactionTime.toInstant().isAfter(maxBundleDate.toInstant())
+                ? transactionTime
+                : maxBundleDate);
     return bundle;
   }
 
@@ -1617,10 +1620,10 @@ public final class TransformerUtilsV2 {
    * @param resource is the FHIR resource to set lastUpdate
    * @param lastUpdated is the lastUpdated value set. If not present, set the fallback lastUpdated.
    */
-  public static void setLastUpdated(IAnyResource resource, Optional<Instant> lastUpdated) {
+  public static void setLastUpdated(IAnyResource resource, Optional<Date> lastUpdated) {
     resource
         .getMeta()
-        .setLastUpdated(Date.from(lastUpdated.orElse(TransformerConstants.FALLBACK_LAST_UPDATED)));
+        .setLastUpdated(lastUpdated.orElse(TransformerConstants.FALLBACK_LAST_UPDATED));
   }
 
   /**
@@ -1630,15 +1633,12 @@ public final class TransformerUtilsV2 {
    * @param resource is the FHIR resource to update
    * @param lastUpdated is the lastUpdated value from the entity
    */
-  public static void updateMaxLastUpdated(IAnyResource resource, Optional<Instant> lastUpdated) {
+  public static void updateMaxLastUpdated(IAnyResource resource, Optional<Date> lastUpdated) {
     lastUpdated.ifPresent(
         newDate -> {
-          Instant currentDate =
-              resource.getMeta().getLastUpdated() != null
-                  ? resource.getMeta().getLastUpdated().toInstant()
-                  : null;
-          if (currentDate != null && newDate.isAfter(currentDate)) {
-            resource.getMeta().setLastUpdated(Date.from(newDate));
+          Date currentDate = resource.getMeta().getLastUpdated();
+          if (currentDate != null && newDate.after(currentDate)) {
+            resource.getMeta().setLastUpdated(newDate);
           }
         });
   }
@@ -2939,7 +2939,7 @@ public final class TransformerUtilsV2 {
       BigDecimal totalChargeAmount,
       BigDecimal primaryPayerPaidAmount,
       Optional<String> fiscalIntermediaryNumber,
-      Optional<Instant> lastUpdated) {
+      Optional<Date> lastUpdated) {
 
     // ORG_NPI_NUM => ExplanationOfBenefit.provider
     addProviderSlice(eob, C4BBOrganizationIdentifierType.NPI, organizationNpi, lastUpdated);
@@ -3337,7 +3337,7 @@ public final class TransformerUtilsV2 {
       ExplanationOfBenefit eob,
       C4BBOrganizationIdentifierType type,
       Optional<String> value,
-      Optional<Instant> lastUpdated) {
+      Optional<Date> lastUpdated) {
     if (value.isPresent()) {
       Resource providerResource = findOrCreateContainedOrg(eob, PROVIDER_ORG_ID);
 
@@ -3376,7 +3376,7 @@ public final class TransformerUtilsV2 {
       ExplanationOfBenefit eob,
       C4BBOrganizationIdentifierType type,
       String value,
-      Optional<Instant> lastupdated) {
+      Optional<Date> lastupdated) {
     addProviderSlice(eob, type, Optional.of(value), lastupdated);
   }
 

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/ExplanationOfBenefitResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/ExplanationOfBenefitResourceProvider.java
@@ -26,12 +26,12 @@ import gov.cms.bfd.server.war.commons.LoadedFilterManager;
 import gov.cms.bfd.server.war.commons.OffsetLinkBuilder;
 import gov.cms.bfd.server.war.commons.QueryUtils;
 import gov.cms.bfd.server.war.commons.TransformerConstants;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.ListIterator;
@@ -407,21 +407,15 @@ public final class ExplanationOfBenefitResourceProvider implements IResourceProv
     }
 
     if (claimEntities != null && serviceDate != null && !serviceDate.isEmpty()) {
-      final Instant lowerBound =
-          serviceDate.getLowerBoundAsInstant() != null
-              ? serviceDate.getLowerBoundAsInstant().toInstant()
-              : null;
-      final Instant upperBound =
-          serviceDate.getUpperBoundAsInstant() != null
-              ? serviceDate.getUpperBoundAsInstant().toInstant()
-              : null;
+      final Date lowerBound = serviceDate.getLowerBoundAsInstant();
+      final Date upperBound = serviceDate.getUpperBoundAsInstant();
       final java.util.function.Predicate<LocalDate> lowerBoundCheck =
           lowerBound == null
               ? (date) -> true
               : (date) ->
                   compareLocalDate(
                       date,
-                      lowerBound.atZone(ZoneId.systemDefault()).toLocalDate(),
+                      lowerBound.toInstant().atZone(ZoneId.systemDefault()).toLocalDate(),
                       serviceDate.getLowerBound().getPrefix());
       final java.util.function.Predicate<LocalDate> upperBoundCheck =
           upperBound == null
@@ -429,7 +423,7 @@ public final class ExplanationOfBenefitResourceProvider implements IResourceProv
               : (date) ->
                   compareLocalDate(
                       date,
-                      upperBound.atZone(ZoneId.systemDefault()).toLocalDate(),
+                      upperBound.toInstant().atZone(ZoneId.systemDefault()).toLocalDate(),
                       serviceDate.getUpperBound().getPrefix());
       return claimEntities.stream()
           .filter(

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
@@ -281,9 +281,7 @@ public final class PatientResourceProvider implements IResourceProvider, CommonH
       try {
         patients =
             Optional.of(read(new IdType(logicalId.getValue()), requestDetails))
-                .filter(
-                    p ->
-                        QueryUtils.isInRange(p.getMeta().getLastUpdated().toInstant(), lastUpdated))
+                .filter(p -> QueryUtils.isInRange(p.getMeta().getLastUpdated(), lastUpdated))
                 .map(p -> Collections.singletonList((IBaseResource) p))
                 .orElse(Collections.emptyList());
       } catch (ResourceNotFoundException e) {
@@ -653,7 +651,7 @@ public final class PatientResourceProvider implements IResourceProvider, CommonH
       }
 
       patients =
-          QueryUtils.isInRange(patient.getMeta().getLastUpdated().toInstant(), lastUpdated)
+          QueryUtils.isInRange(patient.getMeta().getLastUpdated(), lastUpdated)
               ? Collections.singletonList(patient)
               : Collections.emptyList();
     } catch (NoResultException e) {

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtils.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtils.java
@@ -2,7 +2,6 @@ package gov.cms.bfd.server.war.stu3.providers;
 
 import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import ca.uhn.fhir.model.primitive.IdDt;
-import ca.uhn.fhir.parser.DataFormatException;
 import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import com.codahale.metrics.MetricRegistry;
@@ -53,7 +52,8 @@ import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.time.Instant;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -64,7 +64,6 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -859,18 +858,18 @@ public final class TransformerUtils {
       CcwCodebookInterface ccwVariable, Optional<BigDecimal> dateYear) {
 
     Extension extension = null;
-    if (!dateYear.isPresent()) {
-      throw new NoSuchElementException();
-    }
     try {
-      String stringDate = dateYear.get().toString();
-      DateType dateYearValue = new DateType(stringDate);
+      String stringDate = dateYear.get().toString() + "-01-01";
+      Date date1 = new SimpleDateFormat("yyyy-MM-dd").parse(stringDate);
+      DateType dateYearValue = new DateType(date1, TemporalPrecisionEnum.YEAR);
       String extensionUrl = calculateVariableReferenceUrl(ccwVariable);
       extension = new Extension(extensionUrl, dateYearValue);
-    } catch (DataFormatException e) {
+
+    } catch (ParseException e) {
       throw new InvalidRifValueException(
-          String.format("Unable to create DateYear with reference year: '%s'.", dateYear.get()), e);
+          String.format("Unable to parse reference year: '%s'.", dateYear.get()), e);
     }
+
     return extension;
   }
 
@@ -1301,7 +1300,9 @@ public final class TransformerUtils {
    * @param date the {@link LocalDate} to set the {@link Period#getEnd()} value with/to
    */
   static void setPeriodEnd(Period period, LocalDate date) {
-    period.setEnd(convertToDate(date), TemporalPrecisionEnum.DAY);
+    period.setEnd(
+        Date.from(date.atStartOfDay(ZoneId.systemDefault()).toInstant()),
+        TemporalPrecisionEnum.DAY);
   }
 
   /**
@@ -1309,7 +1310,9 @@ public final class TransformerUtils {
    * @param date the {@link LocalDate} to set the {@link Period#getStart()} value with/to
    */
   static void setPeriodStart(Period period, LocalDate date) {
-    period.setStart(convertToDate(date), TemporalPrecisionEnum.DAY);
+    period.setStart(
+        Date.from(date.atStartOfDay(ZoneId.systemDefault()).toInstant()),
+        TemporalPrecisionEnum.DAY);
   }
 
   /**
@@ -3143,7 +3146,7 @@ public final class TransformerUtils {
    *     {@link Patient}s, which may contain multiple matching resources, or may also be empty.
    */
   public static Bundle createBundle(
-      OffsetLinkBuilder paging, List<IBaseResource> resources, Instant transactionTime) {
+      OffsetLinkBuilder paging, List<IBaseResource> resources, Date transactionTime) {
     Bundle bundle = new Bundle();
     if (paging.isPagingRequested()) {
       /*
@@ -3165,18 +3168,18 @@ public final class TransformerUtils {
      * performance reason, the resources of the bundle may be after the filter manager's version of
      * the timestamp.
      */
-    Instant maxBundleDate =
+    Date maxBundleDate =
         resources.stream()
-            .map(r -> r.getMeta().getLastUpdated().toInstant())
+            .map(r -> r.getMeta().getLastUpdated())
             .filter(Objects::nonNull)
-            .max(Instant::compareTo)
+            .max(Date::compareTo)
             .orElse(transactionTime);
     bundle
         .getMeta()
         .setLastUpdated(
-            transactionTime.isAfter(maxBundleDate)
-                ? Date.from(transactionTime)
-                : Date.from(maxBundleDate));
+            transactionTime.toInstant().isAfter(maxBundleDate.toInstant())
+                ? transactionTime
+                : maxBundleDate);
     bundle.setTotal(resources.size());
     return bundle;
   }
@@ -3192,7 +3195,7 @@ public final class TransformerUtils {
    *     {@link Patient}s, which may contain multiple matching resources, or may also be empty.
    */
   public static Bundle createBundle(
-      List<IBaseResource> resources, LinkBuilder paging, Instant transactionTime) {
+      List<IBaseResource> resources, LinkBuilder paging, Date transactionTime) {
     Bundle bundle = new Bundle();
     TransformerUtils.addResourcesToBundle(bundle, resources);
     paging.addLinks(bundle);
@@ -3205,18 +3208,18 @@ public final class TransformerUtils {
      * performance reason, the resources of the bundle may be after the filter manager's version of
      * the timestamp.
      */
-    Instant maxBundleDate =
+    Date maxBundleDate =
         resources.stream()
-            .map(r -> r.getMeta().getLastUpdated().toInstant())
+            .map(r -> r.getMeta().getLastUpdated())
             .filter(Objects::nonNull)
-            .max(Instant::compareTo)
+            .max(Date::compareTo)
             .orElse(transactionTime);
     bundle
         .getMeta()
         .setLastUpdated(
-            transactionTime.isAfter(maxBundleDate)
-                ? Date.from(transactionTime)
-                : Date.from(maxBundleDate));
+            transactionTime.toInstant().isAfter(maxBundleDate.toInstant())
+                ? transactionTime
+                : maxBundleDate);
     return bundle;
   }
 
@@ -3281,10 +3284,10 @@ public final class TransformerUtils {
    * @param resource is the FHIR resource to set lastUpdate
    * @param lastUpdated is the lastUpdated value set. If not present, set the fallback lastUdpated.
    */
-  public static void setLastUpdated(IAnyResource resource, Optional<Instant> lastUpdated) {
+  public static void setLastUpdated(IAnyResource resource, Optional<Date> lastUpdated) {
     resource
         .getMeta()
-        .setLastUpdated(Date.from(lastUpdated.orElse(TransformerConstants.FALLBACK_LAST_UPDATED)));
+        .setLastUpdated(lastUpdated.orElse(TransformerConstants.FALLBACK_LAST_UPDATED));
   }
 
   /**
@@ -3294,15 +3297,12 @@ public final class TransformerUtils {
    * @param resource is the FHIR resource to update
    * @param lastUpdated is the lastUpdated value from the entity
    */
-  public static void updateMaxLastUpdated(IAnyResource resource, Optional<Instant> lastUpdated) {
+  public static void updateMaxLastUpdated(IAnyResource resource, Optional<Date> lastUpdated) {
     lastUpdated.ifPresent(
         newDate -> {
-          Instant currentDate =
-              resource.getMeta().getLastUpdated() != null
-                  ? resource.getMeta().getLastUpdated().toInstant()
-                  : null;
-          if (currentDate != null && newDate.isAfter(currentDate)) {
-            resource.getMeta().setLastUpdated(Date.from(newDate));
+          Date currentDate = resource.getMeta().getLastUpdated();
+          if (currentDate != null && newDate.after(currentDate)) {
+            resource.getMeta().setLastUpdated(newDate);
           }
         });
   }

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/BeneficiaryTransformerV2Test.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/BeneficiaryTransformerV2Test.java
@@ -17,7 +17,6 @@ import gov.cms.bfd.server.war.ServerTestUtils;
 import gov.cms.bfd.server.war.commons.ProfileConstants;
 import gov.cms.bfd.server.war.commons.RequestHeaders;
 import java.text.SimpleDateFormat;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -63,7 +62,7 @@ public final class BeneficiaryTransformerV2Test {
             .findFirst()
             .get();
 
-    beneficiary.setLastUpdated(Instant.now());
+    beneficiary.setLastUpdated(new Date());
     beneficiary.setMbiHash(Optional.of("someMBIhash"));
 
     // Add the history records to the Beneficiary, but nill out the HICN fields.

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/CarrierClaimTransformerV2Test.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/CarrierClaimTransformerV2Test.java
@@ -10,8 +10,8 @@ import gov.cms.bfd.server.war.ServerTestUtils;
 import gov.cms.bfd.server.war.commons.MedicareSegment;
 import gov.cms.bfd.server.war.commons.TransformerConstants;
 import java.text.SimpleDateFormat;
-import java.time.Instant;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import org.hl7.fhir.exceptions.FHIRException;
@@ -58,7 +58,7 @@ public class CarrierClaimTransformerV2Test {
             .findFirst()
             .get();
 
-    claim.setLastUpdated(Instant.now());
+    claim.setLastUpdated(new Date());
 
     return claim;
   }

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/CoverageTransformerV2Test.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/CoverageTransformerV2Test.java
@@ -49,7 +49,7 @@ public final class CoverageTransformerV2Test {
 
     Calendar calen = Calendar.getInstance();
     calen.set(2021, 3, 17);
-    beneficiary.setLastUpdated(calen.getTime().toInstant());
+    beneficiary.setLastUpdated(calen.getTime());
   }
 
   /** Standalone wrapper to output PART_A */

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/DMEClaimTransformerV2Test.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/DMEClaimTransformerV2Test.java
@@ -1,6 +1,7 @@
 package gov.cms.bfd.server.war.r4.providers;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import com.codahale.metrics.MetricRegistry;
 import gov.cms.bfd.model.rif.DMEClaim;
 import gov.cms.bfd.model.rif.samples.StaticRifResourceGroup;
@@ -10,8 +11,8 @@ import gov.cms.bfd.server.war.commons.TransformerConstants;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.SimpleDateFormat;
-import java.time.Instant;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import org.hl7.fhir.exceptions.FHIRException;
@@ -32,6 +33,7 @@ import org.hl7.fhir.r4.model.ExplanationOfBenefit.Use;
 import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Money;
+import org.hl7.fhir.r4.model.Period;
 import org.hl7.fhir.r4.model.Quantity;
 import org.hl7.fhir.r4.model.Reference;
 import org.junit.Assert;
@@ -60,7 +62,7 @@ public final class DMEClaimTransformerV2Test {
             .findFirst()
             .get();
 
-    claim.setLastUpdated(Instant.now());
+    claim.setLastUpdated(new Date());
 
     return claim;
   }
@@ -534,14 +536,17 @@ public final class DMEClaimTransformerV2Test {
 
   @Test
   public void shouldHaveLineItemServicedPeriod() throws Exception {
-    Assert.assertNotNull(eob.getItemFirstRep().getServicedPeriod().getStart());
-    Assert.assertNotNull(eob.getItemFirstRep().getServicedPeriod().getEnd());
-    Assert.assertEquals(
-        (new SimpleDateFormat("yyy-MM-dd")).parse("2014-02-03"),
-        eob.getItemFirstRep().getServicedPeriod().getStart());
-    Assert.assertEquals(
-        (new SimpleDateFormat("yyy-MM-dd")).parse("2014-02-03"),
-        eob.getItemFirstRep().getServicedPeriod().getEnd());
+    Date serviceStart = eob.getItemFirstRep().getServicedPeriod().getStart();
+    Date serviceEnd = eob.getItemFirstRep().getServicedPeriod().getEnd();
+
+    Period compare = new Period();
+    compare.setStart(
+        new SimpleDateFormat("yyy-MM-dd").parse("2014-02-03"), TemporalPrecisionEnum.DAY);
+    compare.setEnd(
+        new SimpleDateFormat("yyy-MM-dd").parse("2014-02-03"), TemporalPrecisionEnum.DAY);
+
+    Assert.assertEquals(compare.getStart().toString(), serviceStart.toString());
+    Assert.assertEquals(compare.getEnd().toString(), serviceEnd.toString());
   }
 
   @Test

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/HHAClaimTransformerV2Test.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/HHAClaimTransformerV2Test.java
@@ -11,8 +11,8 @@ import gov.cms.bfd.server.war.commons.TransformerConstants;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.SimpleDateFormat;
-import java.time.Instant;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import org.hl7.fhir.exceptions.FHIRException;
@@ -63,7 +63,7 @@ public class HHAClaimTransformerV2Test {
             .findFirst()
             .get();
 
-    claim.setLastUpdated(Instant.now());
+    claim.setLastUpdated(new Date());
 
     return claim;
   }

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/HospiceClaimTransformerV2Test.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/HospiceClaimTransformerV2Test.java
@@ -12,9 +12,9 @@ import gov.cms.bfd.server.war.commons.MedicareSegment;
 import gov.cms.bfd.server.war.commons.ProfileConstants;
 import gov.cms.bfd.server.war.commons.TransformerConstants;
 import java.text.SimpleDateFormat;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import org.hl7.fhir.exceptions.FHIRException;
@@ -66,7 +66,7 @@ public final class HospiceClaimTransformerV2Test {
             .findFirst()
             .get();
 
-    claim.setLastUpdated(Instant.now());
+    claim.setLastUpdated(new Date());
     createEOB(Optional.of(false));
   }
 

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/InpatientClaimTransformerV2Test.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/InpatientClaimTransformerV2Test.java
@@ -8,8 +8,8 @@ import gov.cms.bfd.server.war.ServerTestUtils;
 import gov.cms.bfd.server.war.commons.ProfileConstants;
 import gov.cms.bfd.server.war.commons.TransformerConstants;
 import java.text.SimpleDateFormat;
-import java.time.Instant;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import org.hl7.fhir.exceptions.FHIRException;
@@ -63,7 +63,7 @@ public final class InpatientClaimTransformerV2Test {
             .findFirst()
             .get();
 
-    claim.setLastUpdated(Instant.now());
+    claim.setLastUpdated(new Date());
 
     return claim;
   }

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/OutpatientClaimTransformerV2Test.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/OutpatientClaimTransformerV2Test.java
@@ -8,8 +8,8 @@ import gov.cms.bfd.server.war.ServerTestUtils;
 import gov.cms.bfd.server.war.commons.ProfileConstants;
 import gov.cms.bfd.server.war.commons.TransformerConstants;
 import java.text.SimpleDateFormat;
-import java.time.Instant;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import org.hl7.fhir.exceptions.FHIRException;
@@ -60,7 +60,7 @@ public final class OutpatientClaimTransformerV2Test {
             .findFirst()
             .get();
 
-    claim.setLastUpdated(Instant.now());
+    claim.setLastUpdated(new Date());
 
     return claim;
   }

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/PartDEventTransformerV2Test.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/PartDEventTransformerV2Test.java
@@ -10,8 +10,8 @@ import gov.cms.bfd.server.war.commons.TransformerConstants;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.SimpleDateFormat;
-import java.time.Instant;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import org.hl7.fhir.exceptions.FHIRException;
@@ -55,7 +55,7 @@ public final class PartDEventTransformerV2Test {
             .findFirst()
             .get();
 
-    claim.setLastUpdated(Instant.now());
+    claim.setLastUpdated(new Date());
 
     return claim;
   }

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/R4ExplanationOfBenefitResourceProviderIT.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/R4ExplanationOfBenefitResourceProviderIT.java
@@ -1317,7 +1317,7 @@ public final class R4ExplanationOfBenefitResourceProviderIT {
 
     Assert.assertEquals(
         "Expect null lastUpdated fields to map to the FALLBACK_LAST_UPDATED",
-        Date.from(TransformerConstants.FALLBACK_LAST_UPDATED),
+        TransformerConstants.FALLBACK_LAST_UPDATED,
         filterToClaimType(searchAll, ClaimTypeV2.CARRIER).get(0).getMeta().getLastUpdated());
 
     // Find all EOBs with < now()
@@ -1332,7 +1332,7 @@ public final class R4ExplanationOfBenefitResourceProviderIT {
 
     Assert.assertEquals(
         "Expect null lastUpdated fields to map to the FALLBACK_LAST_UPDATED",
-        Date.from(TransformerConstants.FALLBACK_LAST_UPDATED),
+        TransformerConstants.FALLBACK_LAST_UPDATED,
         filterToClaimType(searchWithLessThan, ClaimTypeV2.CARRIER)
             .get(0)
             .getMeta()

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/TransformerTestUtilsV2.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/TransformerTestUtilsV2.java
@@ -15,8 +15,10 @@ import java.math.RoundingMode;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import org.hl7.fhir.exceptions.FHIRException;
@@ -325,7 +327,8 @@ public final class TransformerTestUtilsV2 {
    * @param actual the actual {@link BaseDateTimeType} to verify
    */
   static void assertDateEquals(LocalDate expected, BaseDateTimeType actual) {
-    Assert.assertEquals(TransformerUtilsV2.convertToDate(expected), actual.getValue());
+    Assert.assertEquals(
+        Date.from(expected.atStartOfDay(ZoneId.systemDefault()).toInstant()), actual.getValue());
     Assert.assertEquals(TemporalPrecisionEnum.DAY, actual.getPrecision());
   }
 
@@ -934,7 +937,7 @@ public final class TransformerTestUtilsV2 {
    * @param actualResource that is being created by the transform
    */
   static void assertLastUpdatedEquals(
-      Optional<Instant> expectedDateTime, IAnyResource actualResource) {
+      Optional<Date> expectedDateTime, IAnyResource actualResource) {
     if (expectedDateTime.isPresent()) {
       /* Dev Note: We often run our tests in parallel, so there is subtle race condition because we
        * use one instance of an IT DB with the same resources for most tests.
@@ -942,7 +945,7 @@ public final class TransformerTestUtilsV2 {
        * because another test over wrote the same resource.
        * To handle this case, dates that are within a second of each other match.
        */
-      final Instant expectedLastUpdated = expectedDateTime.get();
+      final Instant expectedLastUpdated = expectedDateTime.get().toInstant();
       final Instant actualLastUpdated = actualResource.getMeta().getLastUpdated().toInstant();
       final Duration diff = Duration.between(expectedLastUpdated, actualLastUpdated);
       Assert.assertTrue(
@@ -952,7 +955,7 @@ public final class TransformerTestUtilsV2 {
       Assert.assertEquals(
           "Expect lastUpdated to be the fallback value",
           TransformerConstants.FALLBACK_LAST_UPDATED,
-          actualResource.getMeta().getLastUpdated().toInstant());
+          actualResource.getMeta().getLastUpdated());
     }
   }
 

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/BeneficiaryTransformerTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/BeneficiaryTransformerTest.java
@@ -11,8 +11,8 @@ import gov.cms.bfd.server.war.ServerTestUtils;
 import gov.cms.bfd.server.war.commons.RequestHeaders;
 import gov.cms.bfd.server.war.commons.Sex;
 import gov.cms.bfd.server.war.commons.TransformerConstants;
-import java.time.Instant;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -228,7 +228,7 @@ public final class BeneficiaryTransformerTest {
     Beneficiary beneficiary = loadSampleABeneficiary();
 
     RequestHeaders requestHeader = getRHwithIncldIdntityHdr("");
-    beneficiary.setLastUpdated(Instant.now());
+    beneficiary.setLastUpdated(new Date());
     Patient patientWithLastUpdated =
         BeneficiaryTransformer.transform(new MetricRegistry(), beneficiary, requestHeader);
     assertMatches(beneficiary, patientWithLastUpdated, requestHeader);

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/CarrierClaimTransformerTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/CarrierClaimTransformerTest.java
@@ -10,8 +10,8 @@ import gov.cms.bfd.server.war.ServerTestUtils;
 import gov.cms.bfd.server.war.commons.MedicareSegment;
 import gov.cms.bfd.server.war.commons.TransformerConstants;
 import java.math.BigDecimal;
-import java.time.Instant;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import org.hl7.fhir.dstu3.model.ExplanationOfBenefit;
@@ -42,7 +42,7 @@ public final class CarrierClaimTransformerTest {
             .findFirst()
             .get();
 
-    claim.setLastUpdated(Instant.now());
+    claim.setLastUpdated(new Date());
     ExplanationOfBenefit eobWithLastUpdated =
         CarrierClaimTransformer.transform(new MetricRegistry(), claim, Optional.of(true));
     assertMatches(claim, eobWithLastUpdated, Optional.of(true));

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/CoverageTransformerTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/CoverageTransformerTest.java
@@ -8,8 +8,8 @@ import gov.cms.bfd.model.rif.samples.StaticRifResourceGroup;
 import gov.cms.bfd.server.war.ServerTestUtils;
 import gov.cms.bfd.server.war.commons.MedicareSegment;
 import gov.cms.bfd.server.war.commons.TransformerConstants;
-import java.time.Instant;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import org.hl7.fhir.dstu3.model.Coverage;
@@ -38,7 +38,7 @@ public final class CoverageTransformerTest {
             .map(r -> (Beneficiary) r)
             .findFirst()
             .get();
-    beneficiary.setLastUpdated(Instant.now());
+    beneficiary.setLastUpdated(new Date());
 
     Coverage partACoverage =
         CoverageTransformer.transform(new MetricRegistry(), MedicareSegment.PART_A, beneficiary);

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/ExplanationOfBenefitResourceProviderIT.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/ExplanationOfBenefitResourceProviderIT.java
@@ -1699,7 +1699,7 @@ public final class ExplanationOfBenefitResourceProviderIT {
             .execute();
     Assert.assertEquals(
         "Expect null lastUpdated fields to map to the FALLBACK_LAST_UPDATED",
-        Date.from(TransformerConstants.FALLBACK_LAST_UPDATED),
+        TransformerConstants.FALLBACK_LAST_UPDATED,
         filterToClaimType(searchAll, ClaimType.CARRIER).get(0).getMeta().getLastUpdated());
 
     // Find all EOBs with < now()
@@ -1713,7 +1713,7 @@ public final class ExplanationOfBenefitResourceProviderIT {
             .execute();
     Assert.assertEquals(
         "Expect null lastUpdated fields to map to the FALLBACK_LAST_UPDATED",
-        Date.from(TransformerConstants.FALLBACK_LAST_UPDATED),
+        TransformerConstants.FALLBACK_LAST_UPDATED,
         filterToClaimType(searchWithLessThan, ClaimType.CARRIER).get(0).getMeta().getLastUpdated());
     Assert.assertEquals(
         "Expected the search for lastUpdated <= now() to include resources with fallback lastUpdated values",

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/InpatientClaimTransformerTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/InpatientClaimTransformerTest.java
@@ -11,8 +11,9 @@ import gov.cms.bfd.server.war.commons.CCWProcedure;
 import gov.cms.bfd.server.war.commons.Diagnosis;
 import gov.cms.bfd.server.war.commons.MedicareSegment;
 import java.math.BigDecimal;
-import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import org.hl7.fhir.dstu3.model.ExplanationOfBenefit;
@@ -41,7 +42,7 @@ public final class InpatientClaimTransformerTest {
             .map(r -> (InpatientClaim) r)
             .findFirst()
             .get();
-    claim.setLastUpdated(Instant.now());
+    claim.setLastUpdated(new Date());
 
     ExplanationOfBenefit eob =
         InpatientClaimTransformer.transform(new MetricRegistry(), claim, Optional.empty());
@@ -180,7 +181,7 @@ public final class InpatientClaimTransformerTest {
         claim.getProcedure1Code().get(),
         eob.getProcedure().get(0).getProcedureCodeableConcept().getCoding());
     Assert.assertEquals(
-        TransformerUtils.convertToDate(claim.getProcedure1Date().get()),
+        Date.from(claim.getProcedure1Date().get().atStartOfDay(ZoneId.systemDefault()).toInstant()),
         eob.getProcedure().get(0).getDate());
 
     // test to ensure the procedure code display lookup table process works

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/LoadedFilterManagerIT.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/LoadedFilterManagerIT.java
@@ -44,7 +44,7 @@ public final class LoadedFilterManagerIT {
               // After init manager should have an empty filter list but a valid transaction time
               Assert.assertTrue(
                   "Expect transactionTime be before now",
-                  filterManager.getTransactionTime().isBefore(Instant.now()));
+                  filterManager.getTransactionTime().before(new Date()));
               final List<LoadedFileFilter> beforeFilters = filterManager.getFilters();
               Assert.assertEquals(0, beforeFilters.size());
               final DateRangeParam testBound =
@@ -59,7 +59,7 @@ public final class LoadedFilterManagerIT {
               // Should have zero filters
               Assert.assertTrue(
                   "Expect transactionTime be before now",
-                  filterManager.getTransactionTime().isBefore(Instant.now()));
+                  filterManager.getTransactionTime().before(new Date()));
               final List<LoadedFileFilter> afterFilters = filterManager.getFilters();
               Assert.assertEquals(0, afterFilters.size());
               Assert.assertFalse(filterManager.isInBounds(testBound));
@@ -75,8 +75,9 @@ public final class LoadedFilterManagerIT {
               final LoadedFilterManager filterManager = new LoadedFilterManager();
               filterManager.setEntityManager(entityManager);
               filterManager.init();
-              final Instant initialTransactionTime = filterManager.getTransactionTime();
-              Assert.assertTrue(initialTransactionTime.isBefore(Instant.now().plusMillis(1)));
+              final Date initialTransactionTime = filterManager.getTransactionTime();
+              Assert.assertTrue(
+                  initialTransactionTime.before(Date.from(Instant.now().plusMillis(1))));
               loadData(dataSource, Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
               Date afterLoad = new Date();
 
@@ -91,12 +92,11 @@ public final class LoadedFilterManagerIT {
               // Should have many filters
               final List<LoadedFileFilter> afterFilters = filterManager.getFilters();
               Assert.assertTrue(
-                  filterManager.getFirstBatchCreated().toEpochMilli() <= afterLoad.getTime());
+                  filterManager.getFirstBatchCreated().getTime() <= afterLoad.getTime());
               Assert.assertTrue(
-                  filterManager.getLastBatchCreated().toEpochMilli() <= afterRefresh.getTime());
+                  filterManager.getLastBatchCreated().getTime() <= afterRefresh.getTime());
               Assert.assertTrue(
-                  filterManager.getTransactionTime().toEpochMilli()
-                      > initialTransactionTime.toEpochMilli());
+                  filterManager.getTransactionTime().getTime() > initialTransactionTime.getTime());
               Assert.assertTrue(afterFilters.size() > 1);
             });
   }

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/LoadedFilterTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/LoadedFilterTest.java
@@ -19,7 +19,11 @@ public final class LoadedFilterTest {
     final BloomFilter emptyFilter = LoadedFileFilter.createFilter(10);
     final LoadedFileFilter filter1 =
         new LoadedFileFilter(
-            1, 0, Instant.now().minusSeconds(10), Instant.now().minusSeconds(5), emptyFilter);
+            1,
+            0,
+            Date.from(Instant.now().minusSeconds(10)),
+            Date.from(Instant.now().minusSeconds(5)),
+            emptyFilter);
 
     Assert.assertTrue(
         "Expected null range to be treated as an infinite range", filter1.matchesDateRange(null));
@@ -87,7 +91,11 @@ public final class LoadedFilterTest {
 
     final LoadedFileFilter filter1 =
         new LoadedFileFilter(
-            1, 1, Instant.now().minusSeconds(10), Instant.now().minusSeconds(5), smallFilter);
+            1,
+            1,
+            Date.from(Instant.now().minusSeconds(10)),
+            Date.from(Instant.now().minusSeconds(5)),
+            smallFilter);
 
     Assert.assertTrue("Expected to contain this", filter1.mightContain("1"));
     Assert.assertFalse("Expected to not contain this", filter1.mightContain("888"));

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/OutpatientClaimTransformerTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/OutpatientClaimTransformerTest.java
@@ -12,6 +12,7 @@ import gov.cms.bfd.server.war.commons.CCWProcedure;
 import gov.cms.bfd.server.war.commons.MedicareSegment;
 import java.time.ZoneId;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -197,8 +198,9 @@ public final class OutpatientClaimTransformerTest {
           claim.getProcedure1Code().get(),
           eob.getProcedure().get(0).getProcedureCodeableConcept().getCoding());
       Assert.assertEquals(
-          claim.getProcedure1Date().get().atStartOfDay(ZoneId.systemDefault()).toInstant(),
-          eob.getProcedure().get(0).getDate().toInstant());
+          Date.from(
+              claim.getProcedure1Date().get().atStartOfDay(ZoneId.systemDefault()).toInstant()),
+          eob.getProcedure().get(0).getDate());
     }
 
     Assert.assertTrue("Expect actual item count is above 0", 1 <= eob.getItem().size());

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/QueryUtilsTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/QueryUtilsTest.java
@@ -14,32 +14,22 @@ public class QueryUtilsTest {
      * Dev Note: There might be a bug in DateRangeParam and DateParam where it rounds a value that
      * is set a millisecond up or down. It makes it hard to test at the edges of a range.
      */
-    Instant lowerInstant = Instant.now();
     Date lowerDate = new Date();
-    Instant middleInstant = Instant.now().plusSeconds(500);
     Date middleDate = Date.from(Instant.now().plusSeconds(500));
-    Instant upperInstant = Instant.now().plusSeconds(1000);
     Date upperDate = Date.from(Instant.now().plusSeconds(1000));
 
     Assert.assertTrue(
-        QueryUtils.isInRange(
-            upperInstant, new DateRangeParam().setLowerBoundExclusive(middleDate)));
+        QueryUtils.isInRange(upperDate, new DateRangeParam().setLowerBoundExclusive(middleDate)));
     Assert.assertFalse(
-        QueryUtils.isInRange(
-            lowerInstant, new DateRangeParam().setLowerBoundInclusive(middleDate)));
+        QueryUtils.isInRange(lowerDate, new DateRangeParam().setLowerBoundInclusive(middleDate)));
     Assert.assertTrue(
-        QueryUtils.isInRange(
-            lowerInstant, new DateRangeParam().setUpperBoundExclusive(middleDate)));
+        QueryUtils.isInRange(lowerDate, new DateRangeParam().setUpperBoundExclusive(middleDate)));
     Assert.assertFalse(
-        QueryUtils.isInRange(
-            upperInstant, new DateRangeParam().setUpperBoundInclusive(middleDate)));
+        QueryUtils.isInRange(upperDate, new DateRangeParam().setUpperBoundInclusive(middleDate)));
 
-    Assert.assertTrue(
-        QueryUtils.isInRange(middleInstant, new DateRangeParam(lowerDate, upperDate)));
-    Assert.assertFalse(
-        QueryUtils.isInRange(lowerInstant, new DateRangeParam(middleDate, upperDate)));
-    Assert.assertFalse(
-        QueryUtils.isInRange(upperInstant, new DateRangeParam(lowerDate, middleDate)));
+    Assert.assertTrue(QueryUtils.isInRange(middleDate, new DateRangeParam(lowerDate, upperDate)));
+    Assert.assertFalse(QueryUtils.isInRange(lowerDate, new DateRangeParam(middleDate, upperDate)));
+    Assert.assertFalse(QueryUtils.isInRange(upperDate, new DateRangeParam(lowerDate, middleDate)));
   }
 
   @Test

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/SNFClaimTransformerTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/SNFClaimTransformerTest.java
@@ -10,7 +10,9 @@ import gov.cms.bfd.server.war.ServerTestUtils;
 import gov.cms.bfd.server.war.commons.CCWProcedure;
 import gov.cms.bfd.server.war.commons.MedicareSegment;
 import java.math.BigDecimal;
+import java.time.ZoneId;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import org.hl7.fhir.dstu3.model.ExplanationOfBenefit;
@@ -158,7 +160,7 @@ public final class SNFClaimTransformerTest {
         claim.getProcedure1Code().get(),
         eob.getProcedure().get(0).getProcedureCodeableConcept().getCoding());
     Assert.assertEquals(
-        TransformerUtils.convertToDate(claim.getProcedure1Date().get()),
+        Date.from(claim.getProcedure1Date().get().atStartOfDay(ZoneId.systemDefault()).toInstant()),
         eob.getProcedure().get(0).getDate());
 
     Assert.assertEquals(1, eob.getItem().size());

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/TransformerTestUtils.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/TransformerTestUtils.java
@@ -37,7 +37,9 @@ import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import junit.framework.AssertionFailedError;
@@ -400,7 +402,8 @@ final class TransformerTestUtils {
    * @param actual the actual {@link BaseDateTimeType} to verify
    */
   static void assertDateEquals(LocalDate expected, BaseDateTimeType actual) {
-    Assert.assertEquals(TransformerUtils.convertToDate(expected), actual.getValue());
+    Assert.assertEquals(
+        Date.from(expected.atStartOfDay(ZoneId.systemDefault()).toInstant()), actual.getValue());
     Assert.assertEquals(TemporalPrecisionEnum.DAY, actual.getPrecision());
   }
 
@@ -2049,7 +2052,7 @@ final class TransformerTestUtils {
    * @param actualResource that is being created by the transform
    */
   static void assertLastUpdatedEquals(
-      Optional<Instant> expectedDateTime, IAnyResource actualResource) {
+      Optional<Date> expectedDateTime, IAnyResource actualResource) {
     if (expectedDateTime.isPresent()) {
       /* Dev Note: We often run our tests in parallel, so there is subtle race condition because we
        * use one instance of an IT DB with the same resources for most tests.
@@ -2057,7 +2060,7 @@ final class TransformerTestUtils {
        * because another test over wrote the same resource.
        * To handle this case, dates that are within a second of each other match.
        */
-      final Instant expectedLastUpdated = expectedDateTime.get();
+      final Instant expectedLastUpdated = expectedDateTime.get().toInstant();
       final Instant actualLastUpdated = actualResource.getMeta().getLastUpdated().toInstant();
       final Duration diff = Duration.between(expectedLastUpdated, actualLastUpdated);
       Assert.assertTrue(
@@ -2067,7 +2070,7 @@ final class TransformerTestUtils {
       Assert.assertEquals(
           "Expect lastUpdated to be the fallback value",
           TransformerConstants.FALLBACK_LAST_UPDATED,
-          actualResource.getMeta().getLastUpdated().toInstant());
+          actualResource.getMeta().getLastUpdated());
     }
   }
 }


### PR DESCRIPTION
### Change Details

This PR reverts #693. It needs an additional test case before being reintroduced.

### Acceptance Validation

### Feedback Requested

### External References

### Security Implications
- [ ] new software dependencies
- [ ] altered security controls
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications

