### PR TITLE
Revert "[BFD-835] ASG warm pools (#692)" :(

### DIFF
--- a/ops/terraform/modules/resources/asg/main.tf
+++ b/ops/terraform/modules/resources/asg/main.tf
@@ -159,12 +159,6 @@ resource "aws_autoscaling_group" "main" {
     "GroupTotalInstances",
   ]
 
-  warm_pool {
-    pool_state                  = "Stopped"
-    min_size                    = var.asg_config.min
-    max_group_prepared_capacity = var.asg_config.max_warm
-  }
-
   dynamic "tag" {
     for_each = local.tags
     content {

--- a/ops/terraform/modules/resources/asg/variables.tf
+++ b/ops/terraform/modules/resources/asg/variables.tf
@@ -13,7 +13,7 @@ variable "layer" {
 }
 
 variable "asg_config" {
-  type = object({ min = number, max = number, max_warm = number, desired = number, sns_topic_arn = string, instance_warmup = number })
+  type = object({ min = number, max = number, desired = number, sns_topic_arn = string, instance_warmup = number })
 }
 
 variable "db_config" {

--- a/ops/terraform/modules/stateless/main.tf
+++ b/ops/terraform/modules/stateless/main.tf
@@ -197,7 +197,6 @@ module "fhir_asg" {
   asg_config = {
     min             = local.is_prod ? 2 * length(local.azs) : length(local.azs)
     max             = 8 * length(local.azs)
-    max_warm        = 4 * length(local.azs)
     desired         = local.is_prod ? 2 * length(local.azs) : length(local.azs)
     sns_topic_arn   = ""
     instance_warmup = 430


### PR DESCRIPTION
### Change Details

Reverts BFD-835 as it was discovered the provisioning of extra stopped instances for the prod ASG may be timing out the deployment.

### Acceptance Validation

Prod deployment works.

### Feedback Requested

<!-- What type of feedback you want from your reviewers? -->

### External References

<!-- For example: replace xxx with the JIRA ticket number: -->

- [BFD-835](https://jira.cms.gov/browse/BFD-835)

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] altered security controls

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications
<!-- Use this to indicate you're unsure how this change may impact system security and would like to solicit the team's feedback. Optionally, provide background information regarding your questions and concerns. -->

