### PR TITLE
DCGEO-144 (DRAFT): Adds status code checking for MCS and FISS claims.

### DIFF
--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/source/DataTransformer.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/source/DataTransformer.java
@@ -185,6 +185,8 @@ public class DataTransformer {
       addError(fieldName, "no value set");
     } else if (status == EnumStringExtractor.Status.InvalidValue) {
       addError(fieldName, "unrecognized enum value");
+    } else if (status == EnumStringExtractor.Status.UnsupportedValue) {
+      addError(fieldName, "unsupported enum value");
     } else {
       final String value = enumResult.getValue();
       copyString(fieldName, nullable, minLength, maxLength, value, copier);

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/source/EnumStringExtractor.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/source/EnumStringExtractor.java
@@ -1,7 +1,9 @@
 package gov.cms.bfd.pipeline.rda.grpc.source;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.ProtocolMessageEnum;
 import gov.cms.mpsm.rda.v1.EnumOptions;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
@@ -40,6 +42,8 @@ public class EnumStringExtractor<TRecord, TEnum extends ProtocolMessageEnum> {
   private final Predicate<TRecord> hasUnrecognizedValue;
   private final Function<TRecord, String> getUnrecognizedValue;
   private final TEnum invalidValue;
+  private final Set<ProtocolMessageEnum> unsupportedEnumValues;
+  private final ImmutableSet<Options> options;
 
   /**
    * Constructs a value using the provided functions and value.
@@ -50,18 +54,25 @@ public class EnumStringExtractor<TRecord, TEnum extends ProtocolMessageEnum> {
    *     string
    * @param getUnrecognizedValue lambda used to get the value string
    * @param invalidValue enum value (usually TEnum.UNRECOGNIZED) for protobuf's bad enum value
+   * @param unsupportedEnumValues set of enum values that should generate an UnsupportedValue Result
+   * @param allowUnrecognizedValue when true causes unrecognized values ot generate an
+   *     UnsupportedValue Result
    */
   public EnumStringExtractor(
       Predicate<TRecord> hasEnumValue,
       Function<TRecord, ProtocolMessageEnum> getEnumValue,
       Predicate<TRecord> hasUnrecognizedValue,
       Function<TRecord, String> getUnrecognizedValue,
-      TEnum invalidValue) {
+      TEnum invalidValue,
+      Set<ProtocolMessageEnum> unsupportedEnumValues,
+      Set<Options> options) {
     this.hasEnumValue = hasEnumValue;
     this.getEnumValue = getEnumValue;
     this.hasUnrecognizedValue = hasUnrecognizedValue;
     this.getUnrecognizedValue = getUnrecognizedValue;
     this.invalidValue = invalidValue;
+    this.unsupportedEnumValues = unsupportedEnumValues;
+    this.options = ImmutableSet.copyOf(options);
   }
 
   /**
@@ -77,11 +88,17 @@ public class EnumStringExtractor<TRecord, TEnum extends ProtocolMessageEnum> {
       if (value == invalidValue) {
         return INVALID_VALUE_RESULT;
       }
-      return new Result(
-          value.getValueDescriptor().getOptions().getExtension(EnumOptions.stringValue));
+      final String strValue =
+          value.getValueDescriptor().getOptions().getExtension(EnumOptions.stringValue);
+      final Status status =
+          unsupportedEnumValues.contains(value) ? Status.UnsupportedValue : Status.HasValue;
+      return new Result(status, strValue);
     }
     if (hasUnrecognizedValue.test(record)) {
-      return new Result(getUnrecognizedValue.apply(record));
+      final String strValue = getUnrecognizedValue.apply(record);
+      final Status status =
+          options.contains(Options.RejectUnrecognized) ? Status.UnsupportedValue : Status.HasValue;
+      return new Result(status, strValue);
     }
     return NO_VALUE_RESULT;
   }
@@ -96,7 +113,9 @@ public class EnumStringExtractor<TRecord, TEnum extends ProtocolMessageEnum> {
      */
     InvalidValue,
     /** Either the enum was set to a valid value or the unrecognized string value was set. */
-    HasValue
+    HasValue,
+    /** A vault was present but was rejected as unsupported. */
+    UnsupportedValue
   }
 
   @Getter
@@ -115,5 +134,19 @@ public class EnumStringExtractor<TRecord, TEnum extends ProtocolMessageEnum> {
       status = Status.HasValue;
       this.value = value;
     }
+
+    public Result(Status status, @Nullable String value) {
+      this.status = status;
+      this.value = value;
+    }
+  }
+
+  /**
+   * Additional options that can be used to alter default behavior. Currently, there is only one but
+   * using an enum instead of a boolean improves code clarity.
+   */
+  public enum Options {
+    /** Report an unsupported value result if the field has its unrecognized value. */
+    RejectUnrecognized
   }
 }

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/source/FissClaimTransformer.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/source/FissClaimTransformer.java
@@ -1,5 +1,6 @@
 package gov.cms.bfd.pipeline.rda.grpc.source;
 
+import com.google.common.collect.ImmutableSet;
 import gov.cms.bfd.model.rda.PreAdjFissClaim;
 import gov.cms.bfd.model.rda.PreAdjFissDiagnosisCode;
 import gov.cms.bfd.model.rda.PreAdjFissProcCode;
@@ -31,21 +32,27 @@ public class FissClaimTransformer {
           FissClaim::getCurrStatusEnum,
           FissClaim::hasCurrStatusUnrecognized,
           FissClaim::getCurrStatusUnrecognized,
-          FissClaimStatus.UNRECOGNIZED);
+          FissClaimStatus.UNRECOGNIZED,
+          ImmutableSet.of(),
+          ImmutableSet.of(EnumStringExtractor.Options.RejectUnrecognized));
   private static final EnumStringExtractor<FissClaim, FissProcessingType> currLoc1 =
       new EnumStringExtractor<>(
           FissClaim::hasCurrLoc1Enum,
           FissClaim::getCurrLoc1Enum,
           FissClaim::hasCurrLoc1Unrecognized,
           FissClaim::getCurrLoc1Unrecognized,
-          FissProcessingType.UNRECOGNIZED);
+          FissProcessingType.UNRECOGNIZED,
+          ImmutableSet.of(),
+          ImmutableSet.of());
   private static final EnumStringExtractor<FissClaim, FissCurrentLocation2> currLoc2 =
       new EnumStringExtractor<>(
           FissClaim::hasCurrLoc2Enum,
           FissClaim::getCurrLoc2Enum,
           FissClaim::hasCurrLoc2Unrecognized,
           FissClaim::getCurrLoc2Unrecognized,
-          FissCurrentLocation2.UNRECOGNIZED);
+          FissCurrentLocation2.UNRECOGNIZED,
+          ImmutableSet.of(),
+          ImmutableSet.of());
   private static final EnumStringExtractor<
           FissDiagnosisCode, FissDiagnosisPresentOnAdmissionIndicator>
       diagPoaInd =
@@ -54,7 +61,9 @@ public class FissClaimTransformer {
               FissDiagnosisCode::getDiagPoaIndEnum,
               FissDiagnosisCode::hasDiagPoaIndUnrecognized,
               FissDiagnosisCode::getDiagPoaIndUnrecognized,
-              FissDiagnosisPresentOnAdmissionIndicator.UNRECOGNIZED);
+              FissDiagnosisPresentOnAdmissionIndicator.UNRECOGNIZED,
+              ImmutableSet.of(),
+              ImmutableSet.of());
 
   private final Clock clock;
   private final IdHasher idHasher;

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/source/McsClaimTransformer.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/source/McsClaimTransformer.java
@@ -1,5 +1,6 @@
 package gov.cms.bfd.pipeline.rda.grpc.source;
 
+import com.google.common.collect.ImmutableSet;
 import gov.cms.bfd.model.rda.PreAdjMcsClaim;
 import gov.cms.bfd.model.rda.PreAdjMcsDetail;
 import gov.cms.bfd.model.rda.PreAdjMcsDiagnosisCode;
@@ -27,21 +28,27 @@ public class McsClaimTransformer {
           McsClaim::getIdrClaimTypeEnum,
           McsClaim::hasIdrClaimTypeUnrecognized,
           McsClaim::getIdrClaimTypeUnrecognized,
-          McsClaimType.UNRECOGNIZED);
+          McsClaimType.UNRECOGNIZED,
+          ImmutableSet.of(),
+          ImmutableSet.of());
   private static final EnumStringExtractor<McsClaim, McsBeneficiarySex> idrBeneSex =
       new EnumStringExtractor<>(
           McsClaim::hasIdrBeneSexEnum,
           McsClaim::getIdrBeneSexEnum,
           McsClaim::hasIdrBeneSexUnrecognized,
           McsClaim::getIdrBeneSexUnrecognized,
-          McsBeneficiarySex.UNRECOGNIZED);
+          McsBeneficiarySex.UNRECOGNIZED,
+          ImmutableSet.of(),
+          ImmutableSet.of());
   private static final EnumStringExtractor<McsClaim, McsStatusCode> idrStatusCode =
       new EnumStringExtractor<>(
           McsClaim::hasIdrStatusCodeEnum,
           McsClaim::getIdrStatusCodeEnum,
           McsClaim::hasIdrStatusCodeUnrecognized,
           McsClaim::getIdrStatusCodeUnrecognized,
-          McsStatusCode.UNRECOGNIZED);
+          McsStatusCode.UNRECOGNIZED,
+          ImmutableSet.of(McsStatusCode.STATUS_CODE_NOT_USED),
+          ImmutableSet.of(EnumStringExtractor.Options.RejectUnrecognized));
   private static final EnumStringExtractor<McsClaim, McsBillingProviderIndicator>
       idrBillProvGroupInd =
           new EnumStringExtractor<>(
@@ -49,7 +56,9 @@ public class McsClaimTransformer {
               McsClaim::getIdrBillProvGroupIndEnum,
               McsClaim::hasIdrBillProvGroupIndUnrecognized,
               McsClaim::getIdrBillProvGroupIndUnrecognized,
-              McsBillingProviderIndicator.UNRECOGNIZED);
+              McsBillingProviderIndicator.UNRECOGNIZED,
+              ImmutableSet.of(),
+              ImmutableSet.of());
   private static final EnumStringExtractor<McsClaim, McsBillingProviderStatusCode>
       idrBillProvStatusCd =
           new EnumStringExtractor<>(
@@ -57,28 +66,36 @@ public class McsClaimTransformer {
               McsClaim::getIdrBillProvStatusCdEnum,
               McsClaim::hasIdrBillProvStatusCdUnrecognized,
               McsClaim::getIdrBillProvStatusCdUnrecognized,
-              McsBillingProviderStatusCode.UNRECOGNIZED);
+              McsBillingProviderStatusCode.UNRECOGNIZED,
+              ImmutableSet.of(),
+              ImmutableSet.of());
   private static final EnumStringExtractor<McsDiagnosisCode, McsDiagnosisIcdType> idrDiagIcdType =
       new EnumStringExtractor<>(
           McsDiagnosisCode::hasIdrDiagIcdTypeEnum,
           McsDiagnosisCode::getIdrDiagIcdTypeEnum,
           McsDiagnosisCode::hasIdrDiagIcdTypeEnumUnrecognized,
           McsDiagnosisCode::getIdrDiagIcdTypeEnumUnrecognized,
-          McsDiagnosisIcdType.UNRECOGNIZED);
+          McsDiagnosisIcdType.UNRECOGNIZED,
+          ImmutableSet.of(),
+          ImmutableSet.of());
   private static final EnumStringExtractor<McsDetail, McsDetailStatus> idrDtlStatus =
       new EnumStringExtractor<>(
           McsDetail::hasIdrDtlStatusEnum,
           McsDetail::getIdrDtlStatusEnum,
           McsDetail::hasIdrDtlStatusUnrecognized,
           McsDetail::getIdrDtlStatusUnrecognized,
-          McsDetailStatus.UNRECOGNIZED);
+          McsDetailStatus.UNRECOGNIZED,
+          ImmutableSet.of(),
+          ImmutableSet.of());
   private static final EnumStringExtractor<McsDetail, McsDiagnosisIcdType> idrDtlDiagIcdType =
       new EnumStringExtractor<>(
           McsDetail::hasIdrDtlDiagIcdTypeEnum,
           McsDetail::getIdrDtlDiagIcdTypeEnum,
           McsDetail::hasIdrDtlDiagIcdTypeUnrecognized,
           McsDetail::getIdrDtlDiagIcdTypeUnrecognized,
-          McsDiagnosisIcdType.UNRECOGNIZED);
+          McsDiagnosisIcdType.UNRECOGNIZED,
+          ImmutableSet.of(),
+          ImmutableSet.of());
 
   private final Clock clock;
   private final IdHasher idHasher;

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/DataTransformerTest.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/DataTransformerTest.java
@@ -165,13 +165,21 @@ public class DataTransformerTest {
             new EnumStringExtractor.Result((String) null),
             copied::add)
         .copyEnumAsString(
+            "unsupported-value-bad",
+            false,
+            0,
+            10,
+            new EnumStringExtractor.Result(EnumStringExtractor.Status.UnsupportedValue, "boo!"),
+            copied::add)
+        .copyEnumAsString(
             "good-value", false, 0, 10, new EnumStringExtractor.Result("boo!"), copied::add);
     assertEquals(ImmutableList.of("boo!"), copied);
     assertEquals(
         ImmutableList.of(
             new DataTransformer.ErrorMessage("no-value", "no value set"),
             new DataTransformer.ErrorMessage("invalid-value", "unrecognized enum value"),
-            new DataTransformer.ErrorMessage("null-value-bad", "is null")),
+            new DataTransformer.ErrorMessage("null-value-bad", "is null"),
+            new DataTransformer.ErrorMessage("unsupported-value-bad", "unsupported enum value")),
         transformer.getErrors());
   }
 

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/EnumStringExtractorTest.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/EnumStringExtractorTest.java
@@ -2,52 +2,95 @@ package gov.cms.bfd.pipeline.rda.grpc.source;
 
 import static org.junit.Assert.assertEquals;
 
+import com.google.common.collect.ImmutableSet;
 import gov.cms.mpsm.rda.v1.fiss.FissClaim;
 import gov.cms.mpsm.rda.v1.fiss.FissClaimStatus;
+import gov.cms.mpsm.rda.v1.mcs.McsClaim;
+import gov.cms.mpsm.rda.v1.mcs.McsStatusCode;
 import org.junit.Before;
 import org.junit.Test;
 
 public class EnumStringExtractorTest {
-  private final EnumStringExtractor<FissClaim, FissClaimStatus> currStatusExtractor =
+  private final EnumStringExtractor<FissClaim, FissClaimStatus> fissStatusExtractor =
       new EnumStringExtractor<>(
           FissClaim::hasCurrStatusEnum,
           FissClaim::getCurrStatusEnum,
           FissClaim::hasCurrStatusUnrecognized,
           FissClaim::getCurrStatusUnrecognized,
-          FissClaimStatus.UNRECOGNIZED);
-  private FissClaim.Builder claim;
+          FissClaimStatus.UNRECOGNIZED,
+          ImmutableSet.of(FissClaimStatus.CLAIM_STATUS_SUSPEND),
+          ImmutableSet.of());
+  private final EnumStringExtractor<McsClaim, McsStatusCode> mcsStatusExtractor =
+      new EnumStringExtractor<>(
+          McsClaim::hasIdrStatusCodeEnum,
+          McsClaim::getIdrStatusCodeEnum,
+          McsClaim::hasIdrStatusCodeUnrecognized,
+          McsClaim::getIdrStatusCodeUnrecognized,
+          McsStatusCode.UNRECOGNIZED,
+          ImmutableSet.of(McsStatusCode.STATUS_CODE_NOT_USED),
+          ImmutableSet.of(EnumStringExtractor.Options.RejectUnrecognized));
+  private FissClaim.Builder fissClaim;
+  private McsClaim.Builder mcsClaim;
 
   @Before
   public void setUp() throws Exception {
-    claim = FissClaim.newBuilder();
+    fissClaim = FissClaim.newBuilder();
+    mcsClaim = McsClaim.newBuilder();
   }
 
   @Test
   public void noValue() {
     assertEquals(
         new EnumStringExtractor.Result(EnumStringExtractor.Status.NoValue),
-        currStatusExtractor.getEnumString(claim.build()));
+        fissStatusExtractor.getEnumString(fissClaim.build()));
+
+    assertEquals(
+        new EnumStringExtractor.Result(EnumStringExtractor.Status.NoValue),
+        mcsStatusExtractor.getEnumString(mcsClaim.build()));
   }
 
   @Test
   public void invalidValue() {
-    claim.setCurrStatusEnumValue(-1);
+    fissClaim.setCurrStatusEnumValue(-1);
     assertEquals(
         new EnumStringExtractor.Result(EnumStringExtractor.Status.InvalidValue),
-        currStatusExtractor.getEnumString(claim.build()));
+        fissStatusExtractor.getEnumString(fissClaim.build()));
+
+    mcsClaim.setIdrStatusCodeEnumValue(-1);
+    assertEquals(
+        new EnumStringExtractor.Result(EnumStringExtractor.Status.InvalidValue),
+        mcsStatusExtractor.getEnumString(mcsClaim.build()));
   }
 
   @Test
   public void unrecognizedValue() {
-    claim.setCurrStatusUnrecognized("boo!");
+    fissClaim.setCurrStatusUnrecognized("boo!");
     assertEquals(
-        new EnumStringExtractor.Result("boo!"), currStatusExtractor.getEnumString(claim.build()));
+        new EnumStringExtractor.Result("boo!"),
+        fissStatusExtractor.getEnumString(fissClaim.build()));
+
+    mcsClaim.setIdrStatusCodeUnrecognized("boo!");
+    assertEquals(
+        new EnumStringExtractor.Result(EnumStringExtractor.Status.UnsupportedValue, "boo!"),
+        mcsStatusExtractor.getEnumString(mcsClaim.build()));
   }
 
   @Test
   public void goodValue() {
-    claim.setCurrStatusEnum(FissClaimStatus.CLAIM_STATUS_RTP);
+    fissClaim.setCurrStatusEnum(FissClaimStatus.CLAIM_STATUS_RTP);
     assertEquals(
-        new EnumStringExtractor.Result("T"), currStatusExtractor.getEnumString(claim.build()));
+        new EnumStringExtractor.Result("T"), fissStatusExtractor.getEnumString(fissClaim.build()));
+
+    mcsClaim.setIdrStatusCodeEnum(McsStatusCode.STATUS_CODE_ACTIVE_A);
+    assertEquals(
+        new EnumStringExtractor.Result("A"), mcsStatusExtractor.getEnumString(mcsClaim.build()));
+  }
+
+  @Test
+  public void unsupportedEnumValue() {
+    mcsClaim.setIdrStatusCodeEnum(McsStatusCode.STATUS_CODE_NOT_USED);
+    assertEquals(
+        new EnumStringExtractor.Result(EnumStringExtractor.Status.UnsupportedValue, "6"),
+        mcsStatusExtractor.getEnumString(mcsClaim.build()));
   }
 }

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/McsClaimTransformerTest.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/McsClaimTransformerTest.java
@@ -1,0 +1,463 @@
+package gov.cms.bfd.pipeline.rda.grpc.source;
+
+import static gov.cms.bfd.pipeline.rda.grpc.source.TransformerTestUtils.assertListContentsHaveSamePropertyValues;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.samePropertyValuesAs;
+import static org.junit.Assert.*;
+
+import com.google.common.collect.ImmutableList;
+import gov.cms.bfd.model.rda.PreAdjMcsClaim;
+import gov.cms.bfd.model.rda.PreAdjMcsDetail;
+import gov.cms.bfd.model.rda.PreAdjMcsDiagnosisCode;
+import gov.cms.bfd.pipeline.rda.grpc.RdaChange;
+import gov.cms.bfd.pipeline.sharedutils.IdHasher;
+import gov.cms.mpsm.rda.v1.ClaimChange;
+import gov.cms.mpsm.rda.v1.mcs.McsBeneficiarySex;
+import gov.cms.mpsm.rda.v1.mcs.McsBillingProviderStatusCode;
+import gov.cms.mpsm.rda.v1.mcs.McsClaim;
+import gov.cms.mpsm.rda.v1.mcs.McsClaimType;
+import gov.cms.mpsm.rda.v1.mcs.McsDetail;
+import gov.cms.mpsm.rda.v1.mcs.McsDetailStatus;
+import gov.cms.mpsm.rda.v1.mcs.McsDiagnosisCode;
+import gov.cms.mpsm.rda.v1.mcs.McsDiagnosisIcdType;
+import gov.cms.mpsm.rda.v1.mcs.McsStatusCode;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import org.junit.Before;
+import org.junit.Test;
+
+public class McsClaimTransformerTest {
+  // using a fixed Clock ensures our timestamp is predictable
+  private final Clock clock = Clock.fixed(Instant.ofEpochMilli(1621609413832L), ZoneOffset.UTC);
+  private final McsClaimTransformer transformer =
+      new McsClaimTransformer(
+          clock,
+          new IdHasher(
+              new IdHasher.Config(1000, "nottherealpepper".getBytes(StandardCharsets.UTF_8))));
+  private ClaimChange.Builder changeBuilder;
+  private McsClaim.Builder claimBuilder;
+  private PreAdjMcsClaim claim;
+
+  @Before
+  public void setUp() {
+    changeBuilder = ClaimChange.newBuilder();
+    claimBuilder = McsClaim.newBuilder();
+    claim = new PreAdjMcsClaim();
+  }
+
+  @Test
+  public void minimumValidClaim() {
+    claim.setIdrClmHdIcn("123456789012345");
+    claim.setIdrContrId("12345");
+    claim.setIdrClaimType("3");
+    claim.setLastUpdated(clock.instant());
+    claimBuilder
+        .setIdrClmHdIcn("123456789012345")
+        .setIdrContrId("12345")
+        .setIdrClaimTypeEnum(McsClaimType.CLAIM_TYPE_MEDICAL);
+    changeBuilder
+        .setChangeType(ClaimChange.ChangeType.CHANGE_TYPE_INSERT)
+        .setMcsClaim(claimBuilder.build());
+    assertChangeMatches(RdaChange.Type.INSERT);
+  }
+
+  @Test
+  public void allFields() {
+    claim.setIdrClmHdIcn("123456789012345");
+    claim.setIdrContrId("12345");
+    claim.setIdrHic("123456789012");
+    claim.setIdrClaimType("3");
+    claim.setIdrDtlCnt(0);
+    claim.setIdrBeneLast_1_6("123456");
+    claim.setIdrBeneFirstInit("7");
+    claim.setIdrBeneMidInit("8");
+    claim.setIdrBeneSex("F");
+    claim.setIdrStatusCode("A");
+    claim.setIdrStatusDate(LocalDate.of(2020, 2, 3));
+    claim.setIdrBillProvNpi("CDEFGHIJKL");
+    claim.setIdrBillProvNum("MNOPQRSTUV");
+    claim.setIdrBillProvEin("WXYZabcdef");
+    claim.setIdrBillProvType("RS");
+    claim.setIdrBillProvSpec("tu");
+    claim.setIdrBillProvGroupInd("v");
+    claim.setIdrBillProvPriceSpec("rw");
+    claim.setIdrBillProvCounty("34");
+    claim.setIdrBillProvLoc("43");
+    claim.setIdrTotAllowed(new BigDecimal("12345.42"));
+    claim.setIdrCoinsurance(new BigDecimal("67890.94"));
+    claim.setIdrDeductible(new BigDecimal("87945.28"));
+    claim.setIdrBillProvStatusCd("P");
+    claim.setIdrTotBilledAmt(new BigDecimal("67591.96"));
+    claim.setIdrClaimReceiptDate(LocalDate.of(2020, 2, 1));
+    claim.setIdrClaimMbi("5467891245678");
+    claim.setIdrClaimMbiHash("8033928eb4cf902474141065280c51791663e86d760da5a0fadf354daffb4b01");
+    claim.setIdrHdrFromDateOfSvc(LocalDate.of(2020, 1, 7));
+    claim.setIdrHdrToDateOfSvc(LocalDate.of(2020, 1, 14));
+    claim.setLastUpdated(clock.instant());
+    claimBuilder
+        .setIdrClmHdIcn("123456789012345")
+        .setIdrContrId("12345")
+        .setIdrHic("123456789012")
+        .setIdrClaimTypeEnum(McsClaimType.CLAIM_TYPE_MEDICAL)
+        .setIdrDtlCnt(0)
+        .setIdrBeneLast16("123456")
+        .setIdrBeneFirstInit("7")
+        .setIdrBeneMidInit("8")
+        .setIdrBeneSexEnum(McsBeneficiarySex.BENEFICIARY_SEX_FEMALE)
+        .setIdrStatusCodeEnum(McsStatusCode.STATUS_CODE_ACTIVE_A)
+        .setIdrStatusDate("2020-02-03")
+        .setIdrBillProvNpi("CDEFGHIJKL")
+        .setIdrBillProvNum("MNOPQRSTUV")
+        .setIdrBillProvEin("WXYZabcdef")
+        .setIdrBillProvType("RS")
+        .setIdrBillProvSpec("tu")
+        .setIdrBillProvGroupIndUnrecognized("v")
+        .setIdrBillProvPriceSpec("rw")
+        .setIdrBillProvCounty("34")
+        .setIdrBillProvLoc("43")
+        .setIdrTotAllowed("12345.42")
+        .setIdrCoinsurance("67890.94")
+        .setIdrDeductible("87945.28")
+        .setIdrBillProvStatusCdEnum(
+            McsBillingProviderStatusCode.BILLING_PROVIDER_STATUS_CODE_PARTICIPATING)
+        .setIdrTotBilledAmt("67591.96")
+        .setIdrClaimReceiptDate("2020-02-01")
+        .setIdrClaimMbi("5467891245678")
+        .setIdrHdrFromDos("2020-01-07")
+        .setIdrHdrToDos("2020-01-14");
+    changeBuilder
+        .setChangeType(ClaimChange.ChangeType.CHANGE_TYPE_INSERT)
+        .setMcsClaim(claimBuilder.build());
+    assertChangeMatches(RdaChange.Type.INSERT);
+  }
+
+  @Test
+  public void details() {
+    claim.setIdrClmHdIcn("123456789012345");
+    claim.setIdrContrId("12345");
+    claim.setIdrClaimType("3");
+    claim.setLastUpdated(clock.instant());
+    final PreAdjMcsDetail detail = new PreAdjMcsDetail();
+    detail.setIdrClmHdIcn(claim.getIdrClmHdIcn());
+    detail.setPriority((short) 0);
+    detail.setIdrDtlStatus("F");
+    detail.setIdrDtlFromDate(LocalDate.of(2020, 1, 9));
+    detail.setIdrDtlToDate(LocalDate.of(2020, 1, 10));
+    detail.setIdrProcCode("abCDe");
+    detail.setIdrModOne("aB");
+    detail.setIdrModTwo("Cd");
+    detail.setIdrModThree("EF");
+    detail.setIdrModFour("gh");
+    detail.setIdrDtlDiagIcdType("9");
+    detail.setIdrDtlPrimaryDiagCode("hetwpqj");
+    detail.setIdrKPosLnameOrg("123456789012345678901234567890123456789012345678901234567890");
+    detail.setIdrKPosFname("12345678901234567890123456789012345");
+    detail.setIdrKPosMname("1234567890123456789012345");
+    detail.setIdrKPosAddr1("1234567890123456789012345678901234567890123456789012345");
+    detail.setIdrKPosAddr2_1st("123456789012345678901234567890");
+    detail.setIdrKPosAddr2_2nd("1234567890123456789012345");
+    detail.setIdrKPosCity("123456789012345678901234567890");
+    detail.setIdrKPosState("12");
+    detail.setIdrKPosZip("123456789012345");
+    detail.setLastUpdated(clock.instant());
+    claim.getDetails().add(detail);
+    claimBuilder
+        .setIdrClmHdIcn("123456789012345")
+        .setIdrContrId("12345")
+        .setIdrClaimTypeEnum(McsClaimType.CLAIM_TYPE_MEDICAL)
+        .addMcsDetails(
+            McsDetail.newBuilder()
+                .setIdrDtlStatusEnum(McsDetailStatus.DETAIL_STATUS_FINAL)
+                .setIdrDtlFromDate("2020-01-09")
+                .setIdrDtlToDate("2020-01-10")
+                .setIdrProcCode("abCDe")
+                .setIdrModOne("aB")
+                .setIdrModTwo("Cd")
+                .setIdrModThree("EF")
+                .setIdrModFour("gh")
+                .setIdrDtlDiagIcdTypeEnum(McsDiagnosisIcdType.DIAGNOSIS_ICD_TYPE_ICD9)
+                .setIdrDtlPrimaryDiagCode("hetwpqj")
+                .setIdrKPosLnameOrg("123456789012345678901234567890123456789012345678901234567890")
+                .setIdrKPosFname("12345678901234567890123456789012345")
+                .setIdrKPosMname("1234567890123456789012345")
+                .setIdrKPosAddr1("1234567890123456789012345678901234567890123456789012345")
+                .setIdrKPosAddr21St("123456789012345678901234567890")
+                .setIdrKPosAddr22Nd("1234567890123456789012345")
+                .setIdrKPosCity("123456789012345678901234567890")
+                .setIdrKPosState("12")
+                .setIdrKPosZip("123456789012345")
+                .build());
+    changeBuilder
+        .setChangeType(ClaimChange.ChangeType.CHANGE_TYPE_INSERT)
+        .setMcsClaim(claimBuilder.build());
+    assertChangeMatches(RdaChange.Type.INSERT);
+    PreAdjMcsClaim transformed = transformer.transformClaim(changeBuilder.build()).getClaim();
+    assertListContentsHaveSamePropertyValues(
+        claim.getDetails(), transformed.getDetails(), PreAdjMcsDetail::getPriority);
+  }
+
+  @Test
+  public void diagnosisCodes() {
+    claim.setIdrClmHdIcn("123456789012345");
+    claim.setIdrContrId("12345");
+    claim.setIdrClaimType("3");
+    claim.setLastUpdated(clock.instant());
+    PreAdjMcsDiagnosisCode diagCode = new PreAdjMcsDiagnosisCode();
+    diagCode.setIdrClmHdIcn(claim.getIdrClmHdIcn());
+    diagCode.setPriority((short) 0);
+    diagCode.setIdrDiagIcdType("9");
+    diagCode.setIdrDiagCode("1234567");
+    diagCode.setLastUpdated(clock.instant());
+    claim.getDiagCodes().add(diagCode);
+    diagCode = new PreAdjMcsDiagnosisCode();
+    diagCode.setIdrClmHdIcn(claim.getIdrClmHdIcn());
+    diagCode.setPriority((short) 1);
+    diagCode.setIdrDiagIcdType("0");
+    diagCode.setIdrDiagCode("jdsyejs");
+    diagCode.setLastUpdated(clock.instant());
+    claim.getDiagCodes().add(diagCode);
+    claimBuilder
+        .setIdrClmHdIcn("123456789012345")
+        .setIdrContrId("12345")
+        .setIdrClaimTypeEnum(McsClaimType.CLAIM_TYPE_MEDICAL)
+        .addMcsDiagnosisCodes(
+            McsDiagnosisCode.newBuilder()
+                .setIdrClmHdIcn("123456789012345")
+                .setIdrDiagCode("1234567")
+                .setIdrDiagIcdTypeEnum(McsDiagnosisIcdType.DIAGNOSIS_ICD_TYPE_ICD9)
+                .build())
+        .addMcsDiagnosisCodes(
+            McsDiagnosisCode.newBuilder()
+                .setIdrClmHdIcn("123456789012345")
+                .setIdrDiagCode("jdsyejs")
+                .setIdrDiagIcdTypeEnum(McsDiagnosisIcdType.DIAGNOSIS_ICD_TYPE_ICD10)
+                .build());
+    changeBuilder
+        .setChangeType(ClaimChange.ChangeType.CHANGE_TYPE_INSERT)
+        .setMcsClaim(claimBuilder.build());
+    assertChangeMatches(RdaChange.Type.INSERT);
+    PreAdjMcsClaim transformed = transformer.transformClaim(changeBuilder.build()).getClaim();
+    assertListContentsHaveSamePropertyValues(
+        claim.getDetails(), transformed.getDetails(), PreAdjMcsDetail::getPriority);
+  }
+
+  @Test
+  public void requiredFieldsMissing() {
+    try {
+      changeBuilder
+          .setChangeType(ClaimChange.ChangeType.CHANGE_TYPE_UPDATE)
+          .setMcsClaim(
+              claimBuilder
+                  .addMcsDetails(McsDetail.newBuilder().build())
+                  .addMcsDiagnosisCodes(McsDiagnosisCode.newBuilder().build())
+                  .build());
+      transformer.transformClaim(changeBuilder.build());
+      fail("should have thrown");
+    } catch (DataTransformer.TransformationException ex) {
+      assertEquals(
+          ImmutableList.of(
+              new DataTransformer.ErrorMessage(
+                  "idrClmHdIcn", "invalid length: expected=[1,15] actual=0"),
+              new DataTransformer.ErrorMessage(
+                  "idrContrId", "invalid length: expected=[1,5] actual=0"),
+              new DataTransformer.ErrorMessage("idrClaimType", "no value set"),
+              new DataTransformer.ErrorMessage(
+                  "diagCode-0-idrClmHdIcn", "invalid length: expected=[1,15] actual=0")),
+          ex.getErrors());
+    }
+  }
+
+  @Test
+  public void allBadFields() {
+    try {
+      claimBuilder
+          .setIdrClmHdIcn("123456789012345---")
+          .setIdrContrId("12345---")
+          .setIdrHic("123456789012---")
+          .setIdrClaimTypeUnrecognized("55558873478237821782317821782317823783287")
+          .setIdrDtlCnt(0)
+          .setIdrBeneLast16("123456---")
+          .setIdrBeneFirstInit("7---")
+          .setIdrBeneMidInit("8---")
+          .setIdrBeneSexEnum(McsBeneficiarySex.BENEFICIARY_SEX_FEMALE)
+          .setIdrStatusCodeEnum(McsStatusCode.STATUS_CODE_ACTIVE_A)
+          .setIdrStatusDate("2020-02-03---")
+          .setIdrBillProvNpi("CDEFGHIJKL---")
+          .setIdrBillProvNum("MNOPQRSTUV---")
+          .setIdrBillProvEin("WXYZabcdef---")
+          .setIdrBillProvType("RS---")
+          .setIdrBillProvSpec("tu---")
+          .setIdrBillProvGroupIndUnrecognized("v---")
+          .setIdrBillProvPriceSpec("rw---")
+          .setIdrBillProvCounty("34---")
+          .setIdrBillProvLoc("43---")
+          .setIdrTotAllowed("12345.42---")
+          .setIdrCoinsurance("67890.94---")
+          .setIdrDeductible("87945.28---")
+          .setIdrBillProvStatusCdEnum(
+              McsBillingProviderStatusCode.BILLING_PROVIDER_STATUS_CODE_PARTICIPATING)
+          .setIdrTotBilledAmt("67591.96---")
+          .setIdrClaimReceiptDate("2020-02-01---")
+          .setIdrClaimMbi("5467891245678---")
+          .setIdrHdrFromDos("2020-01-07---")
+          .setIdrHdrToDos("2020-01-14---")
+          .addMcsDiagnosisCodes(
+              McsDiagnosisCode.newBuilder()
+                  .setIdrClmHdIcn("123456789012345---")
+                  .setIdrDiagCode("1234567---")
+                  .setIdrDiagIcdTypeEnumUnrecognized("sdjbfdskjbdfskjbsdf---")
+                  .build())
+          .addMcsDetails(
+              McsDetail.newBuilder()
+                  .setIdrDtlStatusEnum(McsDetailStatus.DETAIL_STATUS_FINAL)
+                  .setIdrDtlFromDate("--not-a-date--")
+                  .setIdrDtlToDate("--not-a-date--")
+                  .setIdrProcCode("abCDe---")
+                  .setIdrModOne("aB---")
+                  .setIdrModTwo("Cd---")
+                  .setIdrModThree("EF---")
+                  .setIdrModFour("gh---")
+                  .setIdrDtlDiagIcdTypeUnrecognized("jbkasjdbkjadsfbflasdbglbasdfljbfdsaj---")
+                  .setIdrDtlPrimaryDiagCode("hetwpqj---")
+                  .setIdrKPosLnameOrg(
+                      "123456789012345678901234567890123456789012345678901234567890---")
+                  .setIdrKPosFname("12345678901234567890123456789012345---")
+                  .setIdrKPosMname("1234567890123456789012345---")
+                  .setIdrKPosAddr1("1234567890123456789012345678901234567890123456789012345---")
+                  .setIdrKPosAddr21St("123456789012345678901234567890---")
+                  .setIdrKPosAddr22Nd("1234567890123456789012345---")
+                  .setIdrKPosCity("123456789012345678901234567890---")
+                  .setIdrKPosState("12---")
+                  .setIdrKPosZip("123456789012345---")
+                  .build());
+      changeBuilder
+          .setChangeType(ClaimChange.ChangeType.CHANGE_TYPE_UPDATE)
+          .setMcsClaim(claimBuilder.build());
+      transformer.transformClaim(changeBuilder.build());
+      fail("should have thrown");
+    } catch (DataTransformer.TransformationException ex) {
+      assertEquals(
+          ImmutableList.of(
+              new DataTransformer.ErrorMessage(
+                  "idrClmHdIcn", "invalid length: expected=[1,15] actual=18"),
+              new DataTransformer.ErrorMessage(
+                  "idrContrId", "invalid length: expected=[1,5] actual=8"),
+              new DataTransformer.ErrorMessage(
+                  "idrHic", "invalid length: expected=[1,12] actual=15"),
+              new DataTransformer.ErrorMessage(
+                  "idrClaimType", "invalid length: expected=[1,1] actual=41"),
+              new DataTransformer.ErrorMessage(
+                  "idrBeneLast_1_6", "invalid length: expected=[1,6] actual=9"),
+              new DataTransformer.ErrorMessage(
+                  "idrBeneFirstInit", "invalid length: expected=[1,1] actual=4"),
+              new DataTransformer.ErrorMessage(
+                  "idrBeneMidInit", "invalid length: expected=[1,1] actual=4"),
+              new DataTransformer.ErrorMessage("idrStatusDate", "invalid date"),
+              new DataTransformer.ErrorMessage(
+                  "idrBillProvNpi", "invalid length: expected=[1,10] actual=13"),
+              new DataTransformer.ErrorMessage(
+                  "idrBillProvNum", "invalid length: expected=[1,10] actual=13"),
+              new DataTransformer.ErrorMessage(
+                  "idrBillProvEin", "invalid length: expected=[1,10] actual=13"),
+              new DataTransformer.ErrorMessage(
+                  "idrBillProvType", "invalid length: expected=[1,2] actual=5"),
+              new DataTransformer.ErrorMessage(
+                  "idrBillProvSpec", "invalid length: expected=[1,2] actual=5"),
+              new DataTransformer.ErrorMessage(
+                  "idrBillProvGroupInd", "invalid length: expected=[1,1] actual=4"),
+              new DataTransformer.ErrorMessage(
+                  "idrBillProvType", "invalid length: expected=[1,2] actual=5"),
+              new DataTransformer.ErrorMessage(
+                  "idrBillProvSpec", "invalid length: expected=[1,2] actual=5"),
+              new DataTransformer.ErrorMessage(
+                  "idrBillProvGroupInd", "invalid length: expected=[1,1] actual=4"),
+              new DataTransformer.ErrorMessage(
+                  "idrBillProvPriceSpec", "invalid length: expected=[1,2] actual=5"),
+              new DataTransformer.ErrorMessage(
+                  "idrBillProvCounty", "invalid length: expected=[1,2] actual=5"),
+              new DataTransformer.ErrorMessage(
+                  "idrBillProvLoc", "invalid length: expected=[1,2] actual=5"),
+              new DataTransformer.ErrorMessage("idrTotAllowed", "invalid amount"),
+              new DataTransformer.ErrorMessage("idrCoinsurance", "invalid amount"),
+              new DataTransformer.ErrorMessage("idrDeductible", "invalid amount"),
+              new DataTransformer.ErrorMessage("idrTotBilledAmt", "invalid amount"),
+              new DataTransformer.ErrorMessage("idrClaimReceiptDate", "invalid date"),
+              new DataTransformer.ErrorMessage(
+                  "idrClaimMbi", "invalid length: expected=[1,13] actual=16"),
+              new DataTransformer.ErrorMessage("idrHdrFromDateOfSvc", "invalid date"),
+              new DataTransformer.ErrorMessage("idrHdrToDateOfSvc", "invalid date"),
+              new DataTransformer.ErrorMessage(
+                  "diagCode-0-idrClmHdIcn", "invalid length: expected=[1,15] actual=18"),
+              new DataTransformer.ErrorMessage(
+                  "diagCode-0-idrDiagIcdType", "invalid length: expected=[1,1] actual=22"),
+              new DataTransformer.ErrorMessage(
+                  "diagCode-0-idrDiagCode", "invalid length: expected=[1,7] actual=10"),
+              new DataTransformer.ErrorMessage("detail-0-idrDtlFromDate", "invalid date"),
+              new DataTransformer.ErrorMessage("detail-0-idrDtlToDate", "invalid date"),
+              new DataTransformer.ErrorMessage(
+                  "detail-0-idrProcCode", "invalid length: expected=[1,5] actual=8"),
+              new DataTransformer.ErrorMessage(
+                  "detail-0-idrModOne", "invalid length: expected=[1,2] actual=5"),
+              new DataTransformer.ErrorMessage(
+                  "detail-0-idrModTwo", "invalid length: expected=[1,2] actual=5"),
+              new DataTransformer.ErrorMessage(
+                  "detail-0-idrModThree", "invalid length: expected=[1,2] actual=5"),
+              new DataTransformer.ErrorMessage(
+                  "detail-0-idrModFour", "invalid length: expected=[1,2] actual=5"),
+              new DataTransformer.ErrorMessage(
+                  "detail-0-idrDtlDiagIcdType", "invalid length: expected=[1,1] actual=39"),
+              new DataTransformer.ErrorMessage(
+                  "detail-0-idrDtlPrimaryDiagCode", "invalid length: expected=[1,7] actual=10"),
+              new DataTransformer.ErrorMessage(
+                  "detail-0-idrKPosLnameOrg", "invalid length: expected=[1,60] actual=63"),
+              new DataTransformer.ErrorMessage(
+                  "detail-0-idrKPosFname", "invalid length: expected=[1,35] actual=38"),
+              new DataTransformer.ErrorMessage(
+                  "detail-0-idrKPosMname", "invalid length: expected=[1,25] actual=28"),
+              new DataTransformer.ErrorMessage(
+                  "detail-0-idrKPosAddr1", "invalid length: expected=[1,55] actual=58"),
+              new DataTransformer.ErrorMessage(
+                  "detail-0-idrKPosAddr2_1st", "invalid length: expected=[1,30] actual=33"),
+              new DataTransformer.ErrorMessage(
+                  "detail-0-idrKPosAddr2_2nd", "invalid length: expected=[1,25] actual=28"),
+              new DataTransformer.ErrorMessage(
+                  "detail-0-idrKPosCity", "invalid length: expected=[1,30] actual=33"),
+              new DataTransformer.ErrorMessage(
+                  "detail-0-idrKPosState", "invalid length: expected=[1,2] actual=5"),
+              new DataTransformer.ErrorMessage(
+                  "detail-0-idrKPosZip", "invalid length: expected=[1,15] actual=18")),
+          ex.getErrors());
+    }
+  }
+
+  @Test
+  public void unrecognizedStatusCode() {
+    claimBuilder
+        .setIdrClmHdIcn("123456789012345")
+        .setIdrContrId("12345")
+        .setIdrClaimTypeEnum(McsClaimType.CLAIM_TYPE_MEDICAL)
+        .setIdrStatusCodeUnrecognized("X");
+    changeBuilder
+        .setChangeType(ClaimChange.ChangeType.CHANGE_TYPE_INSERT)
+        .setMcsClaim(claimBuilder.build());
+    try {
+      transformer.transformClaim(changeBuilder.build());
+      fail("should have thrown");
+    } catch (DataTransformer.TransformationException ex) {
+      assertEquals(
+          ImmutableList.of(
+              new DataTransformer.ErrorMessage("idrStatusCode", "unsupported enum value")),
+          ex.getErrors());
+    }
+  }
+
+  private void assertChangeMatches(RdaChange.Type changeType) {
+    RdaChange<PreAdjMcsClaim> changed = transformer.transformClaim(changeBuilder.build());
+    assertEquals(changeType, changed.getType());
+    assertThat(changed.getClaim(), samePropertyValuesAs(claim));
+  }
+}

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/TransformerTestUtils.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/TransformerTestUtils.java
@@ -1,0 +1,29 @@
+package gov.cms.bfd.pipeline.rda.grpc.source;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.samePropertyValuesAs;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.function.ToIntFunction;
+import java.util.stream.Collectors;
+
+public class TransformerTestUtils {
+  /**
+   * The McsClaimTransformerTest and FissClaimTransformerTest need to be able to compare lists of
+   * objects and there isn't a standard matcher that is compatible and handles ordering properly.
+   */
+  public static <T> void assertListContentsHaveSamePropertyValues(
+      Set<T> expectedSet, Set<T> actualSet, ToIntFunction<T> priority) {
+    List<T> expected =
+        expectedSet.stream().sorted(Comparator.comparingInt(priority)).collect(Collectors.toList());
+    List<T> actual =
+        actualSet.stream().sorted(Comparator.comparingInt(priority)).collect(Collectors.toList());
+    assertEquals(expected.size(), actual.size());
+    for (int i = 0; i < expected.size(); ++i) {
+      assertThat(actual.get(i), samePropertyValuesAs(expected.get(i)));
+    }
+  }
+}


### PR DESCRIPTION
### Change Details

Adds support for rejecting FissClaim and McsClaim objects from the RDA API if they contain unsupported values.

- For FISS claims all defined enum values are acceptable but "unrecognized" field values are rejected.
- For MCS claims all defined enum values EXCEPT `STATUS_CODE_NOT_USED` are acceptable but "unrecognized" field values are rejected.

In addition to adding the new feature a unit test class was added for the McsClaimTransformer.

### Acceptance Validation

- Are the correct values being rejected and other values being accepted?
- Are the unit tests sufficient to verify the change is working correctly?

### Feedback Requested

Nothing specific.

### External References

- [DCGEO-144](https://jira.cms.gov/browse/DCGEO-144)

### Security Implications

None.

- [ ] new software dependencies

No

- [ ] altered security controls

No

- [ ] new data stored or transmitted

No

- [ ] security checklist is completed for this change

No

- [ ] requires more information or team discussion to evaluate security implications

No

