### PR TITLE
BFD-1613 Clarify Log-Derived Metric Units

### DIFF
--- a/apps/bfd-server/bfd-server-launcher/src/main/java/gov/cms/bfd/server/launcher/DataServerLauncherApp.java
+++ b/apps/bfd-server/bfd-server-launcher/src/main/java/gov/cms/bfd/server/launcher/DataServerLauncherApp.java
@@ -204,7 +204,7 @@ public final class DataServerLauncherApp {
     final String accessLogFileName =
         System.getProperty("bfdServer.logs.dir", "./target/server-work/") + "access.log";
     final String requestLogFormat =
-        "%{remote}a - \"%u\" %t \"%r\" \"%q\" %s %{CLF}S %D"
+        "%{remote}a - \"%u\" %t \"%r\" \"%q\" %s %{CLF}S %{ms}T"
             + " %{BlueButton-OriginalQueryId}i"
             + " %{BlueButton-OriginalQueryCounter}i"
             + " [%{BlueButton-OriginalQueryTimestamp}i]"

--- a/ops/terraform/modules/stateless/main.tf
+++ b/ops/terraform/modules/stateless/main.tf
@@ -352,7 +352,7 @@ module "bfd_server_alarm_all_eob_6s-p95" {
     datapoints       = "15"
     statistic        = null
     ext_statistic    = "p95"
-    threshold        = "6000000.0"
+    threshold        = "6000.0" # milliseconds
     alarm_notify_arn = data.aws_sns_topic.cloudwatch_alarms.arn
     ok_notify_arn    = data.aws_sns_topic.cloudwatch_ok.arn
   }


### PR DESCRIPTION
**JIRA Ticket:**
[BFD-1613](https://jira.cms.gov/browse/BFD-1613)

**User Story or Bug Summary:**
Clarify Log-Derived Metric Units

---

### What Does This PR Do?
This corrects the log format to begin producing milliseconds instead of microseconds in the bfd-server application. Additionally, this effectively reverts recent changes to the alarm threshold to expected milliseconds once again.

**Old Log Format**

Values are represented in microseconds (µs). Three test requests timed at `2196000`, `263000`, and `161000` yields a simple average of `873333` microseconds:

```
127.0.0.1 - "CN=client-local-dev" [23/Mar/2022:22:01:34 +0000] "GET /v2/fhir/ExplanationOfBenefit/?patient=567834&_format=json HTTP/1.1" "?patient=567834&_format=json" 200 129797 2196000 - - [-] - "-" - "-" - "-" -
127.0.0.1 - "CN=client-local-dev" [23/Mar/2022:22:02:29 +0000] "GET /v2/fhir/ExplanationOfBenefit/?patient=567834&_format=json HTTP/1.1" "?patient=567834&_format=json" 200 129797 263000 - - [-] - "-" - "-" - "-" -
127.0.0.1 - "CN=client-local-dev" [23/Mar/2022:22:03:34 +0000] "GET /v2/fhir/ExplanationOfBenefit/?patient=567834&_format=json HTTP/1.1" "?patient=567834&_format=json" 200 129797 161000 - - [-] - "-" - "-" - "-" -
```

**New Log Format**

Values are represented in milliseconds (ms). Three test requests timed at `2507`, `167`, and `145` yields a simple average of `939` milliseconds:

```
127.0.0.1 - "CN=client-local-dev" [23/Mar/2022:22:12:23 +0000] "GET /v2/fhir/ExplanationOfBenefit/?patient=567834&_format=json HTTP/1.1" "?patient=567834&_format=json" 200 129797 2507 - - [-] - "-" - "-" - "-" -
127.0.0.1 - "CN=client-local-dev" [23/Mar/2022:22:12:46 +0000] "GET /v2/fhir/ExplanationOfBenefit/?patient=567834&_format=json HTTP/1.1" "?patient=567834&_format=json" 200 129797 167 - - [-] - "-" - "-" - "-" -
127.0.0.1 - "CN=client-local-dev" [23/Mar/2022:22:12:47 +0000] "GET /v2/fhir/ExplanationOfBenefit/?patient=567834&_format=json HTTP/1.1" "?patient=567834&_format=json" 200 129797 145 - - [-] - "-" - "-" - "-" -
```

### What Should Reviewers Watch For?

# THIS WILL LIKELY BE A NOISY DEPLOYMENT
Older `bfd-server` instances that continue to run briefly after the CloudWatch thresholds are updated will report their metrics in microseconds. Every request in this brief period will appear to break the established threshold. @keithdadkins @lsmitchell

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items to the following list here -->
* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [X] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [X] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [X] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [X] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [X] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [X] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [X] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [X] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [X] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [X] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [X] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
 