### PR TITLE
BFD-1631 Package newrelic-agent with bfd-server

### DIFF
--- a/apps/bfd-server/bfd-server-launcher/pom.xml
+++ b/apps/bfd-server/bfd-server-launcher/pom.xml
@@ -22,6 +22,11 @@
 
 	<dependencies>
 		<dependency>
+			<!-- The newrelic.jar javaagent dependency -->
+			<groupId>com.newrelic.agent.java</groupId>
+			<artifactId>newrelic-agent</artifactId>
+		</dependency>
+		<dependency>
 			<!-- Jetty is the embedded web server that this project uses to run WARs. -->
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-server</artifactId>

--- a/apps/pom.xml
+++ b/apps/pom.xml
@@ -87,6 +87,7 @@
 		<junit.version>5.8.2</junit.version>
 		<jackson.version>2.13.1</jackson.version>
 		<mockito.version>4.2.0</mockito.version>
+		<newrelicAgent.version>7.5.0</newrelicAgent.version>
 
 		<!-- The default DB that will be used in integration tests. -->
 		<!-- Note: See gov.cms.bfd.model.rif.schema.DatabaseTestHelper for details
@@ -107,6 +108,12 @@
 
 	<dependencyManagement>
 		<dependencies>
+			<dependency>
+				<!-- The newrelic.jar javaagent dependency -->
+				<groupId>com.newrelic.agent.java</groupId>
+				<artifactId>newrelic-agent</artifactId>
+				<version>${newrelicAgent.version}</version>
+			</dependency>
 			<dependency>
 				<!-- Provides a sane facade for the giant mess of incompatible logging 
 					frameworks in Java. -->

--- a/ops/ansible/roles/bfd-server/defaults/main.yml
+++ b/ops/ansible/roles/bfd-server/defaults/main.yml
@@ -31,6 +31,3 @@ data_server_v2_enabled: false
 
 # Whether or not pre-adjudicated claims data resources are enabled.
 pre_adj_resources_enabled: false
-
-# new relic
-new_relic_agent_version: '7.5.0'

--- a/ops/ansible/roles/bfd-server/tasks/install.yml
+++ b/ops/ansible/roles/bfd-server/tasks/install.yml
@@ -1,12 +1,8 @@
 ---
-
 - name: Install Pre-requisites
   yum:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    # Needed to supply `keytool` and also to run the app server.
-    - java-11-openjdk-devel
+    pkg:
+      - java-11-openjdk-devel
   become: true
 
 - name: Create Server User
@@ -24,8 +20,9 @@
     mode: u=rwx,g=rx,o=rx
   become: true
 
-# Create the temp directory iff it's missing. (Don't want to accidentally
-# change the permissions on /tmp.)
+
+# Create the temp directory if and only if it's missing. (Don't want to
+# accidentally change the permissions on /tmp.)
 - name: Check for Custom Temp Directory
   stat:
     path: "{{ data_server_tmp_dir }}"
@@ -57,20 +54,6 @@
     dest: "{{ data_server_dir }}/{{ data_server_war | basename }}"
   become: true
 
-# FIXME: Switch to the maven_artifact module after we move to the CCS.
-# see ../defaults/main.yml for version
-- name: Download New Relic Java Agent Bundle
-  get_url:
-    url: 'https://search.maven.org/remotecontent?filepath=com/newrelic/agent/java/newrelic-java/{{new_relic_agent_version}}/newrelic-java-{{new_relic_agent_version}}.zip'
-    dest: /tmp/newrelic-java.zip
-
-- name: Unzip New Relic Java Agent Bundle
-  unarchive:
-    src: /tmp/newrelic-java.zip
-    dest: /tmp
-    creates: /tmp/newrelic
-    remote_src: true
-
 - name: Create New Relic Directories
   file:
     path: "{{ item }}"
@@ -83,14 +66,22 @@
     - "{{ data_server_dir }}/newrelic"
     - "{{ data_server_dir }}/newrelic/extensions"
 
+- name: Find New Relic Agent
+  find:
+    paths: "{{ data_server_dir }}/bfd-server-launcher-1.0.0-SNAPSHOT/lib/"
+    pattern: newrelic-agent*.jar
+  register: find_nra
+
 - name: Copy New Relic Java Agent
   copy:
-    src: /tmp/newrelic/newrelic.jar
+    src: "{{ item.path }}"
     dest: "{{ data_server_dir }}/newrelic/newrelic.jar"
     remote_src: true
     owner: "{{ data_server_user }}"
     group: "{{ data_server_user }}"
     mode: u=rw,g=r,o=r
+  with_items:
+    - "{{ find_nra.files }}"
   become: true
 
 - name: Copy New Relic Java Agent Config

--- a/ops/ansible/roles/bfd-server/test/post-test.sh
+++ b/ops/ansible/roles/bfd-server/test/post-test.sh
@@ -10,4 +10,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$SCRIPT_DIR"
 
 # Remove the Docker instance used in the tests.
-docker rm --force "$CONTAINER_NAME"
+if "$REMOVE_CONTAINER"; then
+    echo "Removing ${CONTAINER_NAME} container..."
+    docker rm --force "$CONTAINER_NAME"
+fi

--- a/ops/ansible/roles/bfd-server/test/run-tests.sh
+++ b/ops/ansible/roles/bfd-server/test/run-tests.sh
@@ -7,7 +7,18 @@
 # Stop immediately if any command returns a non-zero result.
 set -eou pipefail
 
-# These variables can be adjusted to change which test is run.
+function help() {
+    echo "This script runs our test cases locally, via Docker."
+    echo "Usage: ${0} [-e extra-vars] [-hk] [image id]"
+    echo "Options:"
+    echo "  ${0} -e <extra-vars>: [e]xtra variables for ansible-playbook."
+    echo "  ${0} -h:              [h]elp displays this message and exits."
+    # TODO: complete the getopts implementation. See BFD-1628.
+    # echo "  ${0} -i <ID>: image [i]d set in 'ghcr.io/cmsgov/bfd-apps:<ID>'. Defaults to current commit hash."
+    echo "  ${0} -k:              [k]eeps the container under test instead of removing it. Defaults to removing the container."
+}
+
+REMOVE_CONTAINER=true # exported after getopts below...
 export ROLE=bfd-server
 export CONTAINER_NAME="$ROLE"
 export TEST_PLAY=test_basic.yml
@@ -19,7 +30,38 @@ export LAUNCHER_ARTIFACT="bfd-server-launcher-1.0.0-SNAPSHOT.zip"
 export WAR_DIRECTORY="/.m2/repository/gov/cms/bfd/bfd-server-war/1.0.0-SNAPSHOT"
 export WAR_ARTIFACT="bfd-server-war-1.0.0-SNAPSHOT.war"
 
+# iterate getopts
+while getopts "e:hk" option; do
+    case "$option" in
+      e) # extra-vars
+        EXTRA_VARS="$OPTARG"
+        ;;
+      h) # help
+        help
+        exit
+        ;;
+      # TODO: complete the getopts implementation. See BFD-1628.
+      # i) # image id
+      #    input_bfd_apps_image_id="$OPTARG";;
+      k) # keep container
+        REMOVE_CONTAINER=false
+        ;;
+     \?) # Invalid
+        help
+        exit 1
+        ;;
+    esac
+done
+shift "$((OPTIND-1))"
+
+# TODO: complete the getopts implementation. See BFD-1628.
+# use the input from option '-i' or default to current commit's short sha
+# export BFD_APPS_IMAGE_ID="${input_bfd_apps_image_id:-$(git rev-parse --short HEAD)}"
+# use input "$1" or default to current commit's short sha
 # Determine the directory that this script is in.
+export BFD_APPS_IMAGE_ID="${1:-$(git rev-parse --short HEAD)}"
+export REMOVE_CONTAINER EXTRA_VARS
+
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Launch the Docker container that will be used in the tests.


### PR DESCRIPTION
**JIRA Ticket:**
[BFD-1631](https://jira.cms.gov/browse/BFD-1631)

**User Story or Bug Summary:**
 
Prefer maven over ansible for newrelic agent jar inclusion

---

### What Does This PR Do?

* Treats the newrelic agent more like other dependencies by packaging along with other bfd-server dependencies
* Removes newrelic java agent fetch, unarchive, and copy operations from ansible role, replacing them with a find+copy operation from the newly available, pre-installed newrelic java agent
* Updates jdk package installation logic to tamp down on deprecation warnings and prepare for newer ansible versions
* Extends the bfd-server ansible role test harness with `getopts` for more flexibility in local ansible development

If you're reviewing this PR, please check for these things in particular:

* Verify all PR security questions and checklists have been completed and addressed.

### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [X] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [X] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [X] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [X] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [X] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [X] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [X] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [X] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [X] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [X] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [X] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    