### PR TITLE
BFD-1699 fix bene id numeric update bug

### DIFF
--- a/apps/bfd-model/bfd-model-codegen/src/main/java/gov/cms/bfd/model/codegen/RifLayoutsProcessor.java
+++ b/apps/bfd-model/bfd-model-codegen/src/main/java/gov/cms/bfd/model/codegen/RifLayoutsProcessor.java
@@ -1058,17 +1058,8 @@ public final class RifLayoutsProcessor extends AbstractProcessor {
                   .addModifiers(Modifier.PUBLIC)
                   .returns(void.class)
                   .addParameter(TypeName.LONG, headerField.name);
-          // setBeneficiaryId in the "beneficiaries" table we'll also populate
-          // the bene_id_numeric as part of the setter
-          StringBuilder sb = new StringBuilder("this.$N = String.valueOf($N)");
-          if (mappingSpec.getHeaderTable().equalsIgnoreCase("beneficiaries")
-              && headerField.name.equalsIgnoreCase("beneficiaryId")) {
-            sb.append("; beneficiaryIdNumeric = $N");
-            headerFieldSetter.addStatement(
-                sb.toString(), headerField.name, headerField.name, headerField.name);
-          } else {
-            headerFieldSetter.addStatement(sb.toString(), headerField.name, headerField.name);
-          }
+          headerFieldSetter.addStatement(
+              "this.$N = String.valueOf($N)", headerField.name, headerField.name);
         }
       } else {
         headerFieldSetter =

--- a/apps/bfd-model/bfd-model-codegen/src/main/java/gov/cms/bfd/model/codegen/RifLayoutsProcessor.java
+++ b/apps/bfd-model/bfd-model-codegen/src/main/java/gov/cms/bfd/model/codegen/RifLayoutsProcessor.java
@@ -1058,8 +1058,17 @@ public final class RifLayoutsProcessor extends AbstractProcessor {
                   .addModifiers(Modifier.PUBLIC)
                   .returns(void.class)
                   .addParameter(TypeName.LONG, headerField.name);
-          headerFieldSetter.addStatement(
-              "this.$N = String.valueOf($N)", headerField.name, headerField.name);
+          // setBeneficiaryId in the "beneficiaries" table we'll also populate
+          // the bene_id_numeric as part of the setter
+          StringBuilder sb = new StringBuilder("this.$N = String.valueOf($N)");
+          if (mappingSpec.getHeaderTable().equalsIgnoreCase("beneficiaries")
+              && headerField.name.equalsIgnoreCase("beneficiaryId")) {
+            sb.append("; beneficiaryIdNumeric = $N");
+            headerFieldSetter.addStatement(
+                sb.toString(), headerField.name, headerField.name, headerField.name);
+          } else {
+            headerFieldSetter.addStatement(sb.toString(), headerField.name, headerField.name);
+          }
         }
       } else {
         headerFieldSetter =

--- a/apps/bfd-model/bfd-model-rif/src/main/resources/db/migration/V65__Add_PreUpdate_Trigger_Beneficiaries.sql
+++ b/apps/bfd-model/bfd-model-rif/src/main/resources/db/migration/V65__Add_PreUpdate_Trigger_Beneficiaries.sql
@@ -1,18 +1,15 @@
--- Add a pre-update trigger to the beneficiaries table to populate
--- bene_id_numeric on a record update. There is currently a
--- pre-insert trigger, but we also need a pre-update trigger since
--- the Beneficiary.java ORM object will initialize the native data
--- type to 0 (zero) when the object is instantiated.
+-- Add a pre-[insert|update] trigger to the beneficiaries table to populate
+-- bene_id_numeric on a record update. We need both pre-insert and
+-- pre-update trigger to fire since the Beneficiary.java ORM object will
+-- initialize the native data type to 0 (zero) when the object is instantiated.
 
--- create a database trigger which will be used to imbue a bigint value
--- into the bene_id_numeric column during a table record UPDATE operation.
--- The trigger is defined as a pre-update trigger, which means that prior to
--- record being written, the database engine will execute the trigger, causing
--- the bene_id_numeric to be populated with a value based on a 'cast'
--- of the bene_id (varchar).
+-- The database trigger will be used to imbue a bigint value into the bene_id_numeric
+-- column during a table record INSERT or UPDATE operation what this means is that
+-- prior to a record being written, the database engine will execute the trigger, causing
+-- the bene_id_numeric to be populated with a value based on a 'cast' of the bene_id (varchar).
+
 -- Unfortunately HSQL doesn't support 'insert or update' directive so we have to
 -- have a separate trigger for the update.
-
 ${logic.hsql-only} CREATE TRIGGER beneficiaries_pre_update_trigger BEFORE UPDATE ON public.beneficiaries
 ${logic.hsql-only}    REFERENCING NEW as newrow FOR EACH ROW
 ${logic.hsql-only}       BEGIN ATOMIC

--- a/apps/bfd-model/bfd-model-rif/src/main/resources/db/migration/V65__Add_PreUpdate_Trigger_Beneficiaries.sql
+++ b/apps/bfd-model/bfd-model-rif/src/main/resources/db/migration/V65__Add_PreUpdate_Trigger_Beneficiaries.sql
@@ -14,7 +14,7 @@
 -- HSQL always gets created/initialized from scratch so no need to drop trigger
 -- Unfortunately HSQL doesn't support 'insert or update' directive so we have to
 -- have a separate trigger for the update.
-${logic.hsql-only} CREATE TRIGGER beneficiaries_update_trigger BEFORE UPDATE ON public.beneficiaries
+${logic.hsql-only} CREATE TRIGGER beneficiaries_pre_update_trigger BEFORE UPDATE ON public.beneficiaries
 ${logic.hsql-only}    REFERENCING NEW as newrow FOR EACH ROW
 ${logic.hsql-only}       BEGIN ATOMIC
 ${logic.hsql-only}            SET newrow.bene_id_numeric = convert(newrow.bene_id, SQL_BIGINT);

--- a/apps/bfd-model/bfd-model-rif/src/main/resources/db/migration/V65__Add_PreUpdate_Trigger_Beneficiaries.sql
+++ b/apps/bfd-model/bfd-model-rif/src/main/resources/db/migration/V65__Add_PreUpdate_Trigger_Beneficiaries.sql
@@ -10,19 +10,34 @@
 -- record being written, the database engine will execute the trigger, causing
 -- the bene_id_numeric to be populated with a value based on a 'cast'
 -- of the bene_id (varchar).
-
--- HSQL always gets created/initialized from scratch so no need to drop trigger
 -- Unfortunately HSQL doesn't support 'insert or update' directive so we have to
 -- have a separate trigger for the update.
+
 ${logic.hsql-only} CREATE TRIGGER beneficiaries_pre_update_trigger BEFORE UPDATE ON public.beneficiaries
 ${logic.hsql-only}    REFERENCING NEW as newrow FOR EACH ROW
 ${logic.hsql-only}       BEGIN ATOMIC
 ${logic.hsql-only}            SET newrow.bene_id_numeric = convert(newrow.bene_id, SQL_BIGINT);
 ${logic.hsql-only}       END;
 
--- for Postgres, we can combine the directive.
-${logic.psql-only} DROP TRIGGER IF EXISTS beneficiaries_insert_trigger ON public.beneficiaries;
-${logic.psql-only} CREATE TRIGGER beneficiaries_insert_trigger
+-- for psql, completely clean out previous trigger and function created in V60 flyway script
+${logic.psql-only} DROP TRIGGER IF EXISTS beneficiaries_insert_trigger ON public.beneficiaries CASCADE;
+${logic.psql-only} DROP FUNCTION IF EXISTS public.beneficiaries_pre_insert() CASCADE;
+
+-- create a trigger function that can be invoked to populate the bene_id_numeric
+${logic.psql-only} CREATE OR REPLACE FUNCTION public.beneficiaries_populate_bene_id_numeric()
+${logic.psql-only}     RETURNS trigger
+${logic.psql-only}     LANGUAGE 'plpgsql'
+${logic.psql-only}    VOLATILE NOT LEAKPROOF
+${logic.psql-only} AS $BODY$
+${logic.psql-only} BEGIN
+${logic.psql-only}   NEW.bene_id_numeric = NEW.bene_id::bigint;
+${logic.psql-only}   RETURN NEW;
+${logic.psql-only} END;
+${logic.psql-only} $BODY$;
+
+-- for Postgres, we can combine the directive using "INSERT OR UPDATE"
+${logic.psql-only} DROP TRIGGER IF EXISTS beneficiaries_pre_insert_update_trigger ON public.beneficiaries CASCADE;
+${logic.psql-only} CREATE TRIGGER beneficiaries_pre_insert_update_trigger
 ${logic.psql-only}     BEFORE INSERT OR UPDATE ON public.beneficiaries
 ${logic.psql-only}     FOR EACH ROW
-${logic.psql-only}       EXECUTE FUNCTION public.beneficiaries_pre_insert();
+${logic.psql-only}       EXECUTE FUNCTION public.beneficiaries_populate_bene_id_numeric();

--- a/apps/bfd-model/bfd-model-rif/src/main/resources/db/migration/V65__Add_PreUpdate_Trigger_Beneficiaries.sql
+++ b/apps/bfd-model/bfd-model-rif/src/main/resources/db/migration/V65__Add_PreUpdate_Trigger_Beneficiaries.sql
@@ -1,0 +1,28 @@
+-- Add a pre-update trigger to the beneficiaries table to populate
+-- bene_id_numeric on a record update. Therei is currently a
+-- pre-insert trigger, but we also need a pre-update trigger since
+-- the Beneficiary.java ORM object will initialize the native data
+-- type to 0 (zero) when the object is instantiated.
+
+-- create a database trigger which will be used to imbue a bigint value
+-- into the bene_id_numeric column during a table record UPDATE operation.
+-- The trigger is defined as a pre-update trigger, which means that prior to
+-- record being written, the database engine will execute the trigger, causing
+-- the bene_id_numeric to be populated with a value based on a 'cast'
+-- of the bene_id (varchar).
+
+-- HSQL always gets created/initialized from scratch so no need to drop trigger
+-- Unfortunately HSQL doesn't support 'insert or update' directive so we have to
+-- have a separate trigger for the update.
+${logic.hsql-only} CREATE TRIGGER beneficiaries_update_trigger BEFORE UPDATE ON public.beneficiaries
+${logic.hsql-only}    REFERENCING NEW as newrow FOR EACH ROW
+${logic.hsql-only}       BEGIN ATOMIC
+${logic.hsql-only}            SET newrow.bene_id_numeric = convert(newrow.bene_id, SQL_BIGINT);
+${logic.hsql-only}       END;
+
+-- for Postgres, we can combine the directive.
+${logic.psql-only} DROP TRIGGER IF EXISTS beneficiaries_insert_trigger ON public.beneficiaries;
+${logic.psql-only} CREATE TRIGGER beneficiaries_insert_trigger
+${logic.psql-only}     BEFORE INSERT OR UPDATE ON public.beneficiaries
+${logic.psql-only}     FOR EACH ROW
+${logic.psql-only}       EXECUTE FUNCTION public.beneficiaries_pre_insert();

--- a/apps/bfd-model/bfd-model-rif/src/main/resources/db/migration/V65__Add_PreUpdate_Trigger_Beneficiaries.sql
+++ b/apps/bfd-model/bfd-model-rif/src/main/resources/db/migration/V65__Add_PreUpdate_Trigger_Beneficiaries.sql
@@ -1,5 +1,5 @@
 -- Add a pre-update trigger to the beneficiaries table to populate
--- bene_id_numeric on a record update. Therei is currently a
+-- bene_id_numeric on a record update. There is currently a
 -- pre-insert trigger, but we also need a pre-update trigger since
 -- the Beneficiary.java ORM object will initialize the native data
 -- type to 0 (zero) when the object is instantiated.


### PR DESCRIPTION
**JIRA Ticket:**
[BFD-1699](https://jira.cms.gov/browse/BFD-1699)

**User Story or Bug Summary:**
Fix RIF loader bug in which an UPDATE to the _beneficiaries_ table would contain a zero value in the Beneficiary object that is used to persist a record. The issue is that _bene_id_numeric_ is a native long, which will be 0 (zero) when the Beneficiary object is instantiated. This creates a situation in which the first record will be stored with a zero value in a unique index constraint; when the 2nd records is attempted to be persisted, it throws a db constraint violation since we are again trying to write a zero value on a column defined as unique.

### What Does This PR Do?
This PR fixes the issue where the RIF loader attempts to update a _beneficiaries_ record during an UPDATE operation; a pre-update trigger is registered that enforces the bene_id_numeric column has a correct value prior to persisting the record.

_In addition, the _RifLayoutsProcessor.java_ was modified to special-case the _setBeneficiaryId_ method to also populate the _beneficiaryIdNumeric_ field.

This PR is marked as _draft_ until we decide upon the best way to mitigate the problem (one of the above 2 choices).

### What Should Reviewers Watch For?
Weigh the options and come to consensus on best way to handle thie update problem.

If you're reviewing this PR, please check for these things in particular:

* Verify all PR security questions and checklists have been completed and addressed.

### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:
    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [X] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [X] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [X] No

    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [X] No

### What Needs to Be Merged and Deployed Before this PR?

* N/A

### Submitter Checklist

I have gone through and verified that...:

* [X] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [X] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [X] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [X] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [X] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [X] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [X] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    