### PR TITLE
BFD-1685: Implement bfd-server startup check

### DIFF
--- a/ops/ansible/roles/bfd-server/tasks/install.yml
+++ b/ops/ansible/roles/bfd-server/tasks/install.yml
@@ -11,6 +11,14 @@
     shell: /bin/false
   become: true
 
+- name: Add server user to sudoers file
+  lineinfile:
+    path: /etc/sudoers
+    state: present
+    line: "{{ data_server_user }} ALL=(ALL) NOPASSWD: /sbin/iptables"
+    validate: /usr/sbin/visudo -cf %s
+  become: true
+
 - name: Create Server Directory
   file:
     path: "{{ data_server_dir }}"

--- a/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
+++ b/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
@@ -95,6 +95,8 @@ check_endpoint() {
 # Runs test queries to verify that the server is working as expected. If not, issues a 'kill -INT' on the server's process to shut it down.
 ##
 stop_service_if_failing() {
+  # Reject all external traffic to port 7443 until the application has started successfully
+  sudo iptables -A INPUT -p tcp -i eth0 --dport 7443 -j REJECT
   log "Waiting $STARTUP_TESTING_BOOT_TIMEOUT seconds for initial startup"
   sleep $STARTUP_TESTING_BOOT_TIMEOUT
 
@@ -124,6 +126,8 @@ stop_service_if_failing() {
     STARTUP_TESTING_CHECK_V2_EOB_EXIT=$?
 
     if [[ $STARTUP_TESTING_CHECK_V1_METADATA_EXIT == 0 ]] && [[ $STARTUP_TESTING_CHECK_V1_COVERAGE_EXIT == 0 ]] && [[ $STARTUP_TESTING_CHECK_V1_EOB_EXIT == 0 ]] && [[ $STARTUP_TESTING_CHECK_V2_METADATA_EXIT == 0 ]] && [[ $STARTUP_TESTING_CHECK_V2_COVERAGE_EXIT == 0 ]] && [[ $STARTUP_TESTING_CHECK_V2_EOB_EXIT == 0 ]]; then
+      # Effectively allow traffic from external sources to reach instance port 7443
+      sudo iptables -D INPUT -p tcp -i eth0 --dport 7443 -j REJECT
       log "Server started properly"
       return 0
     elif [[ $I -lt $STARTUP_TESTING_RETRIES ]]; then

--- a/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
+++ b/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
@@ -96,7 +96,7 @@ check_endpoint() {
 ##
 stop_service_if_failing() {
   # Reject all external traffic to port 7443 until the application has started successfully
-  sudo iptables -A INPUT -p tcp -i eth0 --dport 7443 -j REJECT
+  sudo iptables -A INPUT -p tcp ! -i lo --dport 7443 -j REJECT
   log "Waiting $STARTUP_TESTING_BOOT_TIMEOUT seconds for initial startup"
   sleep $STARTUP_TESTING_BOOT_TIMEOUT
 
@@ -127,7 +127,7 @@ stop_service_if_failing() {
 
     if [[ $STARTUP_TESTING_CHECK_V1_METADATA_EXIT == 0 ]] && [[ $STARTUP_TESTING_CHECK_V1_COVERAGE_EXIT == 0 ]] && [[ $STARTUP_TESTING_CHECK_V1_EOB_EXIT == 0 ]] && [[ $STARTUP_TESTING_CHECK_V2_METADATA_EXIT == 0 ]] && [[ $STARTUP_TESTING_CHECK_V2_COVERAGE_EXIT == 0 ]] && [[ $STARTUP_TESTING_CHECK_V2_EOB_EXIT == 0 ]]; then
       # Effectively allow traffic from external sources to reach instance port 7443
-      sudo iptables -D INPUT -p tcp -i eth0 --dport 7443 -j REJECT
+      sudo iptables -D INPUT -p tcp ! -i lo --dport 7443 -j REJECT
       log "Server started properly"
       return 0
     elif [[ $I -lt $STARTUP_TESTING_RETRIES ]]; then

--- a/rfcs/0013-bfd-server-startup-check.md
+++ b/rfcs/0013-bfd-server-startup-check.md
@@ -12,7 +12,7 @@ This RFC proposes a minor change to existing bfd-server on-host health checking 
 ## Status
 [Status]: #status
 
-* Status: Proposed <!-- FIXME: adjust prior to merge -->
+* Status: Implemented
 * Implementation JIRA Ticket(s):
     * [BFD-1685](https://jira.cms.gov/browse/BFD-1685)
 


### PR DESCRIPTION
**JIRA Ticket:**
[BFD-1685](https://jira.cms.gov/browse/BFD-1685)

**User Story or Bug Summary:**

Implement a startup check for bfd-server.

---

This is the implementation side of the RFC 0013 and extends the `stop_service_if_failing` function to fully satisfy the requirements of a startup check with the following:

1. Augment the bfd-server service account with sudoers access, restricted to `/sbin/iptables` via ansible definition
2. Adjust the templated `bfd-server.sh.j2` file with the following changes:
    - At the beginning of the `stop_service_if_failing` function, disallow external traffic on port 7443:
    
        ```bash
        sudo iptables -A INPUT -p tcp -i eth0 --dport 7443 -j REJECT
        ```

    - Where the script currently produces the log message "Server started properly", allow external traffic on port 7443:

        ```bash
        sudo iptables -D INPUT -p tcp -i eth0 --dport 7443 -j REJECT
        ```

### What Should Reviewers Watch For?

If you're reviewing this PR, please check for these things in particular:
* Verify all PR security questions and checklists have been completed and addressed.

### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [x] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [x] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [x] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [x] No

### What Needs to Be Merged and Deployed Before this PR?

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* #1074

### Submitter Checklist

I have gone through and verified that...:

* [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    