### PR TITLE
PACA-562 (DRAFT): fiss diagnosis code validation

### DIFF
--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/source/DataTransformer.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/source/DataTransformer.java
@@ -1,5 +1,6 @@
 package gov.cms.bfd.pipeline.rda.grpc.source;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Timestamp;
 import java.math.BigDecimal;
@@ -69,6 +70,31 @@ public class DataTransformer {
   public boolean validateString(
       String fieldName, boolean nullable, int minLength, int maxLength, String value) {
     return nonNull(fieldName, value, nullable) && lengthOk(fieldName, value, minLength, maxLength);
+  }
+
+  /**
+   * Checks to ensure that at least one of the two fields has a non-empty string value. If neither
+   * does an error is added to the list of errors.
+   *
+   * @param fieldName1 name of the first field
+   * @param value1 value (possibly null) of the first field
+   * @param fieldName2 name of the second field
+   * @param value2 value (possibly null) of the second field
+   * @return true if at least one of the two fields has a non-null, non-empty string value
+   */
+  public boolean validateAtLeastOneIsPresent(
+      String fieldName1, String value1, String fieldName2, String value2) {
+    final var isPresent1 = !Strings.isNullOrEmpty(value1);
+    final var isPresent2 = !Strings.isNullOrEmpty(value2);
+    final var isValid = isPresent1 || isPresent2;
+    if (!isValid) {
+      addError(
+          fieldName1,
+          "expected either %s or %s to have value but neither did",
+          fieldName1,
+          fieldName2);
+    }
+    return isValid;
   }
 
   /**

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/source/FissClaimTransformer.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/source/FissClaimTransformer.java
@@ -488,10 +488,19 @@ public class FissClaimTransformer {
     return new FissClaimTransformer(clock, mbiCache);
   }
 
+  /**
+   * Validate and copy field values from a gRPC {@link FissClaimChange} to corresponding fields in
+   * {@link RdaChange}.
+   *
+   * @param change source object
+   * @return the populated object
+   */
   public RdaChange<RdaFissClaim> transformClaim(FissClaimChange change) {
     FissClaim from = change.getClaim();
     final DataTransformer transformer = new DataTransformer();
-    final RdaFissClaim to = transformMessage(from, transformer, clock.instant());
+    Instant now = clock.instant();
+    final RdaFissClaim to = transformMessageImpl(from, transformer, now, "");
+    transformMessageArrays(from, to, transformer, now, "");
     to.setSequenceNumber(change.getSeq());
 
     final List<DataTransformer.ErrorMessage> errors = transformer.getErrors();
@@ -509,12 +518,16 @@ public class FissClaimTransformer {
         transformer.instant(change.getTimestamp()));
   }
 
-  private RdaFissClaim transformMessage(FissClaim from, DataTransformer transformer, Instant now) {
-    final RdaFissClaim to = transformMessageImpl(from, transformer, now, "");
-    transformMessageArrays(from, to, transformer, now, "");
-    return to;
-  }
-
+  /**
+   * Validate and copy field values from a gRPC {@link FissClaim} to corresponding fields in {@link
+   * RdaFissClaim}.
+   *
+   * @param from source object
+   * @param transformer transformer to perform validation and transformation
+   * @param now current time stamp
+   * @param namePrefix added to field names in error message to disambiguate messages
+   * @return the populated object
+   */
   private RdaFissClaim transformMessageImpl(
       FissClaim from, DataTransformer transformer, Instant now, String namePrefix) {
     final RdaFissClaim to = new RdaFissClaim();
@@ -981,6 +994,16 @@ public class FissClaimTransformer {
     return to;
   }
 
+  /**
+   * Validate and copy objects in arrays within the {@link FissClaim} to lists of corresponding
+   * database entity classes in the provided {@link RdaFissClaim} object.
+   *
+   * @param from source object
+   * @param to destination object
+   * @param transformer transformer to perform validation and transformation
+   * @param now current time stamp
+   * @param namePrefix added to field names in error message to disambiguate messages
+   */
   private void transformMessageArrays(
       FissClaim from,
       RdaFissClaim to,
@@ -1024,6 +1047,16 @@ public class FissClaimTransformer {
     }
   }
 
+  /**
+   * Validate and copy field values from a gRPC {@link FissProcedureCode} to corresponding fields in
+   * {@link RdaFissProcCode}.
+   *
+   * @param from source object
+   * @param transformer transformer to perform validation and transformation
+   * @param now current time stamp
+   * @param namePrefix added to field names in error message to disambiguate messages
+   * @return the populated object
+   */
   private RdaFissProcCode transformMessageImpl(
       FissProcedureCode from, DataTransformer transformer, Instant now, String namePrefix) {
     final RdaFissProcCode to = new RdaFissProcCode();
@@ -1050,13 +1083,23 @@ public class FissClaimTransformer {
     return to;
   }
 
+  /**
+   * Validate and copy field values from a gRPC {@link FissDiagnosisCode} to corresponding fields in
+   * {@link RdaFissDiagnosisCode}.
+   *
+   * @param from source object
+   * @param transformer transformer to perform validation and transformation
+   * @param now current time stamp
+   * @param namePrefix added to field names in error message to disambiguate messages
+   * @return the populated object
+   */
   private RdaFissDiagnosisCode transformMessageImpl(
       FissDiagnosisCode from, DataTransformer transformer, Instant now, String namePrefix) {
     final RdaFissDiagnosisCode to = new RdaFissDiagnosisCode();
     transformer.copyString(
         namePrefix + RdaFissDiagnosisCode.Fields.diagCd2,
         false,
-        1,
+        0,
         7,
         from.getDiagCd2(),
         to::setDiagCd2);
@@ -1068,15 +1111,30 @@ public class FissClaimTransformer {
         to::setDiagPoaInd);
     transformer.copyOptionalString(
         namePrefix + RdaFissDiagnosisCode.Fields.bitFlags,
-        1,
+        0,
         4,
         from::hasBitFlags,
         from::getBitFlags,
         to::setBitFlags);
     to.setLastUpdated(now);
+
+    // At least one of these two fields must have a value for the object to be valid.
+    transformer.validateAtLeastOneIsPresent(
+        namePrefix + RdaFissDiagnosisCode.Fields.diagCd2, from.getDiagCd2(),
+        namePrefix + RdaFissDiagnosisCode.Fields.bitFlags, from.getBitFlags());
     return to;
   }
 
+  /**
+   * Validate and copy field values from a gRPC {@link FissPayer} to corresponding fields in {@link
+   * RdaFissPayer}.
+   *
+   * @param from source object
+   * @param transformer transformer to perform validation and transformation
+   * @param now current time stamp
+   * @param namePrefix added to field names in error message to disambiguate messages
+   * @return the populated object
+   */
   private RdaFissPayer transformMessageImpl(
       FissPayer from, DataTransformer transformer, Instant now, String namePrefix) {
     final RdaFissPayer to = new RdaFissPayer();
@@ -1324,6 +1382,16 @@ public class FissClaimTransformer {
     return to;
   }
 
+  /**
+   * Validate and copy field values from a gRPC {@link FissAuditTrail} to corresponding fields in
+   * {@link RdaFissAuditTrail}.
+   *
+   * @param from source object
+   * @param transformer transformer to perform validation and transformation
+   * @param now current time stamp
+   * @param namePrefix added to field names in error message to disambiguate messages
+   * @return the populated object
+   */
   private RdaFissAuditTrail transformMessageImpl(
       FissAuditTrail from, DataTransformer transformer, Instant now, String namePrefix) {
     final RdaFissAuditTrail to = new RdaFissAuditTrail();

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/source/FissClaimTransformer.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/source/FissClaimTransformer.java
@@ -1,5 +1,6 @@
 package gov.cms.bfd.pipeline.rda.grpc.source;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import gov.cms.bfd.model.rda.RdaFissAuditTrail;
 import gov.cms.bfd.model.rda.RdaFissClaim;
@@ -1093,7 +1094,8 @@ public class FissClaimTransformer {
    * @param namePrefix added to field names in error message to disambiguate messages
    * @return the populated object
    */
-  private RdaFissDiagnosisCode transformMessageImpl(
+  @VisibleForTesting
+  RdaFissDiagnosisCode transformMessageImpl(
       FissDiagnosisCode from, DataTransformer transformer, Instant now, String namePrefix) {
     final RdaFissDiagnosisCode to = new RdaFissDiagnosisCode();
     transformer.copyString(

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/DataTransformerTest.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/DataTransformerTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+/** Tests proper operation of the {@link DataTransformer} class. */
 public class DataTransformerTest {
   private DataTransformer transformer;
   private List<Object> copied;
@@ -21,8 +22,44 @@ public class DataTransformerTest {
     copied = new ArrayList<>();
   }
 
+  /** Tests the {@link DataTransformer#validateAtLeastOneIsPresent} method. */
   @Test
-  public void copyString() {
+  public void testValidateAtLeastOneIsPresent() {
+    assertEquals(true, transformer.validateAtLeastOneIsPresent("ok1-1", "1", "ok1-2", ""));
+    assertEquals(true, transformer.validateAtLeastOneIsPresent("ok2-1", "", "ok2-2", "2"));
+    assertEquals(true, transformer.validateAtLeastOneIsPresent("ok3-1", "1", "ok3-2", null));
+    assertEquals(true, transformer.validateAtLeastOneIsPresent("ok4-1", null, "ok4-2", "2"));
+    assertEquals(true, transformer.validateAtLeastOneIsPresent("both-1", "a", "both-2", "b"));
+    assertEquals(0, transformer.getErrors().size());
+
+    assertEquals(
+        false, transformer.validateAtLeastOneIsPresent("neither1-1", "", "neither1-2", ""));
+    assertEquals(
+        false, transformer.validateAtLeastOneIsPresent("neither2-1", null, "neither2-2", ""));
+    assertEquals(
+        false, transformer.validateAtLeastOneIsPresent("neither3-1", "", "neither3-2", null));
+    assertEquals(
+        false, transformer.validateAtLeastOneIsPresent("neither4-1", null, "neither4-2", null));
+    assertEquals(
+        ImmutableList.of(
+            new DataTransformer.ErrorMessage(
+                "neither1-1",
+                "expected either neither1-1 or neither1-2 to have value but neither did"),
+            new DataTransformer.ErrorMessage(
+                "neither2-1",
+                "expected either neither2-1 or neither2-2 to have value but neither did"),
+            new DataTransformer.ErrorMessage(
+                "neither3-1",
+                "expected either neither3-1 or neither3-2 to have value but neither did"),
+            new DataTransformer.ErrorMessage(
+                "neither4-1",
+                "expected either neither4-1 or neither4-2 to have value but neither did")),
+        transformer.getErrors());
+  }
+
+  /** Tests the {@link DataTransformer#copyString} method. */
+  @Test
+  public void testCopyString() {
     transformer
         .copyString("length-one-ok", false, 1, 5, "1", copied::add)
         .copyString("length-five-ok", false, 1, 5, "12345", copied::add)
@@ -42,8 +79,9 @@ public class DataTransformerTest {
         transformer.getErrors());
   }
 
+  /** Tests the {@link DataTransformer#copyCharacter} method. */
   @Test
-  public void copyCharacter() {
+  public void testCopyCharacter() {
     transformer
         .copyCharacter("length-one-ok", "1", copied::add)
         .copyCharacter("length-below-min", "", copied::add)
@@ -59,8 +97,9 @@ public class DataTransformerTest {
         transformer.getErrors());
   }
 
+  /** Tests the {@link DataTransformer#copyDate} method. */
   @Test
-  public void copyDate() {
+  public void testCopyDate() {
     transformer
         .copyDate("valid-1", false, "2021-03-01", copied::add)
         .copyDate("invalid-1", true, "2021/03/01", copied::add)
@@ -77,8 +116,9 @@ public class DataTransformerTest {
         transformer.getErrors());
   }
 
+  /** Tests the {@link DataTransformer#copyAmount} method. */
   @Test
-  public void copyAmount() {
+  public void testCopyAmount() {
     transformer
         .copyAmount("valid-1", false, "123.05", copied::add)
         .copyAmount("invalid-1", true, "not a number", copied::add)
@@ -98,8 +138,9 @@ public class DataTransformerTest {
         transformer.getErrors());
   }
 
+  /** Tests the {@link DataTransformer#copyEnumAsCharacter} method. */
   @Test
-  public void copyEnumAsCharacter() {
+  public void testCopyEnumAsCharacter() {
     transformer
         .copyEnumAsCharacter(
             "no-value",
@@ -127,8 +168,9 @@ public class DataTransformerTest {
         transformer.getErrors());
   }
 
+  /** Tests the {@link DataTransformer#copyEnumAsString} method. */
   @Test
-  public void copyEnumAsString() {
+  public void testCopyEnumAsString() {
     transformer
         .copyEnumAsString(
             "no-value",
@@ -170,8 +212,9 @@ public class DataTransformerTest {
         transformer.getErrors());
   }
 
+  /** Tests the {@link DataTransformer#copyStringWithExpectedValue} method. */
   @Test
-  public void copyExpectedValue() {
+  public void testCopyStringWithExpectedValue() {
     transformer
         .copyStringWithExpectedValue("both-null", true, 1, 1, null, null, copied::add)
         .copyStringWithExpectedValue("both-same", true, 1, 10, "abcdef", "abcdef", copied::add)

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/FissClaimTransformerTest.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/FissClaimTransformerTest.java
@@ -250,7 +250,7 @@ public class FissClaimTransformerTest {
         .setCurrLoc2Enum(FissCurrentLocation2.CURRENT_LOCATION_2_FINAL)
         .addFissDiagCodes(
             FissDiagnosisCode.newBuilder()
-                .setDiagCd2("code-1")
+                .setDiagCd2("")
                 .setDiagPoaIndEnum(
                     FissDiagnosisPresentOnAdmissionIndicator
                         .DIAGNOSIS_PRESENT_ON_ADMISSION_INDICATOR_CLINICALLY_UNDETERMINED)
@@ -262,7 +262,6 @@ public class FissClaimTransformerTest {
                 .setDiagPoaIndEnum(
                     FissDiagnosisPresentOnAdmissionIndicator
                         .DIAGNOSIS_PRESENT_ON_ADMISSION_INDICATOR_NO)
-                .setBitFlags("4321")
                 .build());
     claim.setDcn("dcn");
     claim.setHicNo("hicn");
@@ -273,7 +272,7 @@ public class FissClaimTransformerTest {
     RdaFissDiagnosisCode code = new RdaFissDiagnosisCode();
     code.setDcn("dcn");
     code.setPriority((short) 0);
-    code.setDiagCd2("code-1");
+    code.setDiagCd2("");
     code.setDiagPoaInd("W");
     code.setBitFlags("1234");
     code.setLastUpdated(claim.getLastUpdated());
@@ -283,7 +282,6 @@ public class FissClaimTransformerTest {
     code.setPriority((short) 1);
     code.setDiagCd2("code-2");
     code.setDiagPoaInd("N");
-    code.setBitFlags("4321");
     code.setLastUpdated(claim.getLastUpdated());
     claim.getDiagCodes().add(code);
     changeBuilder
@@ -1283,6 +1281,44 @@ public class FissClaimTransformerTest {
   }
 
   // endregion Claim tests
+  // region DiagnosisCode tests
+
+  @Test
+  public void testDiagnosisCodeDiagCd2() {
+    new DiagnosisCodeFieldTester(false)
+        .verifyStringFieldCopiedCorrectlyEmptyOK(
+            FissDiagnosisCode.Builder::setDiagCd2,
+            RdaFissDiagnosisCode::getDiagCd2,
+            RdaFissDiagnosisCode.Fields.diagCd2,
+            7);
+  }
+
+  @Test
+  public void testDiagnosisCodePoaInd() {
+    new DiagnosisCodeFieldTester(true)
+        .verifyEnumFieldStringValueExtractedCorrectly(
+            FissDiagnosisCode.Builder::setDiagPoaIndEnum,
+            RdaFissDiagnosisCode::getDiagPoaInd,
+            FissDiagnosisPresentOnAdmissionIndicator.DIAGNOSIS_PRESENT_ON_ADMISSION_INDICATOR_YES,
+            "Y")
+        .verifyStringFieldCopiedCorrectlyEmptyOK(
+            FissDiagnosisCode.Builder::setDiagPoaIndUnrecognized,
+            RdaFissDiagnosisCode::getDiagPoaInd,
+            RdaFissDiagnosisCode.Fields.diagPoaInd,
+            1);
+  }
+
+  @Test
+  public void testDiagnosisCodeBitFlags() {
+    new DiagnosisCodeFieldTester(false)
+        .verifyStringFieldCopiedCorrectlyEmptyOK(
+            FissDiagnosisCode.Builder::setBitFlags,
+            RdaFissDiagnosisCode::getBitFlags,
+            RdaFissDiagnosisCode.Fields.bitFlags,
+            4);
+  }
+
+  // endregion ProcCode tests
   // region ProcCode tests
 
   @Test
@@ -1313,7 +1349,6 @@ public class FissClaimTransformerTest {
             RdaFissProcCode::getProcDate,
             RdaFissProcCode.Fields.procDate);
   }
-
   // endregion ProcCode tests
   // region BeneZPayer tests
 
@@ -1869,6 +1904,15 @@ public class FissClaimTransformerTest {
 
   // region Field Tester Classes
 
+  /**
+   * Adaptor class extending the {@link ClaimTransformerFieldTester} class that can be used to
+   * create {@link FissClaim.Builder} instances and to trigger a transformation of a claim. Serves
+   * as a base class for specific field tester classes that share the same implementations of {@code
+   * createClaimBuilder()} and {@code transformClaim()}.
+   *
+   * @param <TBuilder> the claim builder class created by this adaptor
+   * @param <TEntity> the entity class created by this adaptor
+   */
   private abstract class AbstractFieldTester<TBuilder, TEntity>
       extends ClaimTransformerFieldTester<
           FissClaim.Builder, FissClaim, RdaFissClaim, TBuilder, TEntity> {
@@ -1898,6 +1942,11 @@ public class FissClaimTransformerTest {
     }
   }
 
+  /**
+   * Adaptor class extending the {@link ClaimTransformerFieldTester} class that can be used to
+   * create {@link FissClaim.Builder} instances and to trigger a transformation of a claim. Used for
+   * tests that operator on {@link FissClaim} and {@link RdaFissClaim} instances.
+   */
   class ClaimFieldTester extends AbstractFieldTester<FissClaim.Builder, RdaFissClaim> {
     @Override
     FissClaim.Builder getTestEntityBuilder(FissClaim.Builder claimBuilder) {
@@ -1910,6 +1959,11 @@ public class FissClaimTransformerTest {
     }
   }
 
+  /**
+   * Adaptor class extending the {@link ClaimTransformerFieldTester} class that can be used to
+   * create {@link FissAuditTrail.Builder} instances and to trigger a transformation of a claim.
+   * Used for tests that operator on {@link FissAuditTrail} and {@link RdaFissAuditTrail} instances.
+   */
   class AuditTrailFieldTester
       extends AbstractFieldTester<FissAuditTrail.Builder, RdaFissAuditTrail> {
     @Override
@@ -1935,6 +1989,11 @@ public class FissClaimTransformerTest {
     }
   }
 
+  /**
+   * Adaptor class extending the {@link ClaimTransformerFieldTester} class that can be used to
+   * create {@link FissBeneZPayer.Builder} instances and to trigger a transformation of a claim.
+   * Used for tests that operator on {@link FissBeneZPayer} and {@link RdaFissPayer} instances.
+   */
   class BeneZPayerFieldTester extends AbstractFieldTester<FissBeneZPayer.Builder, RdaFissPayer> {
     @Override
     FissBeneZPayer.Builder getTestEntityBuilder(FissClaim.Builder claimBuilder) {
@@ -1959,6 +2018,11 @@ public class FissClaimTransformerTest {
     }
   }
 
+  /**
+   * Adaptor class extending the {@link ClaimTransformerFieldTester} class that can be used to
+   * create {@link FissInsuredPayer.Builder} instances and to trigger a transformation of a claim.
+   * Used for tests that operator on {@link FissInsuredPayer} and {@link RdaFissPayer} instances.
+   */
   class InsuredPayerFieldTester
       extends AbstractFieldTester<FissInsuredPayer.Builder, RdaFissPayer> {
     @Override
@@ -1984,6 +2048,12 @@ public class FissClaimTransformerTest {
     }
   }
 
+  /**
+   * Adaptor class extending the {@link ClaimTransformerFieldTester} class that can be used to
+   * create {@link FissProcedureCode.Builder} instances and to trigger a transformation of a claim.
+   * Used for tests that operator on {@link FissProcedureCode} and {@link RdaFissProcCode}
+   * instances.
+   */
   class ProcCodeFieldTester
       extends AbstractFieldTester<FissProcedureCode.Builder, RdaFissProcCode> {
     @Override
@@ -2007,6 +2077,54 @@ public class FissClaimTransformerTest {
     @Override
     String getLabel(String basicLabel) {
       return "procCode-0-" + basicLabel;
+    }
+  }
+
+  /**
+   * Adaptor class extending the {@link ClaimTransformerFieldTester} class that can be used to
+   * create {@link FissDiagnosisCode.Builder} instances and to trigger a transformation of a claim.
+   * Used for tests that operator on {@link FissDiagnosisCode} and {@link RdaFissDiagnosisCode}
+   * instances.
+   */
+  class DiagnosisCodeFieldTester
+      extends AbstractFieldTester<FissDiagnosisCode.Builder, RdaFissDiagnosisCode> {
+
+    private boolean addDiagCode;
+
+    /**
+     * Either diagCd2 or bitFlags must have a value so when testing those fields we can't pre-define
+     * either. But tests for other fields will require that one of these has a value. Those tests
+     * can set {@code addDiagCode} true.
+     *
+     * @param addDiagCode when true causes new instances to have a non-empty diagCd2 value
+     */
+    private DiagnosisCodeFieldTester(boolean addDiagCode) {
+      this.addDiagCode = addDiagCode;
+    }
+
+    @Override
+    FissDiagnosisCode.Builder getTestEntityBuilder(FissClaim.Builder claimBuilder) {
+      if (claimBuilder.getFissDiagCodesBuilderList().isEmpty()) {
+        claimBuilder.addFissDiagCodesBuilder();
+        if (addDiagCode) {
+          claimBuilder.getFissDiagCodesBuilder(0).setDiagCd2("dc2");
+        }
+      }
+      return claimBuilder.getFissDiagCodesBuilder(0);
+    }
+
+    @Override
+    RdaFissDiagnosisCode getTestEntity(RdaFissClaim claim) {
+      assertEquals(1, claim.getDiagCodes().size());
+      RdaFissDiagnosisCode answer = claim.getDiagCodes().iterator().next();
+      assertEquals("dcn", answer.getDcn());
+      assertEquals((short) 0, answer.getPriority());
+      return answer;
+    }
+
+    @Override
+    String getLabel(String basicLabel) {
+      return "diagCode-0-" + basicLabel;
     }
   }
 


### PR DESCRIPTION
**JIRA Ticket:**
[PACA-562](https://jira.cms.gov/browse/PACA-562)

**User Story or Bug Summary:**

We should not raise a validation error if only the `diagCd2` value is empty/NULL, instead an error should only be raised if BOTH the `diagCd2` value and the `bitFlags` value are both empty/NULL for the same record.

---

### What Does This PR Do?

Changes the validation of the `FissDiagnosisCode` objects received from the RDA API.  Previously an empty `diagCd2` field caused a validation error.  Now an empty `diagCd2` is acceptable if there is a non-null `bitFlags` value.

Also expanded on the `FissClaimTransformerTest` to ensure diagnosis code transformations are fully tested.

### What Should Reviewers Watch For?

If you're reviewing this PR, please check for these things in particular:

* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [x] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [x] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [x] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [x] No

### What Needs to Be Merged and Deployed Before this PR?

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist

I have gone through and verified that...:

* [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    