### PR TITLE
BFD-1691: Store performance statistics in JSON format to S3 or file if specified

### DIFF
--- a/ops/ccs-ops-misc/load_test/README.md
+++ b/ops/ccs-ops-misc/load_test/README.md
@@ -114,6 +114,8 @@ Essentially, all the items you would set up in the config file are set in a sing
 
 **--storeStatsTag**: (Optional) : If this argument is set, the currently running test suite's aggregated performance statistics will be stored to S3 under the specified "tag". This tag is used for retrieval and performance validation. If unset, no performance statistics are captured. _Note that this argument may be deprecated in the future once a more robust means of "tagging" captured statistics is developed._
 
+**--storeStatsEnvironment**: (Optional) : If **-storeStatsTag** is set, then the value of this argument is used to specify the testing environment that the statistics should be stored under. Can be one of two values, `TEST` or `PROD`. If not provided, defaults to `TEST`.
+
 ### Quick Run
 
 Once you've run a test once and the configuration file is set, you can "quick run" a test by calling locust directly, like this:

--- a/ops/ccs-ops-misc/load_test/README.md
+++ b/ops/ccs-ops-misc/load_test/README.md
@@ -112,9 +112,14 @@ Essentially, all the items you would set up in the config file are set in a sing
 
 **--resetStats** : (Optional) : If this flag is included, the test statistics will reset to zero after clients have finished spawning. **Note:** There are many reasons why we might want to capture statistics while new load is being added. There might be performance problems accepting the connection or new connections might affect users already connected to the system.
 
-**--storeStatsTag**: (Optional) : If this argument is set, the currently running test suite's aggregated performance statistics will be stored to S3 under the specified "tag". This tag is used for retrieval and performance validation. If unset, no performance statistics are captured. _Note that this argument may be deprecated in the future once a more robust means of "tagging" captured statistics is developed._
+**--storeStats**: (Optional) : Argument specifying that aggregated performance statistics should be stored to some location. This can either be to a local file or to an S3 bucket. This argument must be specified in the following format: `<STORAGE_TYPE>:<RUNNING_ENVIRONMENT>:<TAG>:<PATH_OR_BUCKET>`, where
 
-**--storeStatsEnvironment**: (Optional) : If **-storeStatsTag** is set, then the value of this argument is used to specify the testing environment that the statistics should be stored under. Can be one of two values, `TEST` or `PROD`. If not provided, defaults to `TEST`.
+* `STORAGE_TYPE` is either `file` or `s3`. 
+* `RUNNING_ENVIRONMENT` is either `TEST` or `PROD`.
+* `TAG` can be any string that follows BFD Insights data organization standards (lower-case letters, numbers and "_").
+  * The tag is used to partition performance statistics for more accurate performance validation between corresponding runs.
+  * _Note that this argument may be deprecated in the future once a more robust means of "tagging" captured statistics is developed._
+* `PATH_OR_BUCKET`, if `STORAGE_TYPE` is `file`, must be a valid local file path. Otherwise, if `STORAGE_TYPE` is `s3`, it must be a valid AWS S3 _bucket_.
 
 ### Quick Run
 

--- a/ops/ccs-ops-misc/load_test/README.md
+++ b/ops/ccs-ops-misc/load_test/README.md
@@ -112,6 +112,8 @@ Essentially, all the items you would set up in the config file are set in a sing
 
 **--resetStats** : (Optional) : If this flag is included, the test statistics will reset to zero after clients have finished spawning. **Note:** There are many reasons why we might want to capture statistics while new load is being added. There might be performance problems accepting the connection or new connections might affect users already connected to the system.
 
+**--storeStatsTag**: (Optional) : If this argument is set, the currently running test suite's aggregated performance statistics will be stored to S3 under the specified "tag". This tag is used for retrieval and performance validation. If unset, no performance statistics are captured. _Note that this argument may be deprecated in the future once a more robust means of "tagging" captured statistics is developed._
+
 ### Quick Run
 
 Once you've run a test once and the configuration file is set, you can "quick run" a test by calling locust directly, like this:

--- a/ops/ccs-ops-misc/load_test/README.md
+++ b/ops/ccs-ops-misc/load_test/README.md
@@ -115,6 +115,7 @@ Essentially, all the items you would set up in the config file are set in a sing
 **--storeStats**: (Optional) : Argument specifying that aggregated performance statistics should be stored to some location. This can either be to a local file or to an S3 bucket. This argument must be specified in the following format: `<STORAGE_TYPE>:<RUNNING_ENVIRONMENT>:<TAG>:<PATH_OR_BUCKET>`, where
 
 * `STORAGE_TYPE` is either `file` or `s3`. 
+  * Note that the `file` `STORAGE_TYPE` is primarily meant for _local debugging_ purposes and should not be used when running these tests as part of a process where the performance statistics should be stored for later retrieval. 
 * `RUNNING_ENVIRONMENT` is either `TEST` or `PROD`.
 * `TAG` can be any string that follows BFD Insights data organization standards (lower-case letters, numbers and "_").
   * The tag is used to partition performance statistics for more accurate performance validation between corresponding runs.

--- a/ops/ccs-ops-misc/load_test/common/bfd_user_base.py
+++ b/ops/ccs-ops-misc/load_test/common/bfd_user_base.py
@@ -37,8 +37,8 @@ class BFDUserBase(HttpUser):
         HttpUser.__init__(self, *args, **kwargs)
 
         # Load configuration needed for making requests to the FHIR server
-        self.client_cert = setup.get_client_cert()
-        self.server_public_key = setup.load_server_public_key()
+        self.client_cert = config.get_client_cert()
+        self.server_public_key = config.load_server_public_key()
         setup.disable_no_cert_warnings(self.server_public_key, urllib3)
         self.last_updated = data.get_last_updated()
 
@@ -191,7 +191,7 @@ def teardown(environment: Environment, **kwargs) -> None:
     """
 
     logger = logging.getLogger()
-    stats_storage_config = setup.load_stats_storage_config()
+    stats_storage_config = config.load_stats_storage_config()
     if stats_storage_config == None:
         return
 

--- a/ops/ccs-ops-misc/load_test/common/bfd_user_base.py
+++ b/ops/ccs-ops-misc/load_test/common/bfd_user_base.py
@@ -198,7 +198,7 @@ def teardown(environment: Environment, **kwargs) -> None:
         logger.info("Writing aggregated performance statistics to file.")
 
         stats_json_writer = StatsJsonFileWriter(stats)
-        stats_json_writer.write(path=stats_storage_config.file_path, pretty_print=True)
+        stats_json_writer.write(stats_storage_config.file_path)
     elif isinstance(stats_storage_config, StatsS3StorageConfig):
         logger.info("Writing aggregated performance statistics to S3.")
 

--- a/ops/ccs-ops-misc/load_test/common/bfd_user_base.py
+++ b/ops/ccs-ops-misc/load_test/common/bfd_user_base.py
@@ -184,7 +184,11 @@ class BFDUserBase(HttpUser):
 
 @events.test_stop.add_listener
 def teardown(environment: Environment, **kwargs) -> None:
-    '''Run one-time teardown tasks after the tests have completed.'''
+    """Run one-time teardown tasks after the tests have completed
+
+    Args:
+        environment (Environment): The current Locust environment
+    """
 
     logger = logging.getLogger()
     stats_storage_config = setup.load_stats_storage_config()

--- a/ops/ccs-ops-misc/load_test/common/bfd_user_base.py
+++ b/ops/ccs-ops-misc/load_test/common/bfd_user_base.py
@@ -183,7 +183,7 @@ class BFDUserBase(HttpUser):
         return None
 
 @events.test_stop.add_listener
-def teardown(environment: Environment, **kwargs) -> None:
+def one_time_teardown(environment: Environment, **kwargs) -> None:
     """Run one-time teardown tasks after the tests have completed
 
     Args:

--- a/ops/ccs-ops-misc/load_test/common/config.py
+++ b/ops/ccs-ops-misc/load_test/common/config.py
@@ -78,6 +78,38 @@ def load_from_path(path: str):
         print("Could not find/read configuration file; let's set it up!")
         return create()
 
+
+def get_client_cert() -> str:
+    '''Checks the config file for the client cert value.
+    '''
+
+    config_file = load()
+    return config_file["clientCertPath"]
+
+
+def load_server_public_key() -> str:
+    '''Load the public key to verify the BFD Server's responses or else ignore the warnings from
+    the self-signed cert.
+    '''
+
+    try:
+        config_file = load()
+        server_public_key = config_file["serverPublicKey"]
+        return server_public_key if server_public_key else False
+    except KeyError:
+        return False
+
+
+def load_stats_storage_config() -> StatsStorageConfig:
+    """Load the storage configuration for storing aggregated statistics.
+
+    Returns:
+        StatsStorageConfig: A dataclass representing the storage configuration for aggregated statistics
+    """
+
+    config_file = load()
+    return config_file["storeStats"]
+
 def _stats_config_representer(dumper: yaml.SafeDumper, stats_config: StatsStorageConfig) -> yaml.nodes.ScalarNode:
     """Returns a scalar representer that instructs PyYAML how to serialize a StatsStorageConfig instance
     to an "arg string" in the format of "<STORAGE_TYPE>:<RUNNING_ENVIRONMENT>:<TAG>:<PATH_OR_BUCKET>".

--- a/ops/ccs-ops-misc/load_test/common/config.py
+++ b/ops/ccs-ops-misc/load_test/common/config.py
@@ -1,6 +1,7 @@
 '''Load and save configuration file.
 '''
 
+from enum import Enum
 from typing import Dict
 
 import yaml
@@ -10,7 +11,7 @@ def save(file_data: Dict[str, str]):
     '''
 
     with open('config.yml', 'w', encoding='utf-8') as config:
-        yaml.dump(file_data, config, default_flow_style=False)
+        yaml.dump(file_data, config, default_flow_style=False, Dumper=EnumeSafeDumper)
 
 
 def create():
@@ -74,3 +75,22 @@ def load_from_path(path: str):
     except OSError:
         print("Could not find/read configuration file; let's set it up!")
         return create()
+
+class EnumeSafeDumper(yaml.SafeDumper):
+    """Inherits from pyyaml's default SafeDumper to add a value-based representation for all Enums
+
+    Args:
+        yaml (SafeDumper): pyyaml's default SafeDumper
+    """
+    def represent_data(self, data):
+        """Defines how data is represented in YAML; for this Dumper, Enums are represented by their name.
+
+        Args:
+            data (Any): Data to be serialized to YAML
+
+        Returns:
+            Any: A mapping of how the data should be represented in YAML; in this case, Enums are represented by their name
+        """
+        if isinstance(data, Enum):
+            return self.represent_data(data.name)
+        return super().represent_data(data)

--- a/ops/ccs-ops-misc/load_test/common/stats.py
+++ b/ops/ccs-ops-misc/load_test/common/stats.py
@@ -15,11 +15,11 @@ class StatsEnvironment(Enum):
     PROD = 2
 
 
-class StatsJSON:
+class StatsJson:
     """Class to generate performance statistics in JSON format"""
 
     def __init__(self, locust_env: Environment, percentiles_to_report: List[float], stats_tag: str, running_env: StatsEnvironment = StatsEnvironment.TEST) -> None:
-        """Creates a new instance of StatsJSON given the current Locust environment and a list of percentiles to report.
+        """Creates a new instance of StatsJson given the current Locust environment and a list of percentiles to report.
 
         Args:
             environment (Environment): Current Locust environment
@@ -112,12 +112,12 @@ class StatsJSON:
         return json.dumps(full_dict, indent=(4 if pretty_print else None))
 
 
-class StatsFileWriter():
-    def __init__(self, stats_json: StatsJSON) -> None:
-        """Creates a new instance of StatsFileWriter given a StatsJSON object
+class StatsJsonFileWriter():
+    def __init__(self, stats_json: StatsJson) -> None:
+        """Creates a new instance of StatsJsonFileWriter given a StatsJson object
 
         Args:
-            stats_json (StatsJSON): A StatsJSON object that encodes the aggregated performance statistics of all Locust tasks in the current environment
+            stats_json (StatsJson): A StatsJson object that encodes the aggregated performance statistics of all Locust tasks in the current environment
         """
         super().__init__()
 

--- a/ops/ccs-ops-misc/load_test/common/stats.py
+++ b/ops/ccs-ops-misc/load_test/common/stats.py
@@ -1,7 +1,7 @@
 """
 Much of this file is adapted from equivalent Locust code, particularly locust.stats.StatsCSV
 """
-from ast import Dict, List
+from typing import Dict, List
 from enum import Enum
 import json
 import os
@@ -129,5 +129,5 @@ class StatsJsonFileWriter(object):
         Args:
             path (str, optional): The _parent_ path of the file to write to disk. Defaults to ''.
         """
-        with open(os.path.join(path, f'{self.stats_json.running_env}-{self.stats_json.stats_tag}-{int(time.time())}.json')) as json_file:
+        with open(os.path.join(path, f'{self.stats_json.running_env.name}-{self.stats_json.stats_tag}-{int(time.time())}.json')) as json_file:
             json_file.write(self.stats_json.get_stats_json())

--- a/ops/ccs-ops-misc/load_test/common/stats.py
+++ b/ops/ccs-ops-misc/load_test/common/stats.py
@@ -107,7 +107,9 @@ class StatsJson(object):
             'timestamp': int(time.time()),
             'tag': self.stats_tag,
             'environment': self.running_env.name,
-            'numUsers': self.locust_env.runner.user_count,
+            'statsResetAfterSpawn': self.locust_env.reset_stats,
+            'numUsers': self.locust_env.parsed_options.num_users,
+            'usersPerSecond': self.locust_env.parsed_options.spawn_rate,
             # We cannot get the user provided runtime directly; however, we can compute a more exact
             # runtime by subtracting the start time from the last request's time
             'runtime': self.locust_env.stats.last_request_timestamp - self.locust_env.stats.start_time

--- a/ops/ccs-ops-misc/load_test/common/stats.py
+++ b/ops/ccs-ops-misc/load_test/common/stats.py
@@ -7,7 +7,9 @@ import json
 import os
 import time
 from locust.env import Environment
-from locust.stats import StatsEntry, sort_stats
+from locust.stats import StatsEntry, sort_stats, PERCENTILES_TO_REPORT
+
+PERCENTILES_TO_REPORT = PERCENTILES_TO_REPORT
 
 
 class StatsEnvironment(Enum):

--- a/ops/ccs-ops-misc/load_test/common/stats.py
+++ b/ops/ccs-ops-misc/load_test/common/stats.py
@@ -138,7 +138,7 @@ class AggregatedStats(object):
         """Creates a new instance of AggregatedStats given the current Locust environment and a list of percentiles to report.
 
         Args:
-            environment (Environment): Current Locust environment
+            locust_env (Environment): Current Locust environment
             percentiles_to_report (List[float]): List of percentiles to report in the generated JSON
             stats_tag (str): A string which tags the output JSON; used to distinguish between separate test runs
             running_env (StatsEnvironment, optional): A StatsEnvironment enum which represents the current testing environment; either TEST or PROD. Defaults to TEST.

--- a/ops/ccs-ops-misc/load_test/common/stats.py
+++ b/ops/ccs-ops-misc/load_test/common/stats.py
@@ -37,7 +37,7 @@ class StatsEnvironment(Enum):
 
 @dataclass
 class StatsStorageConfig(ABC):
-    """Abstract dataclass that holds data about where and how aggregated JSON performance statistics are stored"""
+    """Abstract dataclass that holds data about where and how aggregated performance statistics are stored"""
     stats_environment: StatsEnvironment
     """The test running environment from which the statistics will be collected"""
     tag: str
@@ -102,8 +102,9 @@ class StatsStorageConfig(ABC):
 @dataclass
 class StatsFileStorageConfig(StatsStorageConfig):
     """Concrete dataclass inheriting from StatsStorageConfig distinguishing a config for storing
-    JSON files to a local file"""
+    statistics files to a local file"""
     file_path: str
+    """The parent path of the statistics file that will be written to disk"""
 
     def to_arg_str(self) -> str:
         return f'file:{self.stats_environment.name}:{self.tag}:{self.file_path}'
@@ -112,8 +113,9 @@ class StatsFileStorageConfig(StatsStorageConfig):
 @dataclass
 class StatsS3StorageConfig(StatsStorageConfig):
     """Concrete dataclass inheriting from StatsStorageConfig distinguishing a config for storing
-    JSON files to an S3 Bucket"""
+    statistics files to an S3 Bucket"""
     bucket: str
+    """The AWS S3 Bucket that statistics will be written to"""
 
     def to_arg_str(self) -> str:
         return f's3:{self.stats_environment.name}:{self.tag}:{self.bucket}'

--- a/ops/ccs-ops-misc/load_test/common/stats.py
+++ b/ops/ccs-ops-misc/load_test/common/stats.py
@@ -15,7 +15,7 @@ class StatsEnvironment(Enum):
     PROD = 2
 
 
-class StatsJson:
+class StatsJson(object):
     """Class to generate performance statistics in JSON format"""
 
     def __init__(self, locust_env: Environment, percentiles_to_report: List[float], stats_tag: str, running_env: StatsEnvironment = StatsEnvironment.TEST) -> None:
@@ -112,7 +112,7 @@ class StatsJson:
         return json.dumps(full_dict, indent=(4 if pretty_print else None))
 
 
-class StatsJsonFileWriter():
+class StatsJsonFileWriter(object):
     def __init__(self, stats_json: StatsJson) -> None:
         """Creates a new instance of StatsJsonFileWriter given a StatsJson object
 

--- a/ops/ccs-ops-misc/load_test/common/stats.py
+++ b/ops/ccs-ops-misc/load_test/common/stats.py
@@ -129,5 +129,5 @@ class StatsJsonFileWriter(object):
         Args:
             path (str, optional): The _parent_ path of the file to write to disk. Defaults to ''.
         """
-        with open(os.path.join(path, f'{self.stats_json.running_env.name}-{self.stats_json.stats_tag}-{int(time.time())}.json')) as json_file:
+        with open(os.path.join(path, f'{self.stats_json.running_env.name}-{self.stats_json.stats_tag}-{int(time.time())}.json'), 'x') as json_file:
             json_file.write(self.stats_json.get_stats_json())

--- a/ops/ccs-ops-misc/load_test/common/stats.py
+++ b/ops/ccs-ops-misc/load_test/common/stats.py
@@ -106,7 +106,11 @@ class StatsJson(object):
         full_dict = {**{
             'timestamp': int(time.time()),
             'tag': self.stats_tag,
-            'environment': self.running_env.name
+            'environment': self.running_env.name,
+            'numUsers': self.locust_env.runner.user_count,
+            # We cannot get the user provided runtime directly; however, we can compute a more exact
+            # runtime by subtracting the start time from the last request's time
+            'runtime': self.locust_env.stats.last_request_timestamp - self.locust_env.stats.start_time
         }, **{
             'statistics': self._get_stats_entries_list()
         }}
@@ -133,4 +137,5 @@ class StatsJsonFileWriter(object):
             pretty_print (bool, optional): A boolean which if True will write the JSON in a more human-readable format. Defaults to False.
         """
         with open(os.path.join(path, f'{self.stats_json.running_env.name}-{self.stats_json.stats_tag}-{int(time.time())}.json'), 'x') as json_file:
-            json_file.write(self.stats_json.get_stats_json(pretty_print=pretty_print))
+            json_file.write(self.stats_json.get_stats_json(
+                pretty_print=pretty_print))

--- a/ops/ccs-ops-misc/load_test/common/stats.py
+++ b/ops/ccs-ops-misc/load_test/common/stats.py
@@ -230,16 +230,14 @@ class StatsJsonFileWriter(object):
 
         self.stats = stats
 
-    def write(self, path: str = '', pretty_print: bool = False) -> None:
+    def write(self, path: str = '') -> None:
         """Writes the JSON-formatted statistics to the given path
 
         Args:
             path (str, optional): The _parent_ path of the file to write to disk. Defaults to ''.
-            pretty_print (bool, optional): A boolean which if True will write the JSON in a more human-readable format. Defaults to False.
         """
         with open(os.path.join(path, f'{self.stats.running_env.name}-{self.stats.stats_tag}-{int(time.time())}.json'), 'x') as json_file:
-            json_file.write(json.dumps(self.stats.all_stats,
-                            indent=(4 if pretty_print else None)))
+            json_file.write(json.dumps(self.stats.all_stats, indent=4))
 
 
 class StatsJsonS3Writer(object):

--- a/ops/ccs-ops-misc/load_test/common/stats.py
+++ b/ops/ccs-ops-misc/load_test/common/stats.py
@@ -21,6 +21,9 @@ from gevent import monkey
 monkey.patch_all()
 import boto3
 
+# We are re-exporting Locust's default percentiles list here so that consumers of members
+# of this file do not need to also import from the locust.stats module if they want to use
+# the default reporting percentiles
 PERCENTILES_TO_REPORT = PERCENTILES_TO_REPORT
 """A list of floating-point percentiles to report when generating JSON performance reports"""
 

--- a/ops/ccs-ops-misc/load_test/common/stats.py
+++ b/ops/ccs-ops-misc/load_test/common/stats.py
@@ -1,5 +1,7 @@
 """
-Much of this file is adapted from equivalent Locust code, particularly locust.stats.StatsCSV
+Much of this file is adapted from equivalent Locust code, particularly locust.stats.StatsCSV.
+Code in this file relates to the storing and retrieval of performance statistics in a given Locust
+environment.
 """
 from locust.stats import StatsEntry, sort_stats, PERCENTILES_TO_REPORT
 from locust.env import Environment

--- a/ops/ccs-ops-misc/load_test/common/stats.py
+++ b/ops/ccs-ops-misc/load_test/common/stats.py
@@ -1,7 +1,10 @@
 """
 Much of this file is adapted from equivalent Locust code, particularly locust.stats.StatsCSV
 """
-from typing import Dict, List
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+import re
+from typing import Dict, List, Optional
 from enum import Enum
 import json
 import os
@@ -10,11 +13,100 @@ from locust.env import Environment
 from locust.stats import StatsEntry, sort_stats, PERCENTILES_TO_REPORT
 
 PERCENTILES_TO_REPORT = PERCENTILES_TO_REPORT
+"""A list of floating-point percentiles to report when generating JSON performance reports"""
+
+
+class StatsStorageType(Enum):
+    """Enumeration for each available type of storage for JSON stats"""
+    FILE = 1
+    S3 = 2
 
 
 class StatsEnvironment(Enum):
+    """Enumeration for each possible test running environment"""
     TEST = 1
     PROD = 2
+
+
+@dataclass
+class StatsStorageConfig(ABC):
+    """Abstract dataclass that holds data about where and how aggregated JSON performance statistics are stored"""
+    stats_environment: StatsEnvironment
+    """The test running environment from which the statistics will be collected"""
+    tag: str
+    """A simple string tag that is used to partition collected statistics when stored"""
+
+    @abstractmethod
+    def to_arg_str(self) -> str:
+        """Returns an "arg string" representation of this StatsStorageConfig instance. Follows the format
+        <STORAGE_TYPE>:<RUNNING_ENVIRONMENT>:<TAG>:<PATH_OR_BUCKET> 
+        Used to serialize this object to config.
+
+        Returns:
+            str: The "arg string" representation of this object.
+        """
+        return
+
+    @staticmethod
+    def from_arg_str(arg_str: str):
+        """Constructs a concrete instance of StatsStorageConfig from a given "arg string" in the format of
+        "<STORAGE_TYPE>:<RUNNING_ENVIRONMENT>:<TAG>:<PATH_OR_BUCKET>".
+
+        Args:
+            arg_str (str): The "arg string" representation of this object.
+
+        Raises:
+            ValueError: Raised if the passed string does not follow the proper format.
+
+        Returns:
+            StatsStorageConfig: Returns a concrete instance of StatsStorageConfig with the values specified in the "arg string".
+        """
+        items = arg_str.split(':')
+        if len(items) != 4:
+            raise ValueError(
+                'Input must follow format: "<STORAGE_TYPE>:<RUNNING_ENVIRONMENT>:<TAG>:<PATH_OR_BUCKET>"') from None
+
+        try:
+            storage_type = StatsStorageType[items[0].upper()]
+        except KeyError:
+            raise ValueError(
+                'STORAGE_TYPE must be either "file" or "s3"') from None
+
+        try:
+            stats_environment = StatsEnvironment[items[1].upper()]
+        except KeyError:
+            raise ValueError(
+                'RUNNING_ENVIRONMENT must be either "TEST" or "PROD"') from None
+
+        tag = items[2]
+        if re.fullmatch('[a-z0-9_]+', tag) == None:
+            raise ValueError(
+                'TAG must only consist of lower-case letters, numbers and the "_" character') from None
+
+        if storage_type == StatsStorageType.FILE:
+            return StatsFileStorageConfig(stats_environment, tag, items[3])
+        else:
+            return StatsS3StorageConfig(stats_environment, tag, items[3])
+
+
+@dataclass
+class StatsFileStorageConfig(StatsStorageConfig):
+    """Concrete dataclass inheriting from StatsStorageConfig distinguishing a config for storing
+    JSON files to a local file"""
+    file_path: str
+
+    def to_arg_str(self) -> str:
+        return f'file:{self.stats_environment.name}:{self.tag}:{self.file_path}'
+
+
+@dataclass
+class StatsS3StorageConfig(StatsStorageConfig):
+    """Concrete dataclass inheriting from StatsStorageConfig distinguishing a config for storing
+    JSON files to an S3 Bucket"""
+    bucket: str
+
+    def to_arg_str(self) -> str:
+        return f's3:{self.stats_environment.name}:{self.tag}:{self.bucket}'
 
 
 class StatsJson(object):

--- a/ops/ccs-ops-misc/load_test/common/stats.py
+++ b/ops/ccs-ops-misc/load_test/common/stats.py
@@ -112,7 +112,7 @@ class StatsJson(object):
             # runtime by subtracting the start time from the last request's time
             'runtime': self.locust_env.stats.last_request_timestamp - self.locust_env.stats.start_time
         }, **{
-            'statistics': self._get_stats_entries_list()
+            'endpoints': self._get_stats_entries_list()
         }}
 
         return json.dumps(full_dict, indent=(4 if pretty_print else None))

--- a/ops/ccs-ops-misc/load_test/common/stats.py
+++ b/ops/ccs-ops-misc/load_test/common/stats.py
@@ -123,11 +123,12 @@ class StatsJsonFileWriter(object):
 
         self.stats_json = stats_json
 
-    def write(self, path: str = '') -> None:
+    def write(self, path: str = '', pretty_print: bool = False) -> None:
         """Writes the JSON-formatted statistics to the given path
 
         Args:
             path (str, optional): The _parent_ path of the file to write to disk. Defaults to ''.
+            pretty_print (bool, optional): A boolean which if True will write the JSON in a more human-readable format. Defaults to False.
         """
         with open(os.path.join(path, f'{self.stats_json.running_env.name}-{self.stats_json.stats_tag}-{int(time.time())}.json'), 'x') as json_file:
-            json_file.write(self.stats_json.get_stats_json())
+            json_file.write(self.stats_json.get_stats_json(pretty_print=pretty_print))

--- a/ops/ccs-ops-misc/load_test/common/stats.py
+++ b/ops/ccs-ops-misc/load_test/common/stats.py
@@ -2,10 +2,16 @@
 Much of this file is adapted from equivalent Locust code, particularly locust.stats.StatsCSV
 """
 from ast import Dict, List
+from enum import Enum
 import json
 import time
 from locust.env import Environment
 from locust.stats import StatsEntry, sort_stats
+
+
+class StatsEnvironment(Enum):
+    TEST = 1
+    PROD = 2
 
 
 class StatsJSON:
@@ -80,12 +86,12 @@ class StatsJSON:
         stats = self.environment.stats
         return [self._get_stats_entry_dict(stats_entry) for stats_entry in sort_stats(stats.entries)]
 
-    def get_stats_json(self, stats_tag: str, running_env: str = "TEST", pretty_print: bool = False) -> str:
+    def get_stats_json(self, stats_tag: str, running_env: StatsEnvironment = StatsEnvironment.TEST, pretty_print: bool = False) -> str:
         """Returns a JSON-formatted string that encodes the performance statistics of all Locust tasks in the current environment
 
         Args:
             stats_tag (str): A string which tags the output JSON; used to distinguish between separate test runs
-            running_env (str, optional): A string which represents the current testing environment; either "TEST" or "PROD". Defaults to "TEST".
+            running_env (StatsEnvironment, optional): A StatsEnvironment enum which represents the current testing environment; either TEST or PROD. Defaults to TEST.
             pretty_print (bool, optional): A boolean which if True will generate the JSON in a more human-readable format. Defaults to False.
 
         Returns:
@@ -94,7 +100,7 @@ class StatsJSON:
         full_dict = {**{
             'timestamp': int(time.time()),
             'tag': stats_tag,
-            'environment': running_env
+            'environment': running_env.name
         }, **{
             'statistics': self._get_stats_entries_list()
         }}

--- a/ops/ccs-ops-misc/load_test/common/test_setup.py
+++ b/ops/ccs-ops-misc/load_test/common/test_setup.py
@@ -37,7 +37,8 @@ def set_locust_env(config_file: Dict[str, str]):
     os.environ['LOCUST_USERS'] = config_file["testNumTotalClients"]
     os.environ['LOCUST_SPAWN_RATE'] = config_file["testCreatedClientsPerSecond"]
     os.environ['LOCUST_LOGLEVEL'] = "INFO"
-    os.environ['LOCUST_RESET_STATS'] = config_file["resetStatsAfterClientSpawn"]
+    os.environ['LOCUST_RESET_STATS'] = str(
+        config_file["resetStatsAfterClientSpawn"])
     # Set the runtime if not running distributed or if test master
     if not is_distributed() or is_master_thread():
         os.environ['LOCUST_RUN_TIME'] = config_file["testRunTime"]

--- a/ops/ccs-ops-misc/load_test/common/test_setup.py
+++ b/ops/ccs-ops-misc/load_test/common/test_setup.py
@@ -6,41 +6,6 @@ from typing import Dict
 from common import config
 from locust.main import main
 
-from common.stats import StatsStorageConfig
-
-
-def get_client_cert() -> str:
-    '''Checks the config file for the client cert value.
-    '''
-
-    config_file = config.load()
-    return config_file["clientCertPath"]
-
-
-def load_server_public_key() -> str:
-    '''Load the public key to verify the BFD Server's responses or else ignore the warnings from
-    the self-signed cert.
-    '''
-
-    try:
-        config_file = config.load()
-        server_public_key = config_file["serverPublicKey"]
-        return server_public_key if server_public_key else False
-    except KeyError:
-        return False
-
-def load_stats_storage_config() -> StatsStorageConfig:
-    """Load the storage configuration for storing aggregated statistics.
-
-    Returns:
-        StatsStorageConfig: A dataclass representing the storage configuration for aggregated statistics
-    """
-
-    # TODO: This may not be the best spot for this method, since it's used during teardown not setup.
-    # Maybe add a new test_teardown.py, or move the loading of values from config to config.py?
-    config_file = config.load()
-    return config_file["storeStats"]
-
 
 def set_locust_env(config_file: Dict[str, str]):
     '''Sets a number of locust variables needed to run the test.

--- a/ops/ccs-ops-misc/load_test/common/test_setup.py
+++ b/ops/ccs-ops-misc/load_test/common/test_setup.py
@@ -6,6 +6,8 @@ from typing import Dict
 from common import config
 from locust.main import main
 
+from common.stats import StatsStorageConfig
+
 
 def get_client_cert() -> str:
     '''Checks the config file for the client cert value.
@@ -26,6 +28,18 @@ def load_server_public_key() -> str:
         return server_public_key if server_public_key else False
     except KeyError:
         return False
+
+def load_stats_storage_config() -> StatsStorageConfig:
+    """Load the storage configuration for storing aggregated statistics.
+
+    Returns:
+        StatsStorageConfig: A dataclass representing the storage configuration for aggregated statistics
+    """
+
+    # TODO: This may not be the best spot for this method, since it's used during teardown not setup.
+    # Maybe add a new test_teardown.py, or move the loading of values from config to config.py?
+    config_file = config.load()
+    return config_file["storeStats"]
 
 
 def set_locust_env(config_file: Dict[str, str]):

--- a/ops/ccs-ops-misc/load_test/requirements.txt
+++ b/ops/ccs-ops-misc/load_test/requirements.txt
@@ -1,3 +1,4 @@
 PyYAML==6.0
 locust==2.6.0
 psycopg2-binary==2.9.3
+boto3==1.22.12

--- a/ops/ccs-ops-misc/load_test/runtests.py
+++ b/ops/ccs-ops-misc/load_test/runtests.py
@@ -157,7 +157,7 @@ def run_with_params(argv):
 
     ## Read the specified configuration file
     yaml_config = config.load_from_path(config_data.get("configPath",
-        default_config_data["configPath"]))
+        default_config_data["configPath"])) or {}
     ## Merge the stored data with data passed in via the CLI, with the
     ## CLI data taking priority
     config_data = {**yaml_config, **config_data}

--- a/ops/ccs-ops-misc/load_test/runtests.py
+++ b/ops/ccs-ops-misc/load_test/runtests.py
@@ -71,7 +71,8 @@ def run_with_params(argv):
         'testNumTotalClients': "100",
         'testCreatedClientsPerSecond': "5",
         'resetStatsAfterClientSpawn': False,
-        'storeStatsTag': ''
+        'storeStatsTag': '',
+        'storeStatsEnvironment': 'TEST'
     }
 
     # Dictionary to hold data passed in via the CLI that will be stored in the root config.yml file
@@ -97,7 +98,8 @@ def run_with_params(argv):
      '\n--worker_threads="<If >1 the test is run as distributed, and expects this many worker '
         'processes to start, int>" (Optional, Default 1 - non distributed mode)'
      '\n--resetStats (Optional)'
-     '\n--storeStatsTag="<Tag to store performance statistics in S3 under; if unset, stats are not stored> (Optional)')
+     '\n--storeStatsTag="<Tag to store performance statistics in S3 under; if unset, stats are not stored> (Optional)'
+     '\n--storeStatsEnvironment="<Either of two values ("TEST", "PROD") that denote test run environment> (Optional, Default "TEST")')
 
     try:
         opts, _args = getopt.getopt(argv, "h", ["homePath=", "clientCertPath=", "databaseUri=",
@@ -140,6 +142,12 @@ def run_with_params(argv):
             config_data["resetStatsAfterClientSpawn"] = True
         elif opt == "--storeStatsTag":
             config_data["storeStatsTag"] = arg
+        elif opt == "--storeStatsEnvironment":
+            if arg.upper() in ["TEST", "PROD"]:
+                config_data["storeStatsEnvironment"] = arg.upper()
+            else:
+                print(help_string)
+                sys.exit()
         else:
             print(help_string)
             sys.exit()

--- a/ops/ccs-ops-misc/load_test/runtests.py
+++ b/ops/ccs-ops-misc/load_test/runtests.py
@@ -11,6 +11,8 @@ from multiprocessing import Process
 from common import config, test_setup as setup
 from locust.main import main
 
+from common.stats import StatsEnvironment
+
 def parse_run_time(run_time):
     '''Parse a given run time setting (which Locust accepts as combinations of "1m", "30s", "2h",
     etc.), and return the duration in seconds.
@@ -72,7 +74,7 @@ def run_with_params(argv):
         'testCreatedClientsPerSecond': "5",
         'resetStatsAfterClientSpawn': False,
         'storeStatsTag': '',
-        'storeStatsEnvironment': 'TEST'
+        'storeStatsEnvironment': StatsEnvironment.TEST
     }
 
     # Dictionary to hold data passed in via the CLI that will be stored in the root config.yml file
@@ -143,9 +145,10 @@ def run_with_params(argv):
         elif opt == "--storeStatsTag":
             config_data["storeStatsTag"] = arg
         elif opt == "--storeStatsEnvironment":
-            if arg.upper() in ["TEST", "PROD"]:
-                config_data["storeStatsEnvironment"] = arg.upper()
-            else:
+            try:
+                config_data["storeStatsEnvironment"] = StatsEnvironment[opt.upper()]
+            except KeyError as err:
+                print(err)
                 print(help_string)
                 sys.exit()
         else:

--- a/ops/ccs-ops-misc/load_test/runtests.py
+++ b/ops/ccs-ops-misc/load_test/runtests.py
@@ -11,7 +11,7 @@ from multiprocessing import Process
 from common import config, test_setup as setup
 from locust.main import main
 
-from common.stats import StatsEnvironment, StatsStorageConfig
+from common.stats import StatsStorageConfig
 
 def parse_run_time(run_time):
     '''Parse a given run time setting (which Locust accepts as combinations of "1m", "30s", "2h",

--- a/ops/ccs-ops-misc/load_test/runtests.py
+++ b/ops/ccs-ops-misc/load_test/runtests.py
@@ -70,7 +70,8 @@ def run_with_params(argv):
         'testRunTime': "1m",
         'testNumTotalClients': "100",
         'testCreatedClientsPerSecond': "5",
-        'resetStatsAfterClientSpawn': False
+        'resetStatsAfterClientSpawn': False,
+        'storeStatsTag': ''
     }
 
     # Dictionary to hold data passed in via the CLI that will be stored in the root config.yml file
@@ -95,7 +96,8 @@ def run_with_params(argv):
         '(Optional, Default 5)'
      '\n--worker_threads="<If >1 the test is run as distributed, and expects this many worker '
         'processes to start, int>" (Optional, Default 1 - non distributed mode)'
-     '\n--resetStats (Optional)')
+     '\n--resetStats (Optional)'
+     '\n--storeStatsTag="<Tag to store performance statistics in S3 under; if unset, stats are not stored> (Optional)')
 
     try:
         opts, _args = getopt.getopt(argv, "h", ["homePath=", "clientCertPath=", "databaseUri=",
@@ -136,6 +138,8 @@ def run_with_params(argv):
             worker_threads = arg
         elif opt == "--resetStats":
             config_data["resetStatsAfterClientSpawn"] = True
+        elif opt == "--storeStatsTag":
+            config_data["storeStatsTag"] = arg
         else:
             print(help_string)
             sys.exit()


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BFD-1691](https://jira.cms.gov/browse/BFD-1691)

**User Story or Bug Summary:**
<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->
As a BFD engineer, I want to capture and store performance performance metrics on configured runs, so that I can store performance metrics which will be reviewed to assess the performance of the BFD as new functionality gets added.

---

### What Does This PR Do?
<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

This PR:

* Adds a new file, `stats.py`, that includes several new classes and enums:
  * A new class, `AggregatedStats`, which exposes a computed property `all_stats` that returns a dictionary of the aggregated stats of all endpoints along with some extra metadata (timestamp, runtime, etc)
  * Two writer classes, `StatsJsonFileWriter` and `StatsJsonS3Writer`. These classes each expose a `write()` method that writes the stats from `AggregatedStats.all_stats` to either a local file or an S3 Bucket (using `boto3`)
    * Which writer is used is controlled by the user-supplied `--storeStats` command-line argument explained below
    * `StatsJsonS3Writer` writes to a pre-determined S3 path that follows the BFD Insights data convention: `<S3_BUCKET_PROVIDED>/databases/bfd/test_performance_stats/env=<ENV_PROVIDED>/tag=<TAG_PROVIDED>/<TIMESTAMP>.json`
    * `StatsJsonFileWriter` writes to a user-provided _parent path_, but the filename always follows the format: `<ENV_PROVIDED>-<TAG_PROVIDED>-<TIMESTAMP>.json`
  * Some new `dataclass`s , `StatsStorageConfig`, `StatsFileStorageConfig` and `StatsS3StorageConfig`, to hold state about where aggregated stats should be stored
  * Some `enum`s, `StatsStorageType` and `StatsEnvironment`, to encode valid types of storage (to a local file \[`FILE`\] or to an S3 Bucket \[`S3`\]) and valid running environments (`TEST` or `PROD`)
* Adds a new command-line argument, `--storeStats`, which requires the user provide a specially-formatted "arg string" (in the format `<STORAGE_TYPE>:<RUNNING_ENVIRONMENT>:<TAG>:<PATH_OR_BUCKET>`) that tells the code where to store performance statistics (file or S3) and how to store them (path or bucket)
  * Documentation was added to the README explaining the argument format in-depth, as well
* Adds some code to `config.py` that modifies PyYAML's dumper and loader to understand how to serialize and deserialize `StatsStorageConfig` objects to the string format used by the `--storeStats` command-line argument (`<STORAGE_TYPE>:<RUNNING_ENVIRONMENT>:<TAG>:<PATH_OR_BUCKET>`)
* Introduces a run-once "teardown" method to `bfd_user_base.py` which listens on Locust's `test_stop` event to write performance statistics to either S3 or to a local file depending on the value of `--storeStats`
* Includes a few small fixes:
  * A fix for a `TypeError` being raised when the default `config.yml` is empty
  * A fix for a `TypeError` being raised due to Locust requiring the `LOCUST_RESET_STATS` environment variable be a `str`, not a `bool`

### What Should Reviewers Watch For?
<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items to the following list here -->
* Are the chosen S3 path and BFD Insights database name (`test_performance_stats`) applicable? 
  * Are the chosen partitions (`env` and `tag`) applicable as well?
  * Do these need to be named differently?
  * Should they be configurable?
* Are the correct performance statistics being collected?
  * Should machine information also be collected?
  * Are there any other metrics that would be useful to collect?
* Is there any additional documentation required? 
* Are the code changes and additions understandable?
* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A** 

    * Does this PR add any new software dependencies? 
      * [x] Yes
      * [ ] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [x] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [x] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    