### PR TITLE
BFD-1600: Add bfd-db-migrator launch playbook

### DIFF
--- a/ops/ansible/playbooks-ccs/build_bfd-db-migrator.yml
+++ b/ops/ansible/playbooks-ccs/build_bfd-db-migrator.yml
@@ -9,8 +9,8 @@
   gather_facts: yes
   vars:
     ansible_ssh_pipelining: no
-    env: "test"
     bfd_migrator_dir: /opt/bfd-db-migrator
+    env: "test"
 
   tasks:
     - name: Include global variables

--- a/ops/ansible/playbooks-ccs/build_bfd-db-migrator.yml
+++ b/ops/ansible/playbooks-ccs/build_bfd-db-migrator.yml
@@ -10,6 +10,7 @@
   vars:
     ansible_ssh_pipelining: no
     env: "test"
+    bfd_migrator_dir: /opt/bfd-db-migrator
 
   tasks:
     - name: Include global variables
@@ -34,10 +35,10 @@
       import_role:
         name: bfd-db-migrator
       vars:
-        # Note: The `db_migrator_zip` variable should have been provided by `--extra-vars` on the command line.
-        db_migrator_jvm_args: "-Xmx{{ (ansible_memtotal_mb * 0.80) | int }}m -XX:+PreserveFramePointer"
-        db_migrator_tmp_dir: "{{ db_migrator_dir }}/tmp"
-        # Primary (i.e. write) DB defined in `environments/<env>/group_vars/all/vault.yml`:
+        db_migrator_dir: "{{ bfd_migrator_dir  }}"
+        db_migrator_tmp_dir: "{{ bfd_migrator_dir }}/tmp"
+        # NOTE: The `db_migrator_zip` variable should have been provided by `--extra-vars` on the command line.
+        # Primary (i.e. write) DB defined in `environments/<env>/group_vars/all/vault.yml`
         db_migrator_db_url: "{{ vault_data_db_primary_url }}"
         db_migrator_db_username: "{{ vault_data_pipeline_db_username }}" # TODO: BFD-1552 get migrator-specific credentials
         db_migrator_db_password: "{{ vault_data_pipeline_db_password }}" # TODO: BFD-1552 get migrator-specific credentials

--- a/ops/ansible/playbooks-ccs/launch_bfd-db-migrator.yml
+++ b/ops/ansible/playbooks-ccs/launch_bfd-db-migrator.yml
@@ -52,6 +52,3 @@
       become: true
       tags:
         - post-ami
-
-  handlers:
-    - import_tasks: handlers/main.yml

--- a/ops/ansible/playbooks-ccs/launch_bfd-db-migrator.yml
+++ b/ops/ansible/playbooks-ccs/launch_bfd-db-migrator.yml
@@ -1,0 +1,57 @@
+---
+##
+# Configures the BFD DB Migrator Service for CCS env
+##
+- name: Configure DB Migrator Server
+  hosts: localhost
+  vars:
+    bfd_migrator_dir: /opt/bfd-db-migrator
+
+  tasks:
+    - name: Include global variables
+      include_vars:
+        file: vars/000_cross_env_vars.yml
+      tags: [pre-ami, post-ami]
+
+    - name: Include env specific variables
+      include_vars:
+        dir: vars/{{ env }}
+      tags: [pre-ami, post-ami]
+
+    - name: Apply BFD DB Migrator Role
+      import_role:
+        name: bfd-db-migrator
+      vars:
+        db_migrator_dir: "{{ bfd_migrator_dir  }}"
+        db_migrator_tmp_dir: "{{ bfd_migrator_dir }}/tmp"
+        # NOTE: Primary (i.e. write) DB defined in `environments/<env>/group_vars/all/vault.yml` but this solution favors
+        # terraform to provide `db_migrator_db_url` via constructed extra_vars.json file.
+        db_migrator_db_username: "{{ vault_data_pipeline_db_username }}" # TODO: BFD-1552 get migrator-specific credentials
+        db_migrator_db_password: "{{ vault_data_pipeline_db_password }}" # TODO: BFD-1552 get migrator-specific credentials
+
+    - name: Add SSH users
+      import_role:
+        name: ssh_users
+      tags:
+        - pre-ami
+
+    # TODO: Consider moving the CloudWatch agent configuration elsewhere, potentially in the application role or a cloudwatch-specific role. This is a little awkward.
+    - name: Build CloudWatch unified agent configuration
+      template:
+        src: cwagent-db-migrator.json.j2
+        dest: '/tmp/cwagent-db-migrator.json'
+        owner: root
+        group: root
+        mode: u=rw,g=r,o=r
+      become: true
+      tags:
+        - post-ami
+
+    - name: Reconfigure and relaunch CloudWatch unified agent
+      shell: "/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a append-config -m ec2 -c file:/tmp/cwagent-db-migrator.json -s"
+      become: true
+      tags:
+        - post-ami
+
+  handlers:
+    - import_tasks: handlers/main.yml

--- a/ops/ansible/playbooks-ccs/templates/cwagent-db-migrator.json.j2
+++ b/ops/ansible/playbooks-ccs/templates/cwagent-db-migrator.json.j2
@@ -1,0 +1,28 @@
+{
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "/var/log/messages",
+            "log_group_name": "/bfd/{{ env }}/var/log/messages",
+            "log_stream_name": "{instance_id}",
+            "timestamp_format": "%b %d %H:%M:%S"
+          },
+          {
+            "file_path": "/var/log/secure",
+            "log_group_name": "/bfd/{{ env }}/var/log/secure",
+            "log_stream_name": "{instance_id}",
+            "timestamp_format": "%b %d %H:%M:%S"
+          },
+          {
+            "file_path": "{{ bfd_migrator_dir }}/migrator-log.json",
+            "log_group_name": "/bfd/{{ env }}/bfd-db-migrator/migrator-log.json",
+            "log_stream_name": "{instance_id}",
+            "timestamp_format": "%Y-%m-%d %H:%M:%S,%f"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/ops/ansible/roles/bfd-db-migrator/README.md
+++ b/ops/ansible/roles/bfd-db-migrator/README.md
@@ -25,12 +25,10 @@ This role is highly configurable, though it tries to provide reasonable defaults
 | db_migrator_db_username             | username for targeted database                                                                | n/a                  | yes             |
 | env                                 | deployment env, e.g. `prod`, `prod-sbx`, `test` **required by migrator-monitor**<sup>\*</sup> | test                 | no<sup>\*</sup> |
 | db_migrator_dir                     | primary, on-host directory for migrator-related resources                                     | /opt/bfd-db-migrator | no              |
-| db_migrator_jvm_args                | arguments passed directly to the JVM                                                          | -Xmx64g              | no              |
-| db_migrator_tmp_dir                 |                                                                                               | /tmp                 | no              |
+| db_migrator_tmp_dir                 | defines the `-Djava.io.tmpdir` for the migrator's jvm                                         | /tmp                 | no              |
 | db_migrator_user                    | user to be created to run migrator and migrator-monitor service                               | bb-migrator          | no              |
 | migrator_monitor_enabled            | migrator-monitor enabled for sqs message passing, **requires `env`**                          | false                | no              |
 | migrator_monitor_heartbeat_interval | sleep interval between monitor heartbeats                                                     | 300                  | no              |
-
 
 See [defaults/main.yml](./defaults/main.yml) for the list of defaulted variables and their default values.
 
@@ -80,5 +78,5 @@ From this, the tests can be run by issuing the following:
 # optional `-e` extra variables flag for migrator monitor enablement
 # optional `-k` to keep the container running after test completion
 # and specifying `some-image-tag` to target the image generated above
-ops/ansible/roles/bfd-db-migrator/test/run-tests.sh -e migrator_monitor_enabled=True -k  some-image-tag
+ops/ansible/roles/bfd-db-migrator/test/run-tests.sh -e migrator_monitor_enabled=True -k some-image-tag
 ```

--- a/ops/ansible/roles/bfd-db-migrator/defaults/main.yml
+++ b/ops/ansible/roles/bfd-db-migrator/defaults/main.yml
@@ -2,7 +2,6 @@
 env: test
 db_migrator_dir: /opt/bfd-db-migrator
 db_migrator_user: bb-migrator
-db_migrator_jvm_args: -Xmx64g
 db_migrator_tmp_dir: /tmp
 migrator_monitor_enabled: true
 migrator_monitor_heartbeat_interval_seconds: 300

--- a/ops/ansible/roles/bfd-db-migrator/handlers/main.yml
+++ b/ops/ansible/roles/bfd-db-migrator/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Enable Migrator Service
+  command: /usr/bin/systemctl --system enable bfd-db-migrator
+  become: true
+
+- name: Restart Migrator Service
+  service:
+    name: bfd-db-migrator
+    state: restarted
+  become: true

--- a/ops/ansible/roles/bfd-db-migrator/tasks/migrator.yml
+++ b/ops/ansible/roles/bfd-db-migrator/tasks/migrator.yml
@@ -97,7 +97,7 @@
     mode: u=rwx,g=rx,o=rx
   become: true
   notify:
-    - 'Restart Migrator Service'
+    - Restart Migrator Service
   tags:
     - post-ami
 
@@ -110,7 +110,7 @@
     mode: u=rw,g=r,o=r
   become: true
   notify:
-    - 'Enable Migrator Service'
-    - 'Restart Migrator Service'
+    - Enable Migrator Service
+    - Restart Migrator Service
   tags:
     - post-ami

--- a/ops/ansible/roles/bfd-db-migrator/tasks/migrator.yml
+++ b/ops/ansible/roles/bfd-db-migrator/tasks/migrator.yml
@@ -96,6 +96,8 @@
     group: "{{ db_migrator_user }}"
     mode: u=rwx,g=rx,o=rx
   become: true
+  notify:
+    - 'Restart Migrator Service'
   tags:
     - post-ami
 
@@ -107,5 +109,8 @@
     group: root
     mode: u=rw,g=r,o=r
   become: true
+  notify:
+    - 'Enable Migrator Service'
+    - 'Restart Migrator Service'
   tags:
     - post-ami


### PR DESCRIPTION
**JIRA Ticket:**
[BFD-1600](https://jira.cms.gov/browse/BFD-1600)

**User Story or Bug Summary:**

Introduce the ansible portions of the bfd-db-migrator infrastructure configuration.

---

### What Does This PR Do?
This _largely_ adds the "launch" playbook (and dependency), but there are some minor adjustments to the "build" playbook and migrator role that seemed appropriate to introduce at this time.

#### Future Work
Ultimately, this is still begging to be tidied up further, but the `bfd-db-migrator` infrastructure has been implicitly re-prioritized over the past six weeks several times and it's badly needed. I've tried to keep the ansible for the migrator and its respective playbooks similar in shape to the existing services, `bfd-pipeline` and `bfd-server`, however there are some innovations that should probably be applied throughout:
1. The split between build and launch ansible playbooks doesn't appear to be necessary–the [play tagging](https://docs.ansible.com/ansible/2.9/user_guide/playbooks_tags.html) is largely implemented already to achieve a similar split in functionality between `pre-ami` and `post-ami` tags. It wouldn't take much more than some careful consideration a fair amount of redundancy.
2. There are no associated _notifies_ with the `Restart awslogs Service` handler, but it's still included. What's more, the reference to `awslogs` is available in Amazon Linux instead of today's `awslogsd` for Amazon Linux 2. I've excluded it from the `bfd-db-migrator` solution, but I've left it alone in the `bfd-pipeline` and `bfd-server` services.
3. The cloudwatch configuration at the playbook level is somewhat awkward in forcing us to encode redundant configuration to the _launch_ playbook. This could be tidier and more obvious if it were packaged in the role itself.

Additionally, the terraform solution is still forthcoming, but both that in-progress solution and the changes in this PR have been successfully leveraged against the `test` environment. After this exists in the trunk, the terraform solution and adjustments should follow shortly thereafter. Full utilization of this service should be implemented shortly after that with updates to the Jenkins stage definitions.

### What Should Reviewers Watch For?
If you're reviewing this PR, please check for these things in particular:
* Verify all PR security questions and checklists have been completed and addressed.

### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [x] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [x] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [x] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [x] No

### What Needs to Be Merged and Deployed Before this PR?
This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
I have gone through and verified that...:

* [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    5. There isn't too much of a burden on reviewers.
    6. Any problems it causes have a small "blast radius".
    7. It'll be easier to rollback if that becomes necessary.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.