### PR TITLE
BFD-1550: Introduce migrator deployment stages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,8 @@ properties([
 	parameters([
 		booleanParam(name: 'deploy_prod_from_non_master', defaultValue: false, description: 'Whether to deploy to prod-like envs for builds of this project\'s non-master branches.'),
 		booleanParam(name: 'deploy_prod_skip_confirm', defaultValue: false, description: 'Whether to prompt for confirmation before deploying to most prod-like envs.'),
-		booleanParam(name: 'build_platinum', description: 'Whether to build/update the "platinum" base AMI.', defaultValue: false)
+		booleanParam(name: 'build_platinum', description: 'Whether to build/update the "platinum" base AMI.', defaultValue: false),
+		booleanParam(name: 'use_latest_images', description: 'When true, defer to latest available AMIs. Skips App and App Image Stages.', defaultValue: false)
 	]),
 	buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: ''))
 ])
@@ -48,6 +49,7 @@ def awsCredentials
 def deployEnvironment
 def scriptForApps
 def scriptForDeploys
+def migratorScripts
 def canDeployToProdEnvs
 def willDeployToProdEnvs
 def appBuildResults
@@ -55,6 +57,7 @@ def amiIds
 def currentStage
 def gitCommitId
 def gitRepoUrl
+def awsRegion = 'us-east-1'
 
 // send notifications to slack, email, etc
 def sendNotifications(String buildStatus = '', String stageName = '', String gitCommitId = '', String gitRepoUrl = ''){
@@ -125,7 +128,7 @@ def sendNotifications(String buildStatus = '', String stageName = '', String git
 // begin pipeline
 try {
 	// See ops/jenkins/cbc-build-push.sh for this image's definition.
-	podTemplate(containers: [containerTemplate(name: 'bfd-cbc-build', image: 'public.ecr.aws/c2o1d8s9/bfd-cbc-build:jdk11-mvn3-an29-tf12', command: 'cat', ttyEnabled: true, alwaysPullImage: true, resourceLimitCpu: '4000m', resourceLimitMemory: '8192Mi', resourceRequestCpu: '4000m', resourceRequestMemory: '8192Mi')], serviceAccount: 'bfd') {
+	podTemplate(containers: [containerTemplate(name: 'bfd-cbc-build', image: 'public.ecr.aws/c2o1d8s9/bfd-cbc-build:jdk11-mvn3-an29-tfenv', command: 'cat', ttyEnabled: true, alwaysPullImage: true, resourceLimitCpu: '4000m', resourceLimitMemory: '8192Mi', resourceRequestCpu: '4000m', resourceRequestMemory: '8192Mi')], serviceAccount: 'bfd') {
 		node(POD_LABEL) {
 			stage('Prepare') {
 				currentStage = "${env.STAGE_NAME}"
@@ -136,6 +139,7 @@ try {
 					// Load the child Jenkinsfiles.
 					scriptForApps = load('apps/build.groovy')
 					scriptForDeploys = load('ops/deploy-ccs.groovy')
+					migratorScripts = load('ops/terraform/services/migrator/Jenkinsfile')
 
 					// Unset any pre-existing session variables
 					// Set global AWS environment variables from role assumption
@@ -197,28 +201,58 @@ try {
 			}
 
 			stage('Build Apps') {
-				currentStage = "${env.STAGE_NAME}"
-				milestone(label: 'stage_build_apps_start')
+				if (!params.use_latest_images) {
+					currentStage = "${env.STAGE_NAME}"
+					milestone(label: 'stage_build_apps_start')
 
-				container('bfd-cbc-build') {
-					build_env = deployEnvironment
-					appBuildResults = scriptForApps.build(build_env)
+					container('bfd-cbc-build') {
+						build_env = deployEnvironment
+						appBuildResults = scriptForApps.build(build_env)
+					}
 				}
 			}
 
 
 			stage('Build App AMIs') {
-				currentStage = "${env.STAGE_NAME}"
-				milestone(label: 'stage_build_app_amis_test_start')
+				if (!params.use_latest_images) {
+					currentStage = "${env.STAGE_NAME}"
+					milestone(label: 'stage_build_app_amis_test_start')
 
-				container('bfd-cbc-build') {
-					amiIds = scriptForDeploys.buildAppAmis(gitBranchName, gitCommitId, amiIds, appBuildResults)
+					container('bfd-cbc-build') {
+						amiIds = scriptForDeploys.buildAppAmis(gitBranchName, gitCommitId, amiIds, appBuildResults)
+					}
+				}
+			}
+
+			stage('Deploy Migrator to TEST') {
+				bfdEnv = 'test'
+				currentStage = "${env.STAGE_NAME}"
+
+				lock(resource: 'env_test') {
+					milestone(label: 'stage_deploy_test_migration_start')
+					container('bfd-cbc-build') {
+
+						migratorDeploymentSuccessful = migratorScripts.deployMigrator(
+							amiId: amiIds.bfdMigratorAmiId,
+							bfdEnv: bfdEnv,
+							heartbeatInterval: 30, // TODO: Consider implementing a backoff functionality in the future
+							awsRegion: awsRegion,
+							gitBranchName: gitBranchName,
+							this.&awsAssumeRole
+						)
+
+						if (migratorDeploymentSuccessful) {
+							println "Proceeding to Stage: 'Deploy to ${bfdEnv.toUpperCase()}'"
+						} else {
+							error('Migrator deployment failed')
+						}
+					}
 				}
 			}
 
 			stage('Deploy to TEST') {
 				currentStage = "${env.STAGE_NAME}"
-				lock(resource: 'env_test', inversePrecendence: true) {
+				lock(resource: 'env_test') {
 					milestone(label: 'stage_deploy_test_start')
 
 					container('bfd-cbc-build') {
@@ -233,7 +267,7 @@ try {
 								env.AWS_SESSION_TOKEN = awsCredentials[3]
 							}
 						}
-						scriptForDeploys.deploy('test', gitBranchName, gitCommitId, amiIds, appBuildResults)
+						scriptForDeploys.deploy('test', gitBranchName, gitCommitId, amiIds)
 					}
 				}
 			}
@@ -264,10 +298,36 @@ try {
 				}
 			}
 
+			stage('Deploy Migrator to PROD-SBX') {
+				bfdEnv = 'prod-sbx'
+				currentStage = "${env.STAGE_NAME}"
+
+				lock(resource: 'env_prod_sbx') {
+					milestone(label: 'stage_deploy_prod_sbx_migration_start')
+					container('bfd-cbc-build') {
+
+						migratorDeploymentSuccessful = migratorScripts.deployMigrator(
+							amiId: amiIds.bfdMigratorAmiId,
+							bfdEnv: bfdEnv,
+							heartbeatInterval: 30, // TODO: Consider implementing a backoff functionality in the future
+							awsRegion: awsRegion,
+							gitBranchName: gitBranchName,
+							this.&awsAssumeRole
+						)
+
+						if (migratorDeploymentSuccessful) {
+							println "Proceeding to Stage: 'Deploy to ${bfdEnv.toUpperCase()}'"
+						} else {
+							error('Migrator deployment failed')
+						}
+					}
+				}
+			}
+
 			stage('Deploy to PROD-SBX') {
 				currentStage = "${env.STAGE_NAME}"
 				if (willDeployToProdEnvs) {
-					lock(resource: 'env_prod_sbx', inversePrecendence: true) {
+					lock(resource: 'env_prod_sbx') {
 						milestone(label: 'stage_deploy_prod_sbx_start')
 
 						container('bfd-cbc-build') {
@@ -282,7 +342,7 @@ try {
 									env.AWS_SESSION_TOKEN = awsCredentials[3]
 								}
 							}
-							scriptForDeploys.deploy('prod-sbx', gitBranchName, gitCommitId, amiIds, appBuildResults)
+							scriptForDeploys.deploy('prod-sbx', gitBranchName, gitCommitId, amiIds)
 						}
 					}
 				} else {
@@ -290,10 +350,36 @@ try {
 				}
 			}
 
+			stage('Deploy Migrator to PROD') {
+				bfdEnv = 'prod'
+				currentStage = "${env.STAGE_NAME}"
+
+				lock(resource: 'env_prod') {
+					milestone(label: 'stage_deploy_prod_migration_start')
+					container('bfd-cbc-build') {
+
+						migratorDeploymentSuccessful = migratorScripts.deployMigrator(
+							amiId: amiIds.bfdMigratorAmiId,
+							bfdEnv: bfdEnv,
+							heartbeatInterval: 30, // TODO: Consider implementing a backoff functionality in the future
+							awsRegion: awsRegion,
+							gitBranchName: gitBranchName,
+							this.&awsAssumeRole
+						)
+
+						if (migratorDeploymentSuccessful) {
+							println "Proceeding to Stage: 'Deploy to ${bfdEnv.toUpperCase()}'"
+						} else {
+							error('Migrator deployment failed')
+						}
+					}
+				}
+			}
+
 			stage('Deploy to PROD') {
 				currentStage = "${env.STAGE_NAME}"
 				if (willDeployToProdEnvs) {
-					lock(resource: 'env_prod', inversePrecendence: true) {
+					lock(resource: 'env_prod') {
 						milestone(label: 'stage_deploy_prod_start')
 
 						container('bfd-cbc-build') {
@@ -308,7 +394,7 @@ try {
 									env.AWS_SESSION_TOKEN = awsCredentials[3]
 								}
 							}
-							scriptForDeploys.deploy('prod', gitBranchName, gitCommitId, amiIds, appBuildResults)
+							scriptForDeploys.deploy('prod', gitBranchName, gitCommitId, amiIds)
 						}
 					}
 				} else {
@@ -325,4 +411,55 @@ try {
 	throw ex
 } finally {
 	sendNotifications(currentBuild.currentResult, currentStage, gitCommitId, gitRepoUrl)
+}
+
+/**
+ * Authenticate with AWS by assuming a specific, fully qualified role stored as a Jenkins secret.
+ *
+ * In addition to the setting credentials as environment variables for AWS requests, this also
+ * sets AWS_REGION, DEFAULT_AWS_REGION, and a special NEXT_AWS_AUTH. NEXT_AWS_AUTH contains the
+ * the time at which ~50% of the requested session has elapsed. If this environment variable is
+ * populated, the script will only re-authenticate if there is less than half the time left in the
+ * current session. By default, this requests a 60 minute session and subsequent calls of this
+ * method will only reauthenticate if there are fewer than 30 minutes remaining on the session. This
+ * keeps both the Jenkins logs tidier and avoids excessive role assumption as recorded in cloudwatch
+ * logs. This is an especially important consideration in tight loops that seek to ensure valid AWS
+ * credentials before or after each iteration.
+ *
+ * @param args Map that optionally included sessionDurationSeconds, sessionName, and awsRegion
+ */
+void awsAssumeRole(Map args = [:]) {
+	sessionDurationSeconds = args.sessionDurationSeconds ?: 3600
+	sessionName = args.sessionName ?: env.JOB_NAME.replaceAll(/[^a-zA-Z\d]/, '-').replaceAll(/[\-]+/, '-')
+	region = args.awsRegion ?: 'us-east-1'
+
+	if (env.NEXT_AWS_AUTH == null || java.time.Instant.now() > java.time.Instant.parse(env.NEXT_AWS_AUTH)) {
+		echo "Authenticating..."
+		withEnv(["DURATION=${sessionDurationSeconds}",
+				 "SESSION_NAME=${sessionName}",
+				 'AWS_ACCESS_KEY_ID=',
+				 'AWS_SECRET_ACCESS_KEY=',
+				 'AWS_SESSION_TOKEN=']) {
+			withCredentials([string(credentialsId: 'bfd-aws-assume-role', variable: 'JENKINS_ROLE')]) {
+				awsCredentials = sh(
+					returnStdout: true,
+					script: '''
+aws sts assume-role \
+  --duration-seconds "$DURATION" \
+  --role-arn "$JENKINS_ROLE" \
+  --role-session-name "$SESSION_NAME" \
+  --output text --query Credentials
+'''
+				).trim().split(/\s+/)
+				// Set nextAuthSeconds to renew through ~50% of original session's duration
+				nextAuthSeconds = (sessionDurationSeconds / 2).longValue()
+				env.NEXT_AWS_AUTH = java.time.Instant.now().plus(java.time.Duration.ofSeconds(nextAuthSeconds))
+				env.AWS_REGION = awsRegion
+				env.AWS_DEFAULT_REGION = awsRegion
+				env.AWS_ACCESS_KEY_ID = awsCredentials[0]
+				env.AWS_SECRET_ACCESS_KEY = awsCredentials[2]
+				env.AWS_SESSION_TOKEN = awsCredentials[3]
+			}
+		}
+	}
 }

--- a/ops/ansible/roles/bfd-db-migrator/test/test_basic.yml
+++ b/ops/ansible/roles/bfd-db-migrator/test/test_basic.yml
@@ -18,7 +18,7 @@
       import_role:
         name: bfd-db-migrator
       vars:
-        bfd_env: dev
+        env: dev
         db_migrator_zip: "{{ lookup('env','HOME') }}/.m2/repository/gov/cms/bfd/bfd-db-migrator/1.0.0-SNAPSHOT/bfd-db-migrator-1.0.0-SNAPSHOT.zip"
         db_migrator_db_url: jdbc:hsqldb:mem:test
         db_migrator_db_username: bfd

--- a/ops/terraform/services/migrator/Jenkinsfile
+++ b/ops/terraform/services/migrator/Jenkinsfile
@@ -1,0 +1,242 @@
+#!/usr/bin/env groovy
+
+// entrypoint to migrator deployment, requires mapped arguments and an aws authentication closure
+// attempts to deploy and monitor and return `true` when the migrator signals a zero exit status
+boolean deployMigrator(Map args = [:], authFunction) {
+    amiId = args.amiId
+    bfdEnv = args.bfdEnv
+    heartbeatInterval = args.heartbeatInterval ?: 30
+    awsRegion = args.awsRegion ?: 'us-east-1'
+    gitBranchName = args.gitBranchName
+
+    // authenticate
+    authFunction()
+
+    // set sqsQueueName
+    sqsQueueName = "${bfdEnv}-db-migrator"
+
+    // precheck
+    if (canMigratorDeploymentProceed(sqsQueueName, awsRegion)) {
+        println "Proceeding to Migrator Deployment"
+    } else {
+        println "Halting Migrator Deployment. Check the SQS Queue ${sqsQueueName}."
+        return false
+    }
+
+    // plan/apply terraform
+    executeTerraform(amiId: amiId,
+                     bfdEnv: bfdEnv,
+                     gitBranchName: gitBranchName,
+                     heartbeatInterval: heartbeatInterval,
+                     createMigratorInstance: true)
+
+    // monitor migrator deployment
+    finalMigratorStatus = monitorMigrator(
+        sqsQueueName: sqsQueueName,
+        region: awsRegion,
+        heartbeatInterval: heartbeatInterval,
+        maxMessages: 10,
+        authFunction
+    )
+
+    // re-authenticate
+    authFunction()
+
+    // set return value for final disposition
+    if (finalMigratorStatus == '0') {
+        migratorDeployedSuccessfully = true
+        // Teardown when there is a healthy exit status
+        executeTerraform(amiId: amiId, bfdEnv: bfdEnv, gitBranchName: gitBranchName)
+    } else {
+        migratorDeployedSuccessfully = false
+    }
+
+    purgeQueue(sqsQueueName)
+
+    println "Migrator completed with exit status ${finalMigratorStatus}"
+    return migratorDeployedSuccessfully
+}
+
+// wraps the aws cli's receive-message subcommand to produce JSON objects
+// that represent the deployed migrator's state. Contains the following
+// fields mapped to string values: pid, start_time, stop_time, status, code
+def receiveMigratorMessages(Map args = [:]) {
+    maxMessages = args.maxMessages
+    region = args.region
+    url = args.url
+    visibilityTimeoutSeconds = args.visibilityTimeoutSeconds
+    waitTimeSeconds = args.waitTimeSeconds
+
+    withEnv(["url=${url}",
+             "region=${region}",
+             "maxMessages=${maxMessages}",
+             "waitTimeSeconds=${waitTimeSeconds}",
+             "visibilityTimeoutSeconds=${visibilityTimeoutSeconds}"]) {
+        rawMessages = sh(
+            returnStdout: true,
+            script: '''
+#!/usr/bin/env bash
+aws sqs receive-message \
+  --region "$region" \
+  --queue-url "$url" \
+  --max-number-of-messages "$maxMessages" \
+  --wait-time-seconds "$waitTimeSeconds" \
+  --visibility-timeout "$visibilityTimeoutSeconds" \
+  --output json \
+  --query Messages |\
+jq '.? | map({receipt: .ReceiptHandle, body: .Body | fromjson}) | unique'
+'''
+        ).trim()
+    }
+    try {
+        jsonMessages = readJSON text: rawMessages
+    } catch(err) {
+        jsonMessages = readJSON text: '[]'
+    }
+    return jsonMessages
+}
+
+// deletes a message by the given `receipt` which indicates the associated message has been proceesed
+String deleteMessage(String receipt, String url, String region = 'us-east-1') {
+    result = sh(returnStdout: true, script: "aws sqs delete-message --queue-url ${url} --region ${region} --receipt-handle ${receipt}")
+    return result
+}
+
+// returns true when if the given `sqsQueueName` exists
+boolean sqsQueueExists(String sqsQueueName, String region = 'us-east-1') {
+    // For whatever reason, the ternary expression doesn't work here. I still don't understand Groovy.
+    exists = sh(returnStatus: true, script: "aws sqs get-queue-url --queue-name ${sqsQueueName} --region ${region} --output text")
+    if (exists == 0) {
+        return true
+    } else {
+        return false
+    }
+}
+
+// returns the url of the given `sqsQueueName`
+String getSqsQueueUrl(String sqsQueueName, String region = 'us-east-1') {
+    url = sh(returnStdout: true, script: "aws sqs get-queue-url --queue-name ${sqsQueueName} --region ${region} --output text").trim()
+    return url
+}
+
+// polls the given AWS SQS Queue `sqsQueueName` for migrator messages for
+// 20s at the `heartbeatInterval`
+String monitorMigrator(Map args = [:], authFunction) {
+    sqsQueueName = args.sqsQueueName
+    region = args.region
+    heartbeatInterval = args.heartbeatInterval
+    maxMessages = args.maxMessages
+
+    sqsQueueUrl = getSqsQueueUrl(sqsQueueName)
+    while (true) {
+        authFunction()
+        messages = receiveMigratorMessages(
+            url: sqsQueueUrl,
+            region: region,
+            visibilityTimeoutSeconds: 30,
+            waitTimeSeconds: 20,
+            maxMessages: maxMessages
+        )
+
+        // 1. "handle" (capture status, print, delete) each message
+        // 2. if the message body contains a non "0/0" (running) value, return it
+        for (msg in messages) {
+            migratorStatus = msg.body.status
+            printMigratorMessage(msg)
+            deleteMessage(msg.receipt, sqsQueueUrl)
+            if (migratorStatus != '0/0') {
+                return migratorStatus
+            }
+        }
+        sleep(heartbeatInterval)
+    }
+}
+
+// print formatted migrator messages
+void printMigratorMessage(message) {
+    body = message.body
+    println "Timestamp: ${java.time.LocalDateTime.now().toString()}"
+
+    if (body.stop_time == "n/a") {
+        println "Migrator ${body.pid} started at ${body.start_time} is running"
+    } else {
+        println "Migrator ${body.pid} started at ${body.start_time} is no longer running: '${body.code}' '${body.status}' as of ${body.stop_time}"
+    }
+}
+
+// purge all messages from the given
+def purgeQueue(String sqsQueueName, String region = 'us-east-1') {
+    sqsQueueUrl = getSqsQueueUrl(sqsQueueName, region)
+    result = sh(returnStdout: true, script: "aws sqs purge-queue --queue-url ${url} --region ${region}")
+    return result
+}
+
+// checks for indications of a running migrator deployment by looking for unconsumed SQS messages
+boolean canMigratorDeploymentProceed(String sqsQueueName, String region) {
+    println "Checking Migrator Queue ${sqsQueueName} State..."
+
+    if (sqsQueueExists(sqsQueueName)) {
+        sqsQueueUrl = getSqsQueueUrl(sqsQueueName)
+        println "Queue ${sqsQueueName} exists. Checking for messages in ${sqsQueueUrl} ..."
+        migratorMessages = receiveMigratorMessages(
+                url: sqsQueueUrl,
+                region: region,
+                maxMessages: 10,
+                visibilityTimeoutSeconds: 0,
+                waitTimeSeconds: 0)
+        if (migratorMessages?.isEmpty()) {
+            println "Queue ${sqsQueueName} is empty. Migrator deployment can proceed!"
+            return true
+        } else {
+            println "Queue ${sqsQueueName} has messages. Is there an old bfd-db-migrator instance running? Migrator deployment cannot proceed."
+            return false
+        }
+    } else {
+        println "Queue ${sqsQueueName} does not exist or is inaccessible. Migrator deployment can proceed!"
+        return true
+    }
+}
+
+// initializes, selects appropriate workspace, plans, and applies terraform
+def executeTerraform(Map args = [:]) {
+    amiId = args.amiId
+    bfdEnv = args.bfdEnv
+    gitBranchName = args.gitBranchName
+    createMigratorInstance = args.createMigratorInstance ?: false
+    heartbeatInterval = args.heartbeatInterval ?: 30
+
+    dir("${workspace}/ops/terraform/services/migrator") {
+        // Debug output terraform version
+        sh "terraform --version"
+
+        // Initilize terraform
+        sh "terraform init -no-color"
+
+        // - Attempt to create the desired workspace
+        // - Select the desired workspace
+        // NOTE: this is the terraform concept of workspace **NOT** Jenkins
+        sh """
+terraform workspace new "$bfdEnv" 2> /dev/null || true &&\
+terraform workspace select "$bfdEnv" -no-color
+"""
+        // Gathering terraform plan
+        echo "Timestamp: ${java.time.LocalDateTime.now().toString()}"
+        sh """
+terraform plan \
+-var='ami_id=${amiId}' \
+-var='create_migrator_instance=${createMigratorInstance}' \
+-var='git_branch_name=${gitBranchName}' \
+-var='migrator_monitor_heartbeat_interval_seconds_override=${heartbeatInterval}' \
+-no-color -out=tfplan
+"""
+        // Apply Terraform plan
+        echo "Timestamp: ${java.time.LocalDateTime.now().toString()}"
+        sh '''
+terraform apply \
+-no-color -input=false tfplan
+'''
+        echo "Timestamp: ${java.time.LocalDateTime.now().toString()}"
+    }
+}
+
+return this

--- a/ops/terraform/services/migrator/Jenkinsfile
+++ b/ops/terraform/services/migrator/Jenkinsfile
@@ -1,5 +1,8 @@
 #!/usr/bin/env groovy
 
+// Load the sqs-specific methods
+sqs = load('ops/terraform/services/migrator/sqs.groovy')
+
 // entrypoint to migrator deployment, requires mapped arguments and an aws authentication closure
 // attempts to deploy and monitor and return `true` when the migrator signals a zero exit status
 boolean deployMigrator(Map args = [:], authFunction) {
@@ -33,7 +36,7 @@ boolean deployMigrator(Map args = [:], authFunction) {
     // monitor migrator deployment
     finalMigratorStatus = monitorMigrator(
         sqsQueueName: sqsQueueName,
-        region: awsRegion,
+        awsRegion: awsRegion,
         heartbeatInterval: heartbeatInterval,
         maxMessages: 10,
         authFunction
@@ -51,88 +54,27 @@ boolean deployMigrator(Map args = [:], authFunction) {
         migratorDeployedSuccessfully = false
     }
 
-    purgeQueue(sqsQueueName)
+    sqs.purgeQueue(sqsQueueName)
 
     println "Migrator completed with exit status ${finalMigratorStatus}"
     return migratorDeployedSuccessfully
 }
 
-// wraps the aws cli's receive-message subcommand to produce JSON objects
-// that represent the deployed migrator's state. Contains the following
-// fields mapped to string values: pid, start_time, stop_time, status, code
-def receiveMigratorMessages(Map args = [:]) {
-    maxMessages = args.maxMessages
-    region = args.region
-    url = args.url
-    visibilityTimeoutSeconds = args.visibilityTimeoutSeconds
-    waitTimeSeconds = args.waitTimeSeconds
-
-    withEnv(["url=${url}",
-             "region=${region}",
-             "maxMessages=${maxMessages}",
-             "waitTimeSeconds=${waitTimeSeconds}",
-             "visibilityTimeoutSeconds=${visibilityTimeoutSeconds}"]) {
-        rawMessages = sh(
-            returnStdout: true,
-            script: '''
-#!/usr/bin/env bash
-aws sqs receive-message \
-  --region "$region" \
-  --queue-url "$url" \
-  --max-number-of-messages "$maxMessages" \
-  --wait-time-seconds "$waitTimeSeconds" \
-  --visibility-timeout "$visibilityTimeoutSeconds" \
-  --output json \
-  --query Messages |\
-jq '.? | map({receipt: .ReceiptHandle, body: .Body | fromjson}) | unique'
-'''
-        ).trim()
-    }
-    try {
-        jsonMessages = readJSON text: rawMessages
-    } catch(err) {
-        jsonMessages = readJSON text: '[]'
-    }
-    return jsonMessages
-}
-
-// deletes a message by the given `receipt` which indicates the associated message has been proceesed
-String deleteMessage(String receipt, String url, String region = 'us-east-1') {
-    result = sh(returnStdout: true, script: "aws sqs delete-message --queue-url ${url} --region ${region} --receipt-handle ${receipt}")
-    return result
-}
-
-// returns true when if the given `sqsQueueName` exists
-boolean sqsQueueExists(String sqsQueueName, String region = 'us-east-1') {
-    // For whatever reason, the ternary expression doesn't work here. I still don't understand Groovy.
-    exists = sh(returnStatus: true, script: "aws sqs get-queue-url --queue-name ${sqsQueueName} --region ${region} --output text")
-    if (exists == 0) {
-        return true
-    } else {
-        return false
-    }
-}
-
-// returns the url of the given `sqsQueueName`
-String getSqsQueueUrl(String sqsQueueName, String region = 'us-east-1') {
-    url = sh(returnStdout: true, script: "aws sqs get-queue-url --queue-name ${sqsQueueName} --region ${region} --output text").trim()
-    return url
-}
 
 // polls the given AWS SQS Queue `sqsQueueName` for migrator messages for
 // 20s at the `heartbeatInterval`
 String monitorMigrator(Map args = [:], authFunction) {
     sqsQueueName = args.sqsQueueName
-    region = args.region
+    awsRegion = args.awsRegion
     heartbeatInterval = args.heartbeatInterval
     maxMessages = args.maxMessages
 
-    sqsQueueUrl = getSqsQueueUrl(sqsQueueName)
+    sqsQueueUrl = sqs.getQueueUrl(sqsQueueName)
     while (true) {
         authFunction()
-        messages = receiveMigratorMessages(
-            url: sqsQueueUrl,
-            region: region,
+        messages = sqs.receiveMessages(
+            sqsQueueUrl: sqsQueueUrl,
+            awsRegion: awsRegion,
             visibilityTimeoutSeconds: 30,
             waitTimeSeconds: 20,
             maxMessages: maxMessages
@@ -143,7 +85,7 @@ String monitorMigrator(Map args = [:], authFunction) {
         for (msg in messages) {
             migratorStatus = msg.body.status
             printMigratorMessage(msg)
-            deleteMessage(msg.receipt, sqsQueueUrl)
+            sqs.deleteMessage(msg.receipt, sqsQueueUrl)
             if (migratorStatus != '0/0') {
                 return migratorStatus
             }
@@ -164,23 +106,16 @@ void printMigratorMessage(message) {
     }
 }
 
-// purge all messages from the given
-def purgeQueue(String sqsQueueName, String region = 'us-east-1') {
-    sqsQueueUrl = getSqsQueueUrl(sqsQueueName, region)
-    result = sh(returnStdout: true, script: "aws sqs purge-queue --queue-url ${url} --region ${region}")
-    return result
-}
-
 // checks for indications of a running migrator deployment by looking for unconsumed SQS messages
-boolean canMigratorDeploymentProceed(String sqsQueueName, String region) {
+boolean canMigratorDeploymentProceed(String sqsQueueName, String awsRegion) {
     println "Checking Migrator Queue ${sqsQueueName} State..."
 
-    if (sqsQueueExists(sqsQueueName)) {
-        sqsQueueUrl = getSqsQueueUrl(sqsQueueName)
+    if (sqs.queueExists(sqsQueueName)) {
+        sqsQueueUrl = sqs.getQueueUrl(sqsQueueName)
         println "Queue ${sqsQueueName} exists. Checking for messages in ${sqsQueueUrl} ..."
-        migratorMessages = receiveMigratorMessages(
-                url: sqsQueueUrl,
-                region: region,
+        migratorMessages = sqs.receiveMessages(
+                sqsQueueUrl: sqsQueueUrl,
+                awsRegion: awsRegion,
                 maxMessages: 10,
                 visibilityTimeoutSeconds: 0,
                 waitTimeSeconds: 0)
@@ -192,7 +127,7 @@ boolean canMigratorDeploymentProceed(String sqsQueueName, String region) {
             return false
         }
     } else {
-        println "Queue ${sqsQueueName} does not exist or is inaccessible. Migrator deployment can proceed!"
+        println "Queue ${sqsQueueName} can not be found. Migrator deployment can proceed!"
         return true
     }
 }

--- a/ops/terraform/services/migrator/sqs.groovy
+++ b/ops/terraform/services/migrator/sqs.groovy
@@ -1,0 +1,74 @@
+#!/usr/bin/env groovy
+// sqs.groovy contains methods that wrap awscli sqs subcommands
+
+// returns the url of the given `sqsQueueName`
+String getQueueUrl(String sqsQueueName, String awsRegion = 'us-east-1') {
+    url = sh(returnStdout: true, script: "aws sqs get-queue-url --queue-name ${sqsQueueName} --region ${awsRegion} --output text").trim()
+    return url
+}
+
+// deletes a message by the given `receipt`
+// this indicates the associated message has been proceesed
+String deleteMessage(String receipt, String sqsQueueUrl, String awsRegion = 'us-east-1') {
+    result = sh(returnStdout: true, script: "aws sqs delete-message --queue-url ${sqsQueueUrl} --region ${awsRegion} --receipt-handle ${receipt}")
+    return result
+}
+
+// returns true when if the given `sqsQueueName` exists
+boolean queueExists(String sqsQueueName, String awsRegion = 'us-east-1') {
+    // For whatever reason, the ternary expression doesn't work here. I still don't understand Groovy.
+    exists = sh(returnStatus: true, script: "aws sqs get-queue-url --queue-name ${sqsQueueName} --region ${awsRegion} --output text")
+    if (exists == 0) {
+        return true
+    } else {
+        return false
+    }
+}
+
+// purge all messages from the given
+def purgeQueue(String sqsQueueName, String awsRegion = 'us-east-1') {
+    sqsQueueUrl = getQueueUrl(sqsQueueName, awsRegion)
+    result = sh(returnStdout: true, script: "aws sqs purge-queue --queue-url ${sqsQueueUrl} --region ${awsRegion}")
+    return result
+}
+
+// wraps the aws cli's receive-message subcommand to produce JSON objects
+// that represent the deployed migrator's state. Contains the following
+// fields mapped to string values: pid, start_time, stop_time, status, code
+def receiveMessages(Map args = [:]) {
+    maxMessages = args.maxMessages
+    awsRegion = args.awsRegion ?: 'us-east-1'
+    sqsQueueUrl = args.sqsQueueUrl
+    visibilityTimeoutSeconds = args.visibilityTimeoutSeconds
+    waitTimeSeconds = args.waitTimeSeconds
+
+    withEnv(["url=${sqsQueueUrl}",
+             "region=${awsRegion}",
+             "maxMessages=${maxMessages}",
+             "waitTimeSeconds=${waitTimeSeconds}",
+             "visibilityTimeoutSeconds=${visibilityTimeoutSeconds}"]) {
+        rawMessages = sh(
+            returnStdout: true,
+            script: '''
+#!/usr/bin/env bash
+aws sqs receive-message \
+  --region "$region" \
+  --queue-url "$url" \
+  --max-number-of-messages "$maxMessages" \
+  --wait-time-seconds "$waitTimeSeconds" \
+  --visibility-timeout "$visibilityTimeoutSeconds" \
+  --output json \
+  --query Messages |\
+jq '.? | map({receipt: .ReceiptHandle, body: .Body | fromjson}) | unique'
+'''
+        ).trim()
+    }
+    try {
+        jsonMessages = readJSON text: rawMessages
+    } catch(err) {
+        jsonMessages = readJSON text: '[]'
+    }
+    return jsonMessages
+}
+
+return this


### PR DESCRIPTION
**JIRA Ticket:**
[BFD-1550](https://jira.cms.gov/browse/BFD-1550)

**User Story or Bug Summary:**

This introduces the test, prod-sbx, and prod database migration stages to the Jenkins pipeline.

---

### What Does This PR Do?
While this changeset focuses mainly on extending the existing multibranch/multistage pipeline in defining a new Jenkinsfile for the `bfd-db-migrator` service, it also fixes a few overlooked issues:
- adjusts the `bfd-db-migrator` ansible role test harness to accurately define the `env` variable
- introduces a new pipeline parameter that allows operators to use the latest image available (useful for faster iterative development in the `test` environment)
- introduces a single, globally accessible `awsAssumeRole` method to standardize role assumption and sessions
- removes the unused `appBuildResults` from the existing `deploy` method
- removes erroneous inversePrecendence _[sic]_ argument from the `lock` method that yields the following warning on each deployment stage: 
  > WARNING: Unknown parameter(s) found for class type 'org.jenkins.plugins.lockableresources.LockStep': inversePrecendence

Any and all feedback on this solution is strongly encouraged.

### What Should Reviewers Watch For?

If you're reviewing this PR, please check for these things in particular:

* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [x] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [x] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [x] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [x] Yes
      * [] No

As discussed, #1147 was opened with the intent of having a review from @StewGoin where the underlying CBC image is updated to include `tfenv` but the timing worked out that _this_ PR is coming ahead of it. `tfenv` is involved where we deploy `bfd-db-migrator` with v1.1.9 and the other _stateless_ infrastructure with v0.12.31.

### What Needs to Be Merged and Deployed Before this PR?

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* TBD. Hibernate validations are currently failing when models are run against a postgresql database which will block the deployment of this service.

### Submitter Checklist

I have gone through and verified that...:

* [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.