### PR TITLE
PACA-630: Allow empty strings to work around bad test data from RDA API.

### DIFF
--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/source/FissClaimTransformer.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/source/FissClaimTransformer.java
@@ -1312,14 +1312,14 @@ public class FissClaimTransformer {
         2,
         RdaFissPayer_beneZPayer_beneRel_Extractor.getEnumString(from),
         to::setBeneRel);
-    transformer.copyOptionalString(
+    transformer.copyOptionalNonEmptyString(
         namePrefix + RdaFissPayer.Fields.beneLastName,
         1,
         15,
         () -> from.hasBeneZPayer() && from.getBeneZPayer().hasBeneLastName(),
         () -> from.getBeneZPayer().getBeneLastName(),
         to::setBeneLastName);
-    transformer.copyOptionalString(
+    transformer.copyOptionalNonEmptyString(
         namePrefix + RdaFissPayer.Fields.beneFirstName,
         1,
         10,

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/source/McsClaimTransformer.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/source/McsClaimTransformer.java
@@ -670,7 +670,7 @@ public class McsClaimTransformer {
         from::hasIdrDtlToDate,
         from::getIdrDtlToDate,
         to::setIdrDtlToDate);
-    transformer.copyOptionalString(
+    transformer.copyOptionalNonEmptyString(
         namePrefix + RdaMcsDetail.Fields.idrProcCode,
         1,
         5,

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/FissClaimTransformerTest.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/FissClaimTransformerTest.java
@@ -1507,7 +1507,7 @@ public class FissClaimTransformerTest {
   @Test
   public void testBeneZPayerBeneLastName() {
     new BeneZPayerFieldTester()
-        .verifyStringFieldCopiedCorrectly(
+        .verifyStringFieldCopiedCorrectlyEmptyIgnored(
             FissBeneZPayer.Builder::setBeneLastName,
             RdaFissPayer::getBeneLastName,
             RdaFissPayer.Fields.beneLastName,
@@ -1517,7 +1517,7 @@ public class FissClaimTransformerTest {
   @Test
   public void testBeneZPayerBeneFirstName() {
     new BeneZPayerFieldTester()
-        .verifyStringFieldCopiedCorrectly(
+        .verifyStringFieldCopiedCorrectlyEmptyIgnored(
             FissBeneZPayer.Builder::setBeneFirstName,
             RdaFissPayer::getBeneFirstName,
             RdaFissPayer.Fields.beneFirstName,

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/McsClaimTransformerTest.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/McsClaimTransformerTest.java
@@ -1037,7 +1037,7 @@ public class McsClaimTransformerTest {
   @Test
   public void testDetailIdrProcCode() {
     new McsClaimTransformerTest.DetailFieldTester()
-        .verifyStringFieldCopiedCorrectly(
+        .verifyStringFieldCopiedCorrectlyEmptyIgnored(
             McsDetail.Builder::setIdrProcCode,
             RdaMcsDetail::getIdrProcCode,
             RdaMcsDetail.Fields.idrProcCode,


### PR DESCRIPTION
**JIRA Ticket:**
[PACA-630](https://jira.cms.gov/browse/PACA-630)

**User Story or Bug Summary:**
<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->

Due to the raw nature of the partially adjudicated claims we receive, it's expected that sometimes the code and name values will come through as empty strings. We should remove our transformer data validation checks around the following and allow for 0 length strings (aka the empty string) to be persisted.

- mcs_details.idr_proc_code
- fiss_payers.bene_last_name
- fiss_payers.bene_first_name

---

### What Does This PR Do?

The API is supposed to not send empty strings as values of empty fields but some bad test data in their IMPL environment caused it to do so for these fields.

This change treats empty strings in these fields as though the fields were not sent in the message rather than applying validation checks that throw an error for minimum length violation.

### What Should Reviewers Watch For?

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items to the following list here -->
* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [x] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [x] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [x] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    