### PR TITLE
BFD-1294 Add payload size to the structured access log (access.json)

### DIFF
--- a/apps/bfd-server/bfd-server-launcher/src/main/java/gov/cms/bfd/server/launcher/DataServerLauncherApp.java
+++ b/apps/bfd-server/bfd-server-launcher/src/main/java/gov/cms/bfd/server/launcher/DataServerLauncherApp.java
@@ -339,7 +339,12 @@ public final class DataServerLauncherApp {
 
         /*
          * Capture the payload size in MDC. This Jetty specific call is the same one that is used by the
-         * CustomRequestLog to write the payload size to the access.log (see @CustomRequestLog.logBytesSent()).
+         * CustomRequestLog to write the payload size to the access.log:
+         * org.eclipse.jetty.server.CustomRequestLog.logBytesSent().
+         *
+         * We capture this field here rather than in the RequestResponsePopulateMdcFilter because we need access to
+         * the underlying Jetty classes in the response that are in classes that are not loaded in the war file so not
+         * accessible to the filter.
          */
         MDC.put(
             "http_access.response.output_size_in_bytes",

--- a/apps/bfd-server/bfd-server-launcher/src/main/java/gov/cms/bfd/server/launcher/DataServerLauncherApp.java
+++ b/apps/bfd-server/bfd-server-launcher/src/main/java/gov/cms/bfd/server/launcher/DataServerLauncherApp.java
@@ -77,6 +77,9 @@ public final class DataServerLauncherApp {
    */
   static final int EXIT_CODE_MONITOR_ERROR = 2;
 
+  public static final String HTTP_ACCESS_RESPONSE_OUTPUT_SIZE_IN_BYTES =
+      "http_access.response.output_size_in_bytes";
+
   private static Server server;
 
   /**
@@ -347,7 +350,7 @@ public final class DataServerLauncherApp {
          * accessible to the filter.
          */
         MDC.put(
-            "http_access.response.output_size_in_bytes",
+            HTTP_ACCESS_RESPONSE_OUTPUT_SIZE_IN_BYTES,
             String.valueOf(response.getHttpOutput().getWritten()));
 
         /*

--- a/apps/bfd-server/bfd-server-launcher/src/main/java/gov/cms/bfd/server/launcher/DataServerLauncherApp.java
+++ b/apps/bfd-server/bfd-server-launcher/src/main/java/gov/cms/bfd/server/launcher/DataServerLauncherApp.java
@@ -77,9 +77,7 @@ public final class DataServerLauncherApp {
    */
   static final int EXIT_CODE_MONITOR_ERROR = 2;
 
-  /**
-   * MDC key for the http output size in bytes
-   */
+  /** MDC key for the http output size in bytes */
   public static final String HTTP_ACCESS_RESPONSE_OUTPUT_SIZE_IN_BYTES =
       "http_access.response.output_size_in_bytes";
 

--- a/apps/bfd-server/bfd-server-launcher/src/main/java/gov/cms/bfd/server/launcher/DataServerLauncherApp.java
+++ b/apps/bfd-server/bfd-server-launcher/src/main/java/gov/cms/bfd/server/launcher/DataServerLauncherApp.java
@@ -77,6 +77,9 @@ public final class DataServerLauncherApp {
    */
   static final int EXIT_CODE_MONITOR_ERROR = 2;
 
+  /**
+   * MDC key for the http output size in bytes
+   */
   public static final String HTTP_ACCESS_RESPONSE_OUTPUT_SIZE_IN_BYTES =
       "http_access.response.output_size_in_bytes";
 

--- a/apps/bfd-server/bfd-server-launcher/src/test/java/gov/cms/bfd/server/launcher/DataServerLauncherAppIT.java
+++ b/apps/bfd-server/bfd-server-launcher/src/test/java/gov/cms/bfd/server/launcher/DataServerLauncherAppIT.java
@@ -229,6 +229,9 @@ public final class DataServerLauncherAppIT {
               .resolve("access.json");
       assertTrue(Files.isReadable(accessLogJson));
       assertTrue(Files.size(accessLogJson) > 0);
+      assertTrue(
+          Files.readString(accessLogJson)
+              .contains(DataServerLauncherApp.HTTP_ACCESS_RESPONSE_OUTPUT_SIZE_IN_BYTES));
 
       // Stop the application.
       serverProcess.close();

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/Operation.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/Operation.java
@@ -69,7 +69,7 @@ public final class Operation {
     String canonicalName = getCanonicalName();
 
     // Ensure that the operation name lands in our access logs.
-    MDC.put(RequestResponseLoggingFilter.computeMdcRequestKey("operation"), canonicalName);
+    MDC.put(RequestResponsePopulateMdcFilter.computeMdcRequestKey("operation"), canonicalName);
 
     // If we got a known operation name, publish it to New Relic as the "transaction name",
     // otherwise stick with New Relic's default transaction name.

--- a/apps/bfd-server/bfd-server-war/src/main/webapp/WEB-INF/web.xml
+++ b/apps/bfd-server/bfd-server-war/src/main/webapp/WEB-INF/web.xml
@@ -4,11 +4,11 @@
 	<!-- Manage the MDC context and ensure that the app's NDJSON-formatted HTTP 
 		access log is populated. -->
 	<filter>
-		<filter-name>RequestResponseLoggingFilter</filter-name>
-		<filter-class>gov.cms.bfd.server.war.RequestResponseLoggingFilter</filter-class>
+		<filter-name>RequestResponsePopulateMdcFilter</filter-name>
+		<filter-class>gov.cms.bfd.server.war.RequestResponsePopulateMdcFilter</filter-class>
 	</filter>
 	<filter-mapping>
-		<filter-name>RequestResponseLoggingFilter</filter-name>
+		<filter-name>RequestResponsePopulateMdcFilter</filter-name>
 		<url-pattern>/*</url-pattern>
 	</filter-mapping>
 


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BFD-1294](https://jira.cms.gov/browse/BFD-1294)

**User Story or Bug Summary:**
<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->

Adds the http response payload size (in bytes) to the access.json, making it possible to deprecate and eventually remove the access.log file entirely once other dependencies are adjusted to no longer rely on access.log.

---

### What Does This PR Do?
<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

BFD currently writes to two access logs -- access.log and access.json (which are respectively unstructured and structured) although the preference is to only have one log (the structured one). In order to remove the unstructured log, all data available in that log must be made available in the structured log file. Currently only the response payload size in bytes is missing from the structured log file. Making that available in the structured log file is the subject of this PR.

In order to accomplish that, this PR moves the code that performs the writes to access.json from a servlet filter (the RequestResponseLoggingFilter) to a new BFD implementation of the Jetty RequestLog interface. This interface has access to the underlying Jetty response object which exposes a method for retrieving the number of bytes in the http output payload which can then be added to access.json via the logging MDC. In order to preserve the unstructured log (which is needed for a time while its dependents are switched over to the structured log), additional code is included in the BFD implementation of the RequestLog interface to write the access.log since only one RequestLog interface may be registered with Jetty.

With the writing (logging) of the access.json no longer taking place in the RequestResponseLoggingFilter, it is renamed to the RequestResponsePopulateMdcFilter to more accurately represent its new purpose -- to populate request and response information in the MDC.

### What Should Reviewers Watch For?
<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items to the following list here -->
* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [X] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [X] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [X] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [X] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [X] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [X] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [X] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [X] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [X] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [X] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [X] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    