### PR TITLE
BFD-1779: Add capability for regression tests to compare performance statistics against prior runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 *.ipr
 *.iws
 *.pid
+**/__pycache__
+**/*.stats.json

--- a/ops/ccs-ops-misc/load_test/README.md
+++ b/ops/ccs-ops-misc/load_test/README.md
@@ -118,7 +118,7 @@ Essentially, all the items you would set up in the config file are set in a sing
 
 **--resetStats** : (Optional) : If this flag is included, the test statistics will reset to zero after clients have finished spawning. **Note:** There are many reasons why we might want to capture statistics while new load is being added. There might be performance problems accepting the connection or new connections might affect users already connected to the system.
 
-**--stats**: (Optional) : Argument specifying that aggregated performance statistics should be collected and stored to some location. This can either be to a local file or to an S3 bucket. This argument must be specified as a list of key-value pairs seperated by semi-colons: `--stats="store=<file/s3>;env=<TEST/PROD>;tag=;path=;bucket=;compare=<previous/average>;comp_tag=;athena_db="`
+**--stats**: (Optional) : Argument specifying that aggregated performance statistics should be collected and stored to some location. This can either be to a local file or to an S3 bucket. This argument must be specified as a list of key-value pairs seperated by semi-colons: `--stats="store=<file/s3>;env=<TEST/PROD>;tag=;path=;bucket=;compare=<previous/average>;comp_tag=;athena_tbl="`
 
 | Key | Required? | Possible Values | Description |
 | :-: | :-: | :-: | - |

--- a/ops/ccs-ops-misc/load_test/README.md
+++ b/ops/ccs-ops-misc/load_test/README.md
@@ -112,15 +112,15 @@ Essentially, all the items you would set up in the config file are set in a sing
 
 **--resetStats** : (Optional) : If this flag is included, the test statistics will reset to zero after clients have finished spawning. **Note:** There are many reasons why we might want to capture statistics while new load is being added. There might be performance problems accepting the connection or new connections might affect users already connected to the system.
 
-**--stats**: (Optional) : Argument specifying that aggregated performance statistics should be stored to some location. This can either be to a local file or to an S3 bucket. This argument must be specified in the following format: `<STORAGE_TYPE>:<RUNNING_ENVIRONMENT>:<TAG>:<PATH_OR_BUCKET>`, where
+**--stats**: (Optional) : Argument specifying that aggregated performance statistics should be collected and stored to some location. This can either be to a local file or to an S3 bucket. This argument must be specified as a list of key-value pairs seperated by semi-colons: `type=<file/s3>;env=<TEST/PROD>;tag=;path=;bucket=`
 
-* `STORAGE_TYPE` is either `file` or `s3`. 
-  * Note that the `file` `STORAGE_TYPE` is primarily meant for _local debugging_ purposes and should not be used when running these tests as part of a process where the performance statistics should be stored for later retrieval. 
-* `RUNNING_ENVIRONMENT` is either `TEST` or `PROD`.
-* `TAG` can be any string that follows BFD Insights data organization standards (lower-case letters, numbers and "_").
-  * The tag is used to partition performance statistics for more accurate performance validation between corresponding runs.
-  * _Note that this argument may be deprecated in the future once a more robust means of "tagging" captured statistics is developed._
-* `PATH_OR_BUCKET`, if `STORAGE_TYPE` is `file`, must be a valid local file path. Otherwise, if `STORAGE_TYPE` is `s3`, it must be a valid AWS S3 _bucket_.
+| Key | Required? | Possible Values | Description |
+| :-: | :-: | :-: | - |
+| `type` | Yes | `file`, `s3` | Specifies where the stats are stored. Note that the `file` `type` is primarily meant for _local debugging_ purposes and should not be used when running these tests as part of a process where the performance statistics should be stored for later retrieval. 
+| `env` | Yes | `TEST`, `PROD` | Specifies which environment the test ran in.
+| `tag` | Yes | Must be non-empty, consisting of letters, numbers and the `_` character | A tag that is used to bucket or partition statistics for more accurate performance validation between corresponding runs.
+| `path` | No | N/A | The _local_ **parent directory** where JSON files will be written to. Used only if `type` is `file`, ignored if `type` is `s3`.
+| `bucket` | Yes, _if `type` is `s3`_ | N/A | The AWS S3 Bucket that the JSON will be written to under a predetermined path following BFD Insights data organization standards.
 
 ### Quick Run
 

--- a/ops/ccs-ops-misc/load_test/README.md
+++ b/ops/ccs-ops-misc/load_test/README.md
@@ -121,7 +121,7 @@ Essentially, all the items you would set up in the config file are set in a sing
 | `store_tag` | Yes | Must be non-empty, consisting of letters, numbers and the `_` character | A tag that is used to bucket or partition statistics for more accurate performance validation between corresponding runs.
 | `path` | No | N/A | The _local_ **parent directory** where JSON files will be written to. Used only if `store` is `file`, ignored if `store` is `s3`.
 | `bucket` | Yes, _if `store` is `s3`_ | N/A | The AWS S3 Bucket that the JSON will be written to under a predetermined path following BFD Insights data organization standards.
-| `compare` | No | `previous`, `average` | Specifies if the current run should be compared to existing statistics. These statistics will be retrieved from the same type of store as specified by `store`. If `previous` is specified, the most recent run from `comp_tag` will be compared against. If `average` is specified, the average of _all_ previous runs from `comp_tag` will be compared against.
+| `compare` | No | `previous`, `average` | Specifies if the current run should be compared to existing statistics. These statistics will be retrieved from the same type of store as specified by `store`. If `previous` is specified, the most recent run from `comp_tag` will be compared against. If `average` is specified, the average of _all_ previous runs from `comp_tag` will be compared against. If unspecified, no comparisons will be done.
 | `comp_tag` | No | Must be non-empty, consisting of letters, numbers and the `_` character | Tag from which comparison statistics will be loaded from the given `store`. Defaults to `store_tag` if unspecified. |
 
 ### Quick Run

--- a/ops/ccs-ops-misc/load_test/README.md
+++ b/ops/ccs-ops-misc/load_test/README.md
@@ -118,7 +118,7 @@ Essentially, all the items you would set up in the config file are set in a sing
 
 **--resetStats** : (Optional) : If this flag is included, the test statistics will reset to zero after clients have finished spawning. **Note:** There are many reasons why we might want to capture statistics while new load is being added. There might be performance problems accepting the connection or new connections might affect users already connected to the system.
 
-**--stats**: (Optional) : Argument specifying that aggregated performance statistics should be collected and stored to some location. This can either be to a local file or to an S3 bucket. This argument must be specified as a list of key-value pairs seperated by semi-colons: `--stats="store=<file/s3>;env=<TEST/PROD>;tag=;path=;bucket=;compare=<previous/average>;comp_tag=;athena_tbl="`
+**--stats**: (Optional) : Argument specifying that aggregated performance statistics should be collected and stored to some location. This can either be to a local file or to an S3 bucket. This argument must be specified as a list of key-value pairs seperated by semi-colons: `--stats="store=<file/s3>;env=<TEST/PROD>;store_tag=;path=;bucket=;compare=<previous/average>;comp_tag=;athena_tbl="`
 
 | Key | Required? | Possible Values | Description |
 | :-: | :-: | :-: | - |

--- a/ops/ccs-ops-misc/load_test/README.md
+++ b/ops/ccs-ops-misc/load_test/README.md
@@ -112,17 +112,17 @@ Essentially, all the items you would set up in the config file are set in a sing
 
 **--resetStats** : (Optional) : If this flag is included, the test statistics will reset to zero after clients have finished spawning. **Note:** There are many reasons why we might want to capture statistics while new load is being added. There might be performance problems accepting the connection or new connections might affect users already connected to the system.
 
-**--stats**: (Optional) : Argument specifying that aggregated performance statistics should be collected and stored to some location. This can either be to a local file or to an S3 bucket. This argument must be specified as a list of key-value pairs seperated by semi-colons: `--stats="type=<file/s3>;env=<TEST/PROD>;tag=;path=;bucket=;compare=<previous/average>"`
+**--stats**: (Optional) : Argument specifying that aggregated performance statistics should be collected and stored to some location. This can either be to a local file or to an S3 bucket. This argument must be specified as a list of key-value pairs seperated by semi-colons: `--stats="store=<file/s3>;env=<TEST/PROD>;tag=;path=;bucket=;compare=<previous/average>"`
 
 | Key | Required? | Possible Values | Description |
 | :-: | :-: | :-: | - |
-| `type` | Yes | `file`, `s3` | Specifies where the stats are stored. Note that the `file` `type` is primarily meant for _local debugging_ purposes and should not be used when running these tests as part of a process where the performance statistics should be stored for later retrieval. 
+| `store` | Yes | `file`, `s3` | Specifies where the stats are stored. Note that the `file` `store` is primarily meant for _local debugging_ purposes and should not be used when running these tests as part of a process where the performance statistics should be stored for later retrieval. 
 | `env` | Yes | `TEST`, `PROD` | Specifies which environment the test ran in.
 | `tag` | Yes | Must be non-empty, consisting of letters, numbers and the `_` character | A tag that is used to bucket or partition statistics for more accurate performance validation between corresponding runs.
-| `path` | No | N/A | The _local_ **parent directory** where JSON files will be written to. Used only if `type` is `file`, ignored if `type` is `s3`.
-| `bucket` | Yes, _if `type` is `s3`_ | N/A | The AWS S3 Bucket that the JSON will be written to under a predetermined path following BFD Insights data organization standards.
-| `compare` | No | `previous`, `average` | Specifies if the current run should be compared to existing statistics. These statistics will be retrieved from the same type of store as specified by `type`. If `previous` is specified, the most recent run from the same `tag` will be compared against. If `average` is specified, the average of _all_ previous runs from the same `tag` will be compared against.
-| `comp_tag` | No | Must be non-empty, consisting of letters, numbers and the `_` character | Tag from which comparison statistics will be loaded from the given store `type`. Defaults to `tag` if unspecified. |
+| `path` | No | N/A | The _local_ **parent directory** where JSON files will be written to. Used only if `store` is `file`, ignored if `store` is `s3`.
+| `bucket` | Yes, _if `store` is `s3`_ | N/A | The AWS S3 Bucket that the JSON will be written to under a predetermined path following BFD Insights data organization standards.
+| `compare` | No | `previous`, `average` | Specifies if the current run should be compared to existing statistics. These statistics will be retrieved from the same type of store as specified by `store`. If `previous` is specified, the most recent run from the same `tag` will be compared against. If `average` is specified, the average of _all_ previous runs from the same `tag` will be compared against.
+| `comp_tag` | No | Must be non-empty, consisting of letters, numbers and the `_` character | Tag from which comparison statistics will be loaded from the given `store`. Defaults to `tag` if unspecified. |
 
 ### Quick Run
 

--- a/ops/ccs-ops-misc/load_test/README.md
+++ b/ops/ccs-ops-misc/load_test/README.md
@@ -48,6 +48,12 @@ Why: Runs the test execution and reporting
 Install: _pip3 install locust_
 See: http://docs.locust.io/en/stable/installation.html
 
+**boto3**
+
+What: Library for interfacing with AWS services
+Why: Store and load performance stats from S3
+Install: _pip3 install boto3_
+See: https://boto3.amazonaws.com/v1/documentation/api/latest/index.html
 
 In addition to these libraries, you'll also need to copy a PEM (credentials) file and set the user to your SSH username on the test box. 
 Run the following two commands on the box from your local directory:

--- a/ops/ccs-ops-misc/load_test/README.md
+++ b/ops/ccs-ops-misc/load_test/README.md
@@ -112,7 +112,7 @@ Essentially, all the items you would set up in the config file are set in a sing
 
 **--resetStats** : (Optional) : If this flag is included, the test statistics will reset to zero after clients have finished spawning. **Note:** There are many reasons why we might want to capture statistics while new load is being added. There might be performance problems accepting the connection or new connections might affect users already connected to the system.
 
-**--stats**: (Optional) : Argument specifying that aggregated performance statistics should be collected and stored to some location. This can either be to a local file or to an S3 bucket. This argument must be specified as a list of key-value pairs seperated by semi-colons: `type=<file/s3>;env=<TEST/PROD>;tag=;path=;bucket=`
+**--stats**: (Optional) : Argument specifying that aggregated performance statistics should be collected and stored to some location. This can either be to a local file or to an S3 bucket. This argument must be specified as a list of key-value pairs seperated by semi-colons: `--stats="type=<file/s3>;env=<TEST/PROD>;tag=;path=;bucket=;compare=<previous/average>"`
 
 | Key | Required? | Possible Values | Description |
 | :-: | :-: | :-: | - |
@@ -121,6 +121,7 @@ Essentially, all the items you would set up in the config file are set in a sing
 | `tag` | Yes | Must be non-empty, consisting of letters, numbers and the `_` character | A tag that is used to bucket or partition statistics for more accurate performance validation between corresponding runs.
 | `path` | No | N/A | The _local_ **parent directory** where JSON files will be written to. Used only if `type` is `file`, ignored if `type` is `s3`.
 | `bucket` | Yes, _if `type` is `s3`_ | N/A | The AWS S3 Bucket that the JSON will be written to under a predetermined path following BFD Insights data organization standards.
+| `compare` | No | `previous`, `average` | Specifies if the current run should be compared to existing statistics. These statistics will be retrieved from the same type of store as specified by `type`. If `previous` is specified, the most recent run from the same `tag` will be compared against. If `average` is specified, the average of _all_ previous runs from the same `tag` will be compared against.
 
 ### Quick Run
 

--- a/ops/ccs-ops-misc/load_test/README.md
+++ b/ops/ccs-ops-misc/load_test/README.md
@@ -123,7 +123,7 @@ Essentially, all the items you would set up in the config file are set in a sing
 | `bucket` | Yes, _if `store` is `s3`_ | N/A | The AWS S3 Bucket that the JSON will be written to under a predetermined path following BFD Insights data organization standards.
 | `compare` | No | `previous`, `average` | Specifies if the current run should be compared to existing statistics. These statistics will be retrieved from the same type of store as specified by `store`. If `previous` is specified, the most recent run from `comp_tag` will be compared against. If `average` is specified, the average of _all_ previous runs from `comp_tag` will be compared against. If unspecified, no comparisons will be done.
 | `comp_tag` | No | Must be non-empty, consisting of letters, numbers and the `_` character | Tag from which comparison statistics will be loaded from the given `store`. Defaults to `store_tag` if unspecified. |
-| `athena_db` | Yes, _if `store` is `s3` **and** `compare` is set_ | N/A | Name of the database to query using Athena if `store` is `s3` and `compare` is set. |
+| `athena_tbl` | Yes, _if `store` is `s3` **and** `compare` is set_ | N/A | Name of the table to query using Athena if `store` is `s3` and `compare` is set. |
 
 ### Quick Run
 

--- a/ops/ccs-ops-misc/load_test/README.md
+++ b/ops/ccs-ops-misc/load_test/README.md
@@ -122,6 +122,7 @@ Essentially, all the items you would set up in the config file are set in a sing
 | `path` | No | N/A | The _local_ **parent directory** where JSON files will be written to. Used only if `type` is `file`, ignored if `type` is `s3`.
 | `bucket` | Yes, _if `type` is `s3`_ | N/A | The AWS S3 Bucket that the JSON will be written to under a predetermined path following BFD Insights data organization standards.
 | `compare` | No | `previous`, `average` | Specifies if the current run should be compared to existing statistics. These statistics will be retrieved from the same type of store as specified by `type`. If `previous` is specified, the most recent run from the same `tag` will be compared against. If `average` is specified, the average of _all_ previous runs from the same `tag` will be compared against.
+| `comp_tag` | No | Must be non-empty, consisting of letters, numbers and the `_` character | Tag from which comparison statistics will be loaded from the given store `type`. Defaults to `tag` if unspecified. |
 
 ### Quick Run
 

--- a/ops/ccs-ops-misc/load_test/README.md
+++ b/ops/ccs-ops-misc/load_test/README.md
@@ -118,11 +118,11 @@ Essentially, all the items you would set up in the config file are set in a sing
 | :-: | :-: | :-: | - |
 | `store` | Yes | `file`, `s3` | Specifies where the stats are stored. Note that the `file` `store` is primarily meant for _local debugging_ purposes and should not be used when running these tests as part of a process where the performance statistics should be stored for later retrieval. 
 | `env` | Yes | `TEST`, `PROD` | Specifies which environment the test ran in.
-| `tag` | Yes | Must be non-empty, consisting of letters, numbers and the `_` character | A tag that is used to bucket or partition statistics for more accurate performance validation between corresponding runs.
+| `store_tag` | Yes | Must be non-empty, consisting of letters, numbers and the `_` character | A tag that is used to bucket or partition statistics for more accurate performance validation between corresponding runs.
 | `path` | No | N/A | The _local_ **parent directory** where JSON files will be written to. Used only if `store` is `file`, ignored if `store` is `s3`.
 | `bucket` | Yes, _if `store` is `s3`_ | N/A | The AWS S3 Bucket that the JSON will be written to under a predetermined path following BFD Insights data organization standards.
-| `compare` | No | `previous`, `average` | Specifies if the current run should be compared to existing statistics. These statistics will be retrieved from the same type of store as specified by `store`. If `previous` is specified, the most recent run from the same `tag` will be compared against. If `average` is specified, the average of _all_ previous runs from the same `tag` will be compared against.
-| `comp_tag` | No | Must be non-empty, consisting of letters, numbers and the `_` character | Tag from which comparison statistics will be loaded from the given `store`. Defaults to `tag` if unspecified. |
+| `compare` | No | `previous`, `average` | Specifies if the current run should be compared to existing statistics. These statistics will be retrieved from the same type of store as specified by `store`. If `previous` is specified, the most recent run from `comp_tag` will be compared against. If `average` is specified, the average of _all_ previous runs from `comp_tag` will be compared against.
+| `comp_tag` | No | Must be non-empty, consisting of letters, numbers and the `_` character | Tag from which comparison statistics will be loaded from the given `store`. Defaults to `store_tag` if unspecified. |
 
 ### Quick Run
 

--- a/ops/ccs-ops-misc/load_test/README.md
+++ b/ops/ccs-ops-misc/load_test/README.md
@@ -112,7 +112,7 @@ Essentially, all the items you would set up in the config file are set in a sing
 
 **--resetStats** : (Optional) : If this flag is included, the test statistics will reset to zero after clients have finished spawning. **Note:** There are many reasons why we might want to capture statistics while new load is being added. There might be performance problems accepting the connection or new connections might affect users already connected to the system.
 
-**--storeStats**: (Optional) : Argument specifying that aggregated performance statistics should be stored to some location. This can either be to a local file or to an S3 bucket. This argument must be specified in the following format: `<STORAGE_TYPE>:<RUNNING_ENVIRONMENT>:<TAG>:<PATH_OR_BUCKET>`, where
+**--stats**: (Optional) : Argument specifying that aggregated performance statistics should be stored to some location. This can either be to a local file or to an S3 bucket. This argument must be specified in the following format: `<STORAGE_TYPE>:<RUNNING_ENVIRONMENT>:<TAG>:<PATH_OR_BUCKET>`, where
 
 * `STORAGE_TYPE` is either `file` or `s3`. 
   * Note that the `file` `STORAGE_TYPE` is primarily meant for _local debugging_ purposes and should not be used when running these tests as part of a process where the performance statistics should be stored for later retrieval. 

--- a/ops/ccs-ops-misc/load_test/README.md
+++ b/ops/ccs-ops-misc/load_test/README.md
@@ -112,7 +112,7 @@ Essentially, all the items you would set up in the config file are set in a sing
 
 **--resetStats** : (Optional) : If this flag is included, the test statistics will reset to zero after clients have finished spawning. **Note:** There are many reasons why we might want to capture statistics while new load is being added. There might be performance problems accepting the connection or new connections might affect users already connected to the system.
 
-**--stats**: (Optional) : Argument specifying that aggregated performance statistics should be collected and stored to some location. This can either be to a local file or to an S3 bucket. This argument must be specified as a list of key-value pairs seperated by semi-colons: `--stats="store=<file/s3>;env=<TEST/PROD>;tag=;path=;bucket=;compare=<previous/average>"`
+**--stats**: (Optional) : Argument specifying that aggregated performance statistics should be collected and stored to some location. This can either be to a local file or to an S3 bucket. This argument must be specified as a list of key-value pairs seperated by semi-colons: `--stats="store=<file/s3>;env=<TEST/PROD>;tag=;path=;bucket=;compare=<previous/average>;comp_tag=;athena_db="`
 
 | Key | Required? | Possible Values | Description |
 | :-: | :-: | :-: | - |
@@ -123,6 +123,7 @@ Essentially, all the items you would set up in the config file are set in a sing
 | `bucket` | Yes, _if `store` is `s3`_ | N/A | The AWS S3 Bucket that the JSON will be written to under a predetermined path following BFD Insights data organization standards.
 | `compare` | No | `previous`, `average` | Specifies if the current run should be compared to existing statistics. These statistics will be retrieved from the same type of store as specified by `store`. If `previous` is specified, the most recent run from `comp_tag` will be compared against. If `average` is specified, the average of _all_ previous runs from `comp_tag` will be compared against. If unspecified, no comparisons will be done.
 | `comp_tag` | No | Must be non-empty, consisting of letters, numbers and the `_` character | Tag from which comparison statistics will be loaded from the given `store`. Defaults to `store_tag` if unspecified. |
+| `athena_db` | Yes, _if `store` is `s3` **and** `compare` is set_ | N/A | Name of the database to query using Athena if `store` is `s3` and `compare` is set. |
 
 ### Quick Run
 

--- a/ops/ccs-ops-misc/load_test/common/bfd_user_base.py
+++ b/ops/ccs-ops-misc/load_test/common/bfd_user_base.py
@@ -204,7 +204,7 @@ def one_time_teardown(environment: Environment, **kwargs) -> None:
         logger.info("Writing aggregated performance statistics to file.")
 
         stats_json_writer = StatsJsonFileWriter(stats)
-        stats_json_writer.write(stats_config.file_path)
+        stats_json_writer.write(stats_config.path)
     elif stats_config.type == StatsStorageType.S3:
         logger.info("Writing aggregated performance statistics to S3.")
 

--- a/ops/ccs-ops-misc/load_test/common/bfd_user_base.py
+++ b/ops/ccs-ops-misc/load_test/common/bfd_user_base.py
@@ -198,7 +198,8 @@ def one_time_teardown(environment: Environment, **kwargs) -> None:
         return
 
     # If --stats was set and it is valid, get the aggregated stats of the stopping test run
-    stats = StatsCollector(environment, stats_config.store_tag, stats_config.env)
+    stats_collector = StatsCollector(environment, stats_config.store_tag, stats_config.env)
+    stats = stats_collector.all_stats
 
     if stats_config.store == StatsStorageType.FILE:
         logger.info("Writing aggregated performance statistics to file.")

--- a/ops/ccs-ops-misc/load_test/common/bfd_user_base.py
+++ b/ops/ccs-ops-misc/load_test/common/bfd_user_base.py
@@ -216,7 +216,7 @@ def one_time_teardown(environment: Environment, **kwargs) -> None:
                 # between the previous/average run and the current. Fail the test run, and log the
                 # failing tasks along with their relative stat percents   
                 environment.process_exit_code = 1
-                logger.error('Comparison against %s stats under "%s" tag failed; following tasks had stats that were at least %.2f%% slower: %s', 
+                logger.error('Comparison against %s stats under "%s" tag failed; following tasks had stats that exceeded %.2f%% of the baseline: %s', 
                             stats_config.compare.value, stats_config.comp_tag, DEFAULT_PERCENT_THRESHOLD, validation_result)
         else:
             logger.warn(

--- a/ops/ccs-ops-misc/load_test/common/bfd_user_base.py
+++ b/ops/ccs-ops-misc/load_test/common/bfd_user_base.py
@@ -199,7 +199,7 @@ def one_time_teardown(environment: Environment, **kwargs) -> None:
 
     # If --stats was set and it is valid, get the aggregated stats of the stopping test run
     stats_collector = StatsCollector(environment, stats_config.store_tag, stats_config.env)
-    stats = stats_collector.all_stats
+    stats = stats_collector.collect_stats()
 
     if stats_config.store == StatsStorageType.FILE:
         logger.info("Writing aggregated performance statistics to file.")

--- a/ops/ccs-ops-misc/load_test/common/bfd_user_base.py
+++ b/ops/ccs-ops-misc/load_test/common/bfd_user_base.py
@@ -200,12 +200,12 @@ def one_time_teardown(environment: Environment, **kwargs) -> None:
     # If --stats was set and it is valid, get the aggregated stats of the stopping test run
     stats = AggregatedStats(environment, PERCENTILES_TO_REPORT, stats_config.tag, stats_config.env)
 
-    if stats_config.type == StatsStorageType.FILE:
+    if stats_config.store == StatsStorageType.FILE:
         logger.info("Writing aggregated performance statistics to file.")
 
         stats_json_writer = StatsJsonFileWriter(stats)
         stats_json_writer.write(stats_config.path)
-    elif stats_config.type == StatsStorageType.S3:
+    elif stats_config.store == StatsStorageType.S3:
         logger.info("Writing aggregated performance statistics to S3.")
 
         stats_s3_writer = StatsJsonS3Writer(stats)

--- a/ops/ccs-ops-misc/load_test/common/bfd_user_base.py
+++ b/ops/ccs-ops-misc/load_test/common/bfd_user_base.py
@@ -198,7 +198,7 @@ def one_time_teardown(environment: Environment, **kwargs) -> None:
         return
 
     # If --stats was set and it is valid, get the aggregated stats of the stopping test run
-    stats = AggregatedStats(environment, PERCENTILES_TO_REPORT, stats_config.tag, stats_config.env)
+    stats = AggregatedStats(environment, PERCENTILES_TO_REPORT, stats_config.store_tag, stats_config.env)
 
     if stats_config.store == StatsStorageType.FILE:
         logger.info("Writing aggregated performance statistics to file.")

--- a/ops/ccs-ops-misc/load_test/common/bfd_user_base.py
+++ b/ops/ccs-ops-misc/load_test/common/bfd_user_base.py
@@ -198,7 +198,7 @@ def one_time_teardown(environment: Environment, **kwargs) -> None:
         return
 
     # If --stats was set and it is valid, get the aggregated stats of the stopping test run
-    stats = AggregatedStats(environment, PERCENTILES_TO_REPORT, stats_config.store_tag, stats_config.env)
+    stats = AggregatedStats(environment, stats_config.store_tag, stats_config.env)
 
     if stats_config.store == StatsStorageType.FILE:
         logger.info("Writing aggregated performance statistics to file.")

--- a/ops/ccs-ops-misc/load_test/common/bfd_user_base.py
+++ b/ops/ccs-ops-misc/load_test/common/bfd_user_base.py
@@ -7,7 +7,7 @@ import os
 
 from typing import Callable, Dict, List, Union
 from common import config, data, test_setup as setup, validation
-from common.stats.aggregated_stats import AggregatedStats, PERCENTILES_TO_REPORT
+from common.stats.aggregated_stats import StatsCollector, PERCENTILES_TO_REPORT
 from common.stats.stats_config import StatsStorageType
 from common.stats.stats_writers import StatsJsonFileWriter, StatsJsonS3Writer
 from common.url_path import create_url_path
@@ -198,7 +198,7 @@ def one_time_teardown(environment: Environment, **kwargs) -> None:
         return
 
     # If --stats was set and it is valid, get the aggregated stats of the stopping test run
-    stats = AggregatedStats(environment, stats_config.store_tag, stats_config.env)
+    stats = StatsCollector(environment, stats_config.store_tag, stats_config.env)
 
     if stats_config.store == StatsStorageType.FILE:
         logger.info("Writing aggregated performance statistics to file.")

--- a/ops/ccs-ops-misc/load_test/common/bfd_user_base.py
+++ b/ops/ccs-ops-misc/load_test/common/bfd_user_base.py
@@ -197,7 +197,7 @@ def one_time_teardown(environment: Environment, **kwargs) -> None:
     if stats_storage_config == None:
         return
 
-    # If --storeStats was set and it is valid, get the aggregated stats of the stopping test run
+    # If --stats was set and it is valid, get the aggregated stats of the stopping test run
     stats = AggregatedStats(environment, PERCENTILES_TO_REPORT, stats_storage_config.tag, stats_storage_config.stats_environment)
 
     if isinstance(stats_storage_config, StatsFileStorageConfig):

--- a/ops/ccs-ops-misc/load_test/common/config.py
+++ b/ops/ccs-ops-misc/load_test/common/config.py
@@ -121,7 +121,7 @@ def _stats_config_representer(dumper: yaml.SafeDumper, stats_config: StatsStorag
     Returns:
         yaml.nodes.ScalarNode: A scalar YAML node representing a StatsStorageConfig instance
     """
-    return dumper.represent_scalar('!StatsConfig', stats_config.to_arg_str())
+    return dumper.represent_scalar('!StatsConfig', stats_config.to_key_val_str())
 
 def _stats_config_constructor(loader: yaml.SafeLoader, node: yaml.nodes.ScalarNode) -> StatsStorageConfig:
     """Returns a scalar constructor that instructs PyYAML how to deserialize a StatsStorageConfig
@@ -134,7 +134,7 @@ def _stats_config_constructor(loader: yaml.SafeLoader, node: yaml.nodes.ScalarNo
     Returns:
         StatsStorageConfig: A StatsStorageConfig instance deserialized from its string scalar representation
     """
-    return StatsStorageConfig.from_arg_str(loader.construct_scalar(node))
+    return StatsStorageConfig.from_key_val_str(loader.construct_scalar(node))
 
 def _get_loader() -> yaml.SafeLoader:
     """Returns a PyYAML SafeLoader with custom constructors added to it.

--- a/ops/ccs-ops-misc/load_test/common/config.py
+++ b/ops/ccs-ops-misc/load_test/common/config.py
@@ -108,7 +108,7 @@ def load_stats_storage_config() -> StatsStorageConfig:
     """
 
     config_file = load()
-    return config_file["storeStats"]
+    return config_file["stats"]
 
 def _stats_config_representer(dumper: yaml.SafeDumper, stats_config: StatsStorageConfig) -> yaml.nodes.ScalarNode:
     """Returns a scalar representer that instructs PyYAML how to serialize a StatsStorageConfig instance

--- a/ops/ccs-ops-misc/load_test/common/config.py
+++ b/ops/ccs-ops-misc/load_test/common/config.py
@@ -6,7 +6,7 @@ from typing import Dict
 
 import yaml
 
-from common.stats.stats_config import StatsFileStorageConfig, StatsS3StorageConfig, StatsStorageConfig
+from common.stats.stats_config import StatsConfiguration
 
 def save(file_data: Dict[str, str]):
     '''Saves a config file using the input file data.
@@ -100,41 +100,41 @@ def load_server_public_key() -> str:
         return False
 
 
-def load_stats_storage_config() -> StatsStorageConfig:
+def load_stats_storage_config() -> StatsConfiguration:
     """Load the storage configuration for storing aggregated statistics.
 
     Returns:
-        StatsStorageConfig: A dataclass representing the storage configuration for aggregated statistics
+        StatsConfiguration: A dataclass representing the storage configuration for aggregated statistics
     """
 
     config_file = load()
     return config_file["stats"]
 
-def _stats_config_representer(dumper: yaml.SafeDumper, stats_config: StatsStorageConfig) -> yaml.nodes.ScalarNode:
-    """Returns a scalar representer that instructs PyYAML how to serialize a StatsStorageConfig instance
-    to an "arg string" in the format of "<STORAGE_TYPE>:<RUNNING_ENVIRONMENT>:<TAG>:<PATH_OR_BUCKET>".
+def _stats_config_representer(dumper: yaml.SafeDumper, stats_config: StatsConfiguration) -> yaml.nodes.ScalarNode:
+    """Returns a scalar representer that instructs PyYAML how to serialize a StatsConfiguration instance
+    to a key-value list seperated by semi-colons ("key1=value1;key2=value2").
 
     Args:
         dumper (yaml.SafeDumper): PyYAML's default SafeDumper instance
-        stats_config (StatsStorageConfig): An instance of StatsStorageConfig to serialize
+        stats_config (StatsConfiguration): An instance of StatsConfiguration to serialize
 
     Returns:
-        yaml.nodes.ScalarNode: A scalar YAML node representing a StatsStorageConfig instance
+        yaml.nodes.ScalarNode: A scalar YAML node representing a StatsConfiguration instance
     """
     return dumper.represent_scalar('!StatsConfig', stats_config.to_key_val_str())
 
-def _stats_config_constructor(loader: yaml.SafeLoader, node: yaml.nodes.ScalarNode) -> StatsStorageConfig:
-    """Returns a scalar constructor that instructs PyYAML how to deserialize a StatsStorageConfig
-    instance from an "arg string" in the format of "<STORAGE_TYPE>:<RUNNING_ENVIRONMENT>:<TAG>:<PATH_OR_BUCKET>".
+def _stats_config_constructor(loader: yaml.SafeLoader, node: yaml.nodes.ScalarNode) -> StatsConfiguration:
+    """Returns a scalar constructor that instructs PyYAML how to deserialize a StatsConfiguration
+    instance from a key-value list seperated by semi-colons ("key1=value1;key2=value2").
 
     Args:
         loader (yaml.SafeLoader): PyYAML's default SafeLoader instance
         node (yaml.nodes.ScalarNode): A YAML scalar node with a string value representing a StatsStorageConfing instance
 
     Returns:
-        StatsStorageConfig: A StatsStorageConfig instance deserialized from its string scalar representation
+        StatsConfiguration: A StatsConfiguration instance deserialized from its string scalar representation
     """
-    return StatsStorageConfig.from_key_val_str(loader.construct_scalar(node))
+    return StatsConfiguration.from_key_val_str(loader.construct_scalar(node))
 
 def _get_loader() -> yaml.SafeLoader:
     """Returns a PyYAML SafeLoader with custom constructors added to it.
@@ -154,8 +154,6 @@ def _get_dumper() -> yaml.SafeDumper:
         yaml.SafeDumper: A PyYAML SafeDumper with custom representers added to it
     """
     safe_dumper = yaml.SafeDumper
-    safe_dumper.add_representer(StatsStorageConfig, _stats_config_representer)
-    safe_dumper.add_representer(StatsFileStorageConfig, _stats_config_representer)
-    safe_dumper.add_representer(StatsS3StorageConfig, _stats_config_representer)
+    safe_dumper.add_representer(StatsConfiguration, _stats_config_representer)
 
     return safe_dumper

--- a/ops/ccs-ops-misc/load_test/common/stats/aggregated_stats.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/aggregated_stats.py
@@ -25,14 +25,14 @@ class StatsCollector(object):
         self.stats_tag = stats_tag
         self.running_env = running_env
 
-    def _get_task_stats_list(self) -> List['TaskStats']:
-        """Returns a list of TaskStats representing the performance statistics of _all_ Locust tasks that ran
+    def _get_task_stats_dict(self) -> Dict[str, 'TaskStats']:
+        """Returns a dictionary of the name of a task to its TaskStats representing the performance statistics of _all_ Locust tasks that ran
 
         Returns:
-            List[TaskStats]: A List of TaskStats that represent the performance statistics of all Locust tasks
+            List[TaskStats]: A a dictionary of the name of a task to its TaskStats
         """
         stats = self.locust_env.stats
-        return [TaskStats.from_stats_entry(stats_entry) for stats_entry in sort_stats(stats.entries)]
+        return {task.task_name: task for task in (TaskStats.from_stats_entry(stats_entry) for stats_entry in sort_stats(stats.entries))}
 
     def collect_stats(self) -> 'AggregatedStats':
         """A method that returns an AggregatedStats instance representing a snapshot of the aggregated performance
@@ -43,7 +43,7 @@ class StatsCollector(object):
         """
         return AggregatedStats(metadata=StatsMetadata.from_locust_env(timestamp=int(time.time()), tag=self.stats_tag,
                                                                       environment=self.running_env, locust_env=self.locust_env),
-                               tasks_stats=self._get_task_stats_list())
+                               tasks=self._get_task_stats_dict())
 
 
 @dataclass
@@ -157,5 +157,5 @@ class AggregatedStats():
     metadata necessary for comparison and storage"""
     metadata: StatsMetadata
     """An instance of StatsMetadata that encapsulates the necessary metadata about the set of Task statistics"""
-    tasks_stats: List[TaskStats]
-    """A list of TaskStats where each entry represents the performance statistics of each Task"""
+    tasks: Dict[str, TaskStats]
+    """A dictionary of the name of a task to its TaskStats where each entry represents the performance statistics of each Task"""

--- a/ops/ccs-ops-misc/load_test/common/stats/aggregated_stats.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/aggregated_stats.py
@@ -72,7 +72,8 @@ class TaskStats():
     total_fails_per_sec: float
     """The average number of failures-per-second of this Task's requests over the test run"""
     response_time_percentiles: Dict[str, int]
-    """A dictionary of response time percentiles to the number of responses under that percentile"""
+    """A dictionary of response time percentiles indicating the percentage of requests that completed
+    in a particular timeframe"""
 
     @classmethod
     def from_stats_entry(cls, stats_entry: StatsEntry) -> 'TaskStats':
@@ -117,13 +118,14 @@ class TaskStats():
 
     @classmethod
     def __get_percentiles_dict(cls, stats_entry: StatsEntry) -> Dict[str, int]:
-        """Returns a dictionary of response time percentiles to the number of responses under that percentile
+        """Returns a dictionary of response time percentiles indicating the percentage of requests that completed
+        in a particular timeframe
 
         Args:
             stats_entry (StatsEntry): The Locust StatsEntry object which encodes a particular task's statistics
 
         Returns:
-            Dict[str, int]: A dictionary of response time percentiles to the number of responses under that percentile
+            Dict[str, int]: A dictionary of response time percentiles
         """
         if not stats_entry.num_requests:
             # If there were no requests made, simply return a dictionary with 0

--- a/ops/ccs-ops-misc/load_test/common/stats/aggregated_stats.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/aggregated_stats.py
@@ -1,3 +1,5 @@
+"""Members of this file/module should be related to the collection of performance statistics during
+a test run as well as the representation of those statistics via dataclasses or other suitable objects"""
 from dataclasses import dataclass, fields
 from locust.stats import StatsEntry, sort_stats, PERCENTILES_TO_REPORT
 from locust.env import Environment

--- a/ops/ccs-ops-misc/load_test/common/stats/aggregated_stats.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/aggregated_stats.py
@@ -159,3 +159,11 @@ class AggregatedStats():
     """An instance of StatsMetadata that encapsulates the necessary metadata about the set of Task statistics"""
     tasks: List[TaskStats]
     """A list of TaskStats where each entry represents the performance statistics of each Task"""
+
+    def __post_init__(self):
+        # Support conversion directly from a nested dictionary, such as when loading from JSON files
+        # or from Athena
+        if isinstance(self.metadata, dict):
+            self.metadata = StatsMetadata(**self.metadata)
+        if isinstance(self.tasks, list) and all(isinstance(task_dict, dict) for task_dict in self.tasks):
+            self.tasks = [TaskStats(**task_dict) for task_dict in self.tasks]

--- a/ops/ccs-ops-misc/load_test/common/stats/aggregated_stats.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/aggregated_stats.py
@@ -42,7 +42,7 @@ class AggregatedStats(object):
         Returns:
             str: A human-readable percent string (i.e. "100%", "95%") for the given percentile number
         """
-        return f"{int(percentile * 100) if (percentile * 100).is_integer() else round(100 * percentile, 6)}%"
+        return f"{int(percentile * 100) if (percentile * 100).is_integer() else round(100 * percentile, 6)}"
 
     def _get_percentiles_dict(self, stats_entry: StatsEntry) -> Dict[str, int]:
         """Returns a dictionary of a human-readable percentile string to its reported value

--- a/ops/ccs-ops-misc/load_test/common/stats/aggregated_stats.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/aggregated_stats.py
@@ -1,8 +1,8 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from locust.stats import StatsEntry, sort_stats, PERCENTILES_TO_REPORT
 from locust.env import Environment
 import time
-from typing import Dict, List
+from typing import Any, Dict, List, Optional
 
 from common.stats.stats_config import StatsEnvironment
 
@@ -95,6 +95,27 @@ class TaskStats():
                    response_time_percentiles=cls.__get_percentiles_dict(stats_entry))
 
     @classmethod
+    def from_list(cls, values: List[Any]) -> 'TaskStats':
+        """Constructs a new instance of TaskStats given a List of values in field declaration order.
+        Used primarily to construct a TaskStats from Athena queries
+
+        Args:
+            values (List[Any]): A List of TaskStats values in field declaration order
+
+        Returns:
+            TaskStats: A TaskStats instance representing the values from the given List
+        """
+        # We assume the list is in field declaration order, otherwise we cannot
+        # create a TaskStats from it
+        inter_dict = {field.name: values[i]
+                      for i, field in enumerate(fields(cls))}
+        # response_time_percentiles will be a list as well, we need to convert it to a dict
+        inter_dict['response_time_percentiles'] = {str(percentile): inter_dict['response_time_percentiles'][i]
+                                                   for i, percentile in enumerate(PERCENTILES_TO_REPORT)}
+
+        return TaskStats(**inter_dict)
+
+    @classmethod
     def __get_percentiles_dict(cls, stats_entry: StatsEntry) -> Dict[str, int]:
         """Returns a dictionary of response time percentiles to the number of responses under that percentile
 
@@ -155,7 +176,7 @@ class StatsMetadata():
 class AggregatedStats():
     """A dataclass encoding the entirety of performance statistics for every Locust Task along with
     metadata necessary for comparison and storage"""
-    metadata: StatsMetadata
+    metadata: Optional[StatsMetadata]
     """An instance of StatsMetadata that encapsulates the necessary metadata about the set of Task statistics"""
     tasks: List[TaskStats]
     """A list of TaskStats where each entry represents the performance statistics of each Task"""

--- a/ops/ccs-ops-misc/load_test/common/stats/aggregated_stats.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/aggregated_stats.py
@@ -5,30 +5,22 @@ from typing import Dict, List
 
 from common.stats.stats_config import StatsEnvironment
 
-# We are re-exporting Locust's default percentiles list here so that consumers of members
-# of this file do not need to also import from the locust.stats module if they want to use
-# the default reporting percentiles
-PERCENTILES_TO_REPORT = PERCENTILES_TO_REPORT
-"""A list of floating-point percentiles to report when generating JSON performance reports"""
-
 
 class AggregatedStats(object):
     """Represents a snapshot of aggregated performance statistics of all tasks, or endpoints, that
     ran in the current Locust environment"""
 
-    def __init__(self, locust_env: Environment, percentiles_to_report: List[float], stats_tag: str, running_env: StatsEnvironment = StatsEnvironment.TEST) -> None:
+    def __init__(self, locust_env: Environment, stats_tag: str, running_env: StatsEnvironment = StatsEnvironment.TEST) -> None:
         """Creates a new instance of AggregatedStats given the current Locust environment and a list of percentiles to report.
 
         Args:
             locust_env (Environment): Current Locust environment
-            percentiles_to_report (List[float]): List of percentiles to report in the generated JSON
             stats_tag (str): A string which tags the output JSON; used to distinguish between separate test runs
             running_env (StatsEnvironment, optional): A StatsEnvironment enum which represents the current testing environment; either TEST or PROD. Defaults to TEST.
         """
         super().__init__()
         self.locust_env = locust_env
-        self.percentiles_to_report = percentiles_to_report
-        self.percentiles_na = ["N/A"] * len(self.percentiles_to_report)
+        self.percentiles_na = ["N/A"] * len(PERCENTILES_TO_REPORT)
 
         self.stats_tag = stats_tag
         self.running_env = running_env
@@ -56,7 +48,7 @@ class AggregatedStats(object):
         if not stats_entry.num_requests:
             return self.percentiles_na
 
-        return {self._get_readable_percentile(percentile): int(stats_entry.get_response_time_percentile(percentile) or 0) for percentile in self.percentiles_to_report}
+        return {self._get_readable_percentile(percentile): int(stats_entry.get_response_time_percentile(percentile) or 0) for percentile in PERCENTILES_TO_REPORT}
 
     def _get_stats_entry_dict(self, stats_entry: StatsEntry) -> Dict[str, any]:
         """Returns a dictionary representation of a StatsEntry object

--- a/ops/ccs-ops-misc/load_test/common/stats/aggregated_stats.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/aggregated_stats.py
@@ -71,7 +71,7 @@ class TaskStats():
     """The average number of requests-per-second of this Taks's requests over the test run"""
     total_fails_per_sec: float
     """The average number of failures-per-second of this Task's requests over the test run"""
-    response_time_percentiles: Dict[float, int]
+    response_time_percentiles: Dict[str, int]
     """A dictionary of response time percentiles to the number of responses under that percentile"""
 
     @classmethod
@@ -95,7 +95,7 @@ class TaskStats():
                    response_time_percentiles=cls.__get_percentiles_dict(stats_entry))
 
     @classmethod
-    def __get_percentiles_dict(cls, stats_entry: StatsEntry) -> Dict[float, int]:
+    def __get_percentiles_dict(cls, stats_entry: StatsEntry) -> Dict[str, int]:
         """Returns a dictionary of response time percentiles to the number of responses under that percentile
 
         Args:
@@ -109,7 +109,7 @@ class TaskStats():
             # for each of its values
             return {k: 0 for k in PERCENTILES_TO_REPORT}
 
-        return {percentile: int(stats_entry.get_response_time_percentile(percentile) or 0)
+        return {str(percentile): int(stats_entry.get_response_time_percentile(percentile) or 0)
                 for percentile in PERCENTILES_TO_REPORT}
 
 

--- a/ops/ccs-ops-misc/load_test/common/stats/aggregated_stats.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/aggregated_stats.py
@@ -25,14 +25,14 @@ class StatsCollector(object):
         self.stats_tag = stats_tag
         self.running_env = running_env
 
-    def _get_task_stats_dict(self) -> Dict[str, 'TaskStats']:
-        """Returns a dictionary of the name of a task to its TaskStats representing the performance statistics of _all_ Locust tasks that ran
+    def _get_task_stats_list(self) -> List['TaskStats']:
+        """Returns a list of TaskStats representing the performance statistics of _all_ Locust tasks that ran
 
         Returns:
-            List[TaskStats]: A a dictionary of the name of a task to its TaskStats
+            List[TaskStats]: A List of TaskStats that represent the performance statistics of all Locust tasks
         """
         stats = self.locust_env.stats
-        return {task.task_name: task for task in (TaskStats.from_stats_entry(stats_entry) for stats_entry in sort_stats(stats.entries))}
+        return [TaskStats.from_stats_entry(stats_entry) for stats_entry in sort_stats(stats.entries)]
 
     def collect_stats(self) -> 'AggregatedStats':
         """A method that returns an AggregatedStats instance representing a snapshot of the aggregated performance
@@ -43,7 +43,7 @@ class StatsCollector(object):
         """
         return AggregatedStats(metadata=StatsMetadata.from_locust_env(timestamp=int(time.time()), tag=self.stats_tag,
                                                                       environment=self.running_env, locust_env=self.locust_env),
-                               tasks=self._get_task_stats_dict())
+                               tasks=self._get_task_stats_list())
 
 
 @dataclass
@@ -157,5 +157,5 @@ class AggregatedStats():
     metadata necessary for comparison and storage"""
     metadata: StatsMetadata
     """An instance of StatsMetadata that encapsulates the necessary metadata about the set of Task statistics"""
-    tasks: Dict[str, TaskStats]
-    """A dictionary of the name of a task to its TaskStats where each entry represents the performance statistics of each Task"""
+    tasks: List[TaskStats]
+    """A list of TaskStats where each entry represents the performance statistics of each Task"""

--- a/ops/ccs-ops-misc/load_test/common/stats/aggregated_stats.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/aggregated_stats.py
@@ -34,9 +34,8 @@ class StatsCollector(object):
         stats = self.locust_env.stats
         return [TaskStats.from_stats_entry(stats_entry) for stats_entry in sort_stats(stats.entries)]
 
-    @property
-    def all_stats(self) -> 'AggregatedStats':
-        """A property that returns an AggregatedStats instance representing a snapshot of the aggregated performance
+    def collect_stats(self) -> 'AggregatedStats':
+        """A method that returns an AggregatedStats instance representing a snapshot of the aggregated performance
         statistics of the current Locust environment at current time.
 
         Returns:

--- a/ops/ccs-ops-misc/load_test/common/stats/aggregated_stats.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/aggregated_stats.py
@@ -6,12 +6,12 @@ from typing import Dict, List
 from common.stats.stats_config import StatsEnvironment
 
 
-class AggregatedStats(object):
-    """Represents a snapshot of aggregated performance statistics of all tasks, or endpoints, that
+class StatsCollector(object):
+    """Used to collect a snapshot of aggregated performance statistics of all tasks, or endpoints, that
     ran in the current Locust environment"""
 
     def __init__(self, locust_env: Environment, stats_tag: str, running_env: StatsEnvironment = StatsEnvironment.TEST) -> None:
-        """Creates a new instance of AggregatedStats given the current Locust environment and a list of percentiles to report.
+        """Creates a new instance of StatsCollector given the current Locust environment and a list of percentiles to report.
 
         Args:
             locust_env (Environment): Current Locust environment

--- a/ops/ccs-ops-misc/load_test/common/stats/aggregated_stats.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/aggregated_stats.py
@@ -1,4 +1,4 @@
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from locust.stats import StatsEntry, sort_stats, PERCENTILES_TO_REPORT
 from locust.env import Environment
 import time
@@ -43,7 +43,7 @@ class StatsCollector(object):
             AggregatedStats: An instance of AggregatedStats representing a snapshot of all stats at the current time
         """
         return AggregatedStats(metadata=StatsMetadata.from_locust_env(timestamp=int(time.time()), tag=self.stats_tag,
-                                                               environment=self.running_env, locust_env=self.locust_env),
+                                                                      environment=self.running_env, locust_env=self.locust_env),
                                tasks_stats=self._get_task_stats_list())
 
 

--- a/ops/ccs-ops-misc/load_test/common/stats/aggregated_stats.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/aggregated_stats.py
@@ -65,8 +65,6 @@ class TaskStats():
     """The fastest response time, in seconds, out of all this Task's requests"""
     max_response_time: float
     """The slowest respone time, in seconds, out of all this Task's requests"""
-    average_content_length: float
-    """The average length of a response from this Task's requests"""
     total_reqs_per_second: float
     """The average number of requests-per-second of this Taks's requests over the test run"""
     total_fails_per_sec: float
@@ -90,7 +88,6 @@ class TaskStats():
                    num_requests=stats_entry.num_requests, num_failures=stats_entry.num_failures,
                    median_response_time=stats_entry.median_response_time, average_response_time=stats_entry.avg_response_time,
                    min_response_time=stats_entry.min_response_time or 0, max_response_time=stats_entry.max_response_time,
-                   average_content_length=stats_entry.avg_content_length,
                    total_reqs_per_second=stats_entry.total_rps,
                    total_fails_per_sec=stats_entry.total_fail_per_sec,
                    response_time_percentiles=cls.__get_percentiles_dict(stats_entry))

--- a/ops/ccs-ops-misc/load_test/common/stats/stats_compare.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/stats_compare.py
@@ -1,0 +1,78 @@
+from dataclasses import dataclass
+from typing import List, Union
+from common.stats.aggregated_stats import TaskStats
+
+
+@dataclass
+class StatDelta:
+    stat: str
+    """The name of the stat"""
+    delta: float
+    """The perent delta difference; larger values indicate worse performance"""
+
+
+def get_stats_delta(previous: TaskStats, current: TaskStats) -> List[StatDelta]:
+    """Compute the percentage difference between two TaskStats instances by comparing
+    each of their stat fields and return the corresponding percentage deltas
+
+    Args:
+        previous (TaskStats): The TaskStats to compare against
+        current (TaskStats): The TaskStats representing the statistics of the current run for a given Locust Task
+
+    Returns:
+        List[StatDelta]: A list of deltas for each stat field in the current TaskStats
+    """
+    # Here we define lists of TaskStats fields that will be compared depending on
+    # whether a larger value is better (i.e. more requests per second) or a smaller
+    # value is better (i.e. less failures). This determines which of the two TaskStats
+    # (previous or current) is the dividend and divisor, as order matters.
+    fields_higher_better = ['num_requests', 'total_reqs_per_second']
+    fields_lower_better = ['num_failures', 'median_response_time', 'average_response_time',
+                           'min_response_time', 'max_response_time', 'total_fails_per_sec']
+
+    # Uses list comprehension to compute how much greater/lesser in percent (percent delta)
+    # each field is when comparing a previous run of the given task versus the current run.
+    deltas_higher = [StatDelta(field, _safe_division(getattr(previous, field),
+                                                     getattr(current, field))) for field in fields_higher_better]
+    deltas_lower = [StatDelta(field, _safe_division(getattr(current, field),
+                                                    getattr(previous, field))) for field in fields_lower_better]
+
+    # Percentiles are stored as a dict within TaskStats, so we need to get the keys common to
+    # both TaskStats and use those as the field names (hence why getattr() isn't being used)
+    prev_percents = previous.response_time_percentiles
+    cur_percents = current.response_time_percentiles
+    percents = prev_percents.keys() & cur_percents.keys()
+    deltas_percents = [StatDelta(_get_readable_percentile(p), _safe_division(cur_percents[p],
+                                                                             prev_percents[p])) for p in percents]
+
+    # Combine all of the lists created above into a single list with all of the important
+    # stats and their percentage deltas
+    return deltas_higher + deltas_lower + deltas_percents
+
+
+def get_stats_above_threshold(stat_deltas: List[StatDelta], threshold: float = 500.0) -> List[StatDelta]:
+    """Computes the list of StatDeltas whose percentage deltas exceed a given threshold, defaulting to
+    500% (or 5x)
+
+    Args:
+        stat_deltas (List[StatDelta]): A list of deltas between the current run of a Task and a previous run of a Task
+        threshold (float, optional): Percentage threshold that the delta should not exceed. Defaults to 500.0.
+
+    Returns:
+        List[StatDelta]: A filtered list of stats with deltas that exceed the given threshold
+    """
+    return [stat_delta for stat_delta in stat_deltas if stat_delta.delta > threshold]
+
+
+def _safe_division(dividend: Union[float, int], divisor: Union[float, int]) -> float:
+    # Often some fields will be 0 (such as the failure stats), and dividing by 0 results
+    # in an error. So, we can check first if the divisor is 0 before dividing to ensure we don't
+    # raise an error unexpectedly when comparing stats
+    if divisor == 0:
+        return 0
+
+    return dividend / divisor
+
+
+def _get_readable_percentile(percentile: float) -> str:
+    return f"{int(percentile * 100) if (percentile * 100).is_integer() else round(100 * percentile, 6)}%"

--- a/ops/ccs-ops-misc/load_test/common/stats/stats_compare.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/stats_compare.py
@@ -1,3 +1,6 @@
+"""Members of this file/module are related to the comparison and subsequent validation 
+of performance statistics against a previous set of statistics or an average of all
+previous statistics"""
 from dataclasses import dataclass
 from typing import Dict, List, Union
 from common.stats.aggregated_stats import AggregatedStats, TaskStats
@@ -13,9 +16,10 @@ class StatPercent:
     stat: str
     """The name of the stat"""
     percent: float
-    """The percent value of this stat's value versus a previous run's, i.e. this stat is percent% worse than
-    the previous run or average of all runs. A value of 100 means no change, whereas values lower than 100 generally
-    indicate positive change and values greater than 100 indicate negative change"""
+    """The percent value of this stat's value versus a previous run's, i.e. this stat is percent% times worse than
+    the previous run or average of all runs. A value of 100 means no change (i.e. current stat is 100% 
+    of a previous snapshot of the same stat), whereas values lower than 100 generally indicate
+    positive change and values greater than 100 indicate negative change"""
 
 
 def get_stats_relative_percent(previous: TaskStats, current: TaskStats) -> List[StatPercent]:

--- a/ops/ccs-ops-misc/load_test/common/stats/stats_compare.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/stats_compare.py
@@ -1,18 +1,22 @@
 """Members of this file/module are related to the comparison and subsequent validation 
 of performance statistics against a previous set of statistics or an average of all
 previous statistics"""
-from dataclasses import dataclass
-from typing import Dict, List, Union
+from dataclasses import asdict, dataclass
+from typing import Dict, List, Set, Type, Union
 from common.stats.aggregated_stats import AggregatedStats, TaskStats
+
+TaskStatsOrPercentiles = type(Union[TaskStats, Dict[str, int]])
+"""Type indicating a value that is either a TaskStats instance or a response time
+percentiles dictionary"""
 
 DEFAULT_PERCENT_THRESHOLD = 500.0
 """The default percent threshold that stats should not exceed or be worse than compared to a previous or average run"""
 
 
 @dataclass
-class StatPercent:
-    """Dataclass representing a given TaskStats field/stat and the percent relativity between the current run's value
-    and a previous run's value of the same stat"""
+class StatCompareResult:
+    """Dataclass representing the result of a comparison between the baseline/previous value of a
+    TaskStats stat and the current value of said stat"""
     stat: str
     """The name of the stat"""
     percent: float
@@ -20,61 +24,63 @@ class StatPercent:
     the previous run or average of all runs. A value of 100 means no change (i.e. current stat is 100% 
     of a previous snapshot of the same stat), whereas values lower than 100 generally indicate
     positive change and values greater than 100 indicate negative change"""
+    baseline: Union[float, int]
+    """The value of the stat that the stat's current value is being compared against"""
+    current: Union[float, int]
+    """The value of the stat from the current test run"""
 
 
-def get_stats_relative_percent(previous: TaskStats, current: TaskStats) -> List[StatPercent]:
-    """Compute the percent relativity (i.e. previous is n% of current) between two TaskStats
-    instances by comparing each of their stat fields
+def get_stats_compare_results(previous: TaskStats, current: TaskStats) -> List[StatCompareResult]:
+    """Get the comparison results between two TaskStats instances by comparing each of their stat fields
 
     Args:
         previous (TaskStats): The TaskStats to compare against
         current (TaskStats): The TaskStats representing the statistics of the current run for a given Locust Task
 
     Returns:
-        List[StatPercent]: A list of percent relativity indicating how much worse or better each stat is for each stat field in the current TaskStats
+        List[StatCompareResult]: A list of comparison results for each TasksStats stats
     """
-    # Here we define lists of TaskStats fields that will be compared depending on
+    # Here we define sets of TaskStats fields that will be compared depending on
     # whether a larger value is better (i.e. more requests per second) or a smaller
     # value is better (i.e. less failures). This determines which of the two TaskStats
     # (previous or current) is the dividend and divisor, as order matters.
-    fields_higher_better = ['num_requests', 'total_reqs_per_second']
-    fields_lower_better = ['num_failures', 'median_response_time', 'average_response_time',
-                           'min_response_time', 'max_response_time', 'total_fails_per_sec']
+    fields_higher_better = {'num_requests', 'total_reqs_per_second'}
+    fields_lower_better = {'num_failures', 'median_response_time', 'average_response_time',
+                           'min_response_time', 'max_response_time', 'total_fails_per_sec'}
 
-    # Uses list comprehension to compute how much greater/lesser in percent (percent delta)
-    # each field is when comparing a previous run of the given task versus the current run.
-    percents_higher = [StatPercent(field, _safe_division(getattr(previous, field),
-                                                         getattr(current, field)) * 100.0) for field in fields_higher_better]
-    percents_lower = [StatPercent(field, _safe_division(getattr(current, field),
-                                                        getattr(previous, field)) * 100.0) for field in fields_lower_better]
+    # Compute the list of StatCompareResults for each type of field
+    results_higher = _compute_results_list(previous, current, fields_higher_better, 
+                                           is_higher_val_better=True)
+    results_lower = _compute_results_list(previous, current, fields_lower_better,
+                                          is_higher_val_better=False)
 
     # Percentiles are stored as a dict within TaskStats, so we need to get the keys common to
-    # both TaskStats and use those as the field names (hence why getattr() isn't being used)
+    # both response percentiles dicts
     prev_percentiles = previous.response_time_percentiles
     cur_percentiles = current.response_time_percentiles
     percentiles = prev_percentiles.keys() & cur_percentiles.keys()
-    percents_percentiles = [StatPercent(p, _safe_division(cur_percentiles[p],
-                                                          prev_percentiles[p]) * 100.0) for p in percentiles]
+    results_percentiles = _compute_results_list(prev_percentiles, cur_percentiles, percentiles,
+                                                is_higher_val_better=False)
 
     # Combine all of the lists created above into a single list with all of the important
-    # stats and their relative percentages
-    return percents_higher + percents_lower + percents_percentiles
+    # stats and their comparison results
+    return results_higher + results_lower + results_percentiles
 
 
-def get_stats_above_threshold(stat_percents: List[StatPercent], threshold: float) -> List[StatPercent]:
-    """Computes the list of StatPercents whose relative percentages exceed a given threshold
+def get_stats_above_threshold(compare_results: List[StatCompareResult], threshold: float) -> List[StatCompareResult]:
+    """Computes the list of  whose relative percentages exceed a given threshold
 
     Args:
-        stat_percents (List[StatPercent]): A list of relative stat percents to the current run of a Task and a previous run of a Task
+        stat_percents (List[StatCompareResult]): A list of comparison results between the baseline and current run
         threshold (float, optional): Percentage threshold that the delta should not exceed. Defaults to 500.0.
 
     Returns:
-        List[StatPercent]: A filtered list of stats with relative percent increase that exceed the given threshold
+        List[StatCompareResult]: A filtered list of comparison results that exceed the threshold percentage given
     """
-    return [stat_delta for stat_delta in stat_percents if stat_delta.percent > threshold]
+    return [stat_delta for stat_delta in compare_results if stat_delta.percent > threshold]
 
 
-def validate_aggregated_stats(previous: AggregatedStats, current: AggregatedStats, threshold: float = DEFAULT_PERCENT_THRESHOLD) -> Dict[str, List[StatPercent]]:
+def validate_aggregated_stats(previous: AggregatedStats, current: AggregatedStats, threshold: float = DEFAULT_PERCENT_THRESHOLD) -> Dict[str, List[StatCompareResult]]:
     """Validates and compares the given AggregatedStats instances against each other, checking each of their common
     TaskStats and returning a dictionary of the name of those tasks that exceed the given threshold to the actual stats
     that failed
@@ -85,7 +91,7 @@ def validate_aggregated_stats(previous: AggregatedStats, current: AggregatedStat
         threshold (float, optional): A percent threshold that the current run's task's stats must not exceed/be worse than. Defaults to DEFAULT_PERCENT_THRESHOLD
 
     Returns:
-        Dict[str, List[StatPercent]]: A dictionary of failing task names to the stats that failed along with their percent relativity
+        Dict[str, List[StatCompareResult]]: A dictionary of failing task names to the stats that failed along with their comparison results
     """
     prev_tasks = {task.task_name: task for task in previous.tasks}
     cur_tasks = {task.task_name: task for task in current.tasks}
@@ -96,13 +102,28 @@ def validate_aggregated_stats(previous: AggregatedStats, current: AggregatedStat
         prev_task = prev_tasks[task]
         cur_task = cur_tasks[task]
 
-        deltas = get_stats_relative_percent(prev_task, cur_task)
+        deltas = get_stats_compare_results(prev_task, cur_task)
         failed_deltas = get_stats_above_threshold(deltas, threshold)
         if failed_deltas != []:
             failed_tasks_with_percents[task] = failed_deltas
 
     return failed_tasks_with_percents
 
+
+def _compute_results_list(previous: TaskStatsOrPercentiles, current: TaskStatsOrPercentiles,
+                          keys: Set[str], is_higher_val_better: bool) -> List[StatCompareResult]:
+    # Convert TaskStats instances to dicts so that we can use the same logic for both
+    prev_dict = asdict(previous) if isinstance(previous, TaskStats) else previous
+    cur_dict = asdict(current) if isinstance(current, TaskStats) else current
+    
+    # Uses list comprehension to compute the relative percent "worseness" of a given stat in the 
+    # dict when comparing a previous run of the given stats versus the current run.
+    dividend = prev_dict if is_higher_val_better else cur_dict
+    divisor = cur_dict if is_higher_val_better else prev_dict
+    return [StatCompareResult(key,
+                              _safe_division(dividend[key], divisor[key]) * 100.0,
+                              baseline=prev_dict[key], current=cur_dict[key])
+            for key in keys]
 
 def _safe_division(dividend: Union[float, int], divisor: Union[float, int]) -> float:
     # Often some fields will be 0 (such as the failure stats), and dividing by 0 results

--- a/ops/ccs-ops-misc/load_test/common/stats/stats_compare.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/stats_compare.py
@@ -1,26 +1,33 @@
 from dataclasses import dataclass
-from typing import List, Union
-from common.stats.aggregated_stats import TaskStats
+from typing import Dict, List, Union
+from common.stats.aggregated_stats import AggregatedStats, TaskStats
+
+DEFAULT_PERCENT_THRESHOLD = 500.0
+"""The default percent threshold that stats should not exceed or be worse than compared to a previous or average run"""
 
 
 @dataclass
-class StatDelta:
+class StatPercent:
+    """Dataclass representing a given TaskStats field/stat and the percent relativity between the current run's value
+    and a previous run's value of the same stat"""
     stat: str
     """The name of the stat"""
-    delta: float
-    """The perent delta difference; larger values indicate worse performance"""
+    percent: float
+    """The percent value of this stat's value versus a previous run's, i.e. this stat is percent% worse than
+    the previous run or average of all runs. A value of 100 means no change, whereas values lower than 100 generally
+    indicate positive change and values greater than 100 indicate negative change"""
 
 
-def get_stats_delta(previous: TaskStats, current: TaskStats) -> List[StatDelta]:
-    """Compute the percentage difference between two TaskStats instances by comparing
-    each of their stat fields and return the corresponding percentage deltas
+def get_stats_relative_percent(previous: TaskStats, current: TaskStats) -> List[StatPercent]:
+    """Compute the percent relativity (i.e. previous is n% of current) between two TaskStats
+    instances by comparing each of their stat fields
 
     Args:
         previous (TaskStats): The TaskStats to compare against
         current (TaskStats): The TaskStats representing the statistics of the current run for a given Locust Task
 
     Returns:
-        List[StatDelta]: A list of deltas for each stat field in the current TaskStats
+        List[StatPercent]: A list of percent relativity indicating how much worse or better each stat is for each stat field in the current TaskStats
     """
     # Here we define lists of TaskStats fields that will be compared depending on
     # whether a larger value is better (i.e. more requests per second) or a smaller
@@ -32,36 +39,65 @@ def get_stats_delta(previous: TaskStats, current: TaskStats) -> List[StatDelta]:
 
     # Uses list comprehension to compute how much greater/lesser in percent (percent delta)
     # each field is when comparing a previous run of the given task versus the current run.
-    deltas_higher = [StatDelta(field, _safe_division(getattr(previous, field),
-                                                     getattr(current, field))) for field in fields_higher_better]
-    deltas_lower = [StatDelta(field, _safe_division(getattr(current, field),
-                                                    getattr(previous, field))) for field in fields_lower_better]
+    percents_higher = [StatPercent(field, _safe_division(getattr(previous, field),
+                                                         getattr(current, field)) * 100.0) for field in fields_higher_better]
+    percents_lower = [StatPercent(field, _safe_division(getattr(current, field),
+                                                        getattr(previous, field)) * 100.0) for field in fields_lower_better]
 
     # Percentiles are stored as a dict within TaskStats, so we need to get the keys common to
     # both TaskStats and use those as the field names (hence why getattr() isn't being used)
-    prev_percents = previous.response_time_percentiles
-    cur_percents = current.response_time_percentiles
-    percents = prev_percents.keys() & cur_percents.keys()
-    deltas_percents = [StatDelta(_get_readable_percentile(p), _safe_division(cur_percents[p],
-                                                                             prev_percents[p])) for p in percents]
+    prev_percentiles = previous.response_time_percentiles
+    cur_percentiles = current.response_time_percentiles
+    percentiles = prev_percentiles.keys() & cur_percentiles.keys()
+    percents_percentiles = [StatPercent(p, _safe_division(cur_percentiles[p],
+                                                          prev_percentiles[p]) * 100.0) for p in percentiles]
 
     # Combine all of the lists created above into a single list with all of the important
-    # stats and their percentage deltas
-    return deltas_higher + deltas_lower + deltas_percents
+    # stats and their relative percentages
+    return percents_higher + percents_lower + percents_percentiles
 
 
-def get_stats_above_threshold(stat_deltas: List[StatDelta], threshold: float = 500.0) -> List[StatDelta]:
-    """Computes the list of StatDeltas whose percentage deltas exceed a given threshold, defaulting to
-    500% (or 5x)
+def get_stats_above_threshold(stat_deltas: List[StatPercent], threshold: float) -> List[StatPercent]:
+    """Computes the list of StatPercents whose relative percentages exceed a given threshold
 
     Args:
-        stat_deltas (List[StatDelta]): A list of deltas between the current run of a Task and a previous run of a Task
+        stat_deltas (List[StatPercent]): A list of deltas between the current run of a Task and a previous run of a Task
         threshold (float, optional): Percentage threshold that the delta should not exceed. Defaults to 500.0.
 
     Returns:
-        List[StatDelta]: A filtered list of stats with deltas that exceed the given threshold
+        List[StatPercent]: A filtered list of stats with relative percent increase that exceed the given threshold
     """
-    return [stat_delta for stat_delta in stat_deltas if stat_delta.delta > threshold]
+    return [stat_delta for stat_delta in stat_deltas if stat_delta.percent > threshold]
+
+
+def validate_aggregated_stats(previous: AggregatedStats, current: AggregatedStats, threshold: float = DEFAULT_PERCENT_THRESHOLD) -> Dict[str, List[StatPercent]]:
+    """Validates and compares the given AggregatedStats instances against each other, checking each of their common
+    TaskStats and returning a dictionary of the name of those tasks that exceed the given threshold to the actual stats
+    that failed
+
+    Args:
+        previous (AggregatedStats): A previous run or average of all previous runs that will be compared against for the curren run
+        current (AggregatedStats): The current run's stats
+        threshold (float, optional): A percent threshold that the current run's task's stats must not exceed/be worse than. Defaults to DEFAULT_PERCENT_THRESHOLD
+
+    Returns:
+        Dict[str, List[StatPercent]]: A dictionary of failing task names to the stats that failed along with their percent relativity
+    """
+    prev_tasks = {task.task_name: task for task in previous.tasks}
+    cur_tasks = {task.task_name: task for task in current.tasks}
+    common_tasks = prev_tasks.keys() & cur_tasks.keys()
+
+    failed_tasks_with_percents = {}
+    for task in common_tasks:
+        prev_task = prev_tasks[task]
+        cur_task = cur_tasks[task]
+
+        deltas = get_stats_relative_percent(prev_task, cur_task)
+        failed_deltas = get_stats_above_threshold(deltas, threshold)
+        if failed_deltas != []:
+            failed_tasks_with_percents[task] = failed_deltas
+
+    return failed_tasks_with_percents
 
 
 def _safe_division(dividend: Union[float, int], divisor: Union[float, int]) -> float:
@@ -72,7 +108,3 @@ def _safe_division(dividend: Union[float, int], divisor: Union[float, int]) -> f
         return 0
 
     return dividend / divisor
-
-
-def _get_readable_percentile(percentile: float) -> str:
-    return f"{int(percentile * 100) if (percentile * 100).is_integer() else round(100 * percentile, 6)}%"

--- a/ops/ccs-ops-misc/load_test/common/stats/stats_compare.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/stats_compare.py
@@ -57,17 +57,17 @@ def get_stats_relative_percent(previous: TaskStats, current: TaskStats) -> List[
     return percents_higher + percents_lower + percents_percentiles
 
 
-def get_stats_above_threshold(stat_deltas: List[StatPercent], threshold: float) -> List[StatPercent]:
+def get_stats_above_threshold(stat_percents: List[StatPercent], threshold: float) -> List[StatPercent]:
     """Computes the list of StatPercents whose relative percentages exceed a given threshold
 
     Args:
-        stat_deltas (List[StatPercent]): A list of deltas between the current run of a Task and a previous run of a Task
+        stat_percents (List[StatPercent]): A list of relative stat percents to the current run of a Task and a previous run of a Task
         threshold (float, optional): Percentage threshold that the delta should not exceed. Defaults to 500.0.
 
     Returns:
         List[StatPercent]: A filtered list of stats with relative percent increase that exceed the given threshold
     """
-    return [stat_delta for stat_delta in stat_deltas if stat_delta.percent > threshold]
+    return [stat_delta for stat_delta in stat_percents if stat_delta.percent > threshold]
 
 
 def validate_aggregated_stats(previous: AggregatedStats, current: AggregatedStats, threshold: float = DEFAULT_PERCENT_THRESHOLD) -> Dict[str, List[StatPercent]]:

--- a/ops/ccs-ops-misc/load_test/common/stats/stats_config.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/stats_config.py
@@ -79,7 +79,7 @@ class StatsStorageConfig(ABC):
         # Tag must follow the BFD Insights data convention constraints for
         # partition/folders names, as it is used as a partition folder when uploading
         # to S3
-        if re.fullmatch('[a-z0-9_]+', tag) == None:
+        if re.fullmatch('[a-z0-9_]+', tag) == None or tag == '':
             raise ValueError(
                 '"tag" must only consist of lower-case letters, numbers and the "_" character') from None
 

--- a/ops/ccs-ops-misc/load_test/common/stats/stats_config.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/stats_config.py
@@ -33,7 +33,7 @@ class StatsComparisonType(Enum):
 @dataclass
 class StatsConfiguration():
     """Dataclass that holds data about where and how aggregated performance statistics are stored and compared"""
-    type: StatsStorageType
+    store: StatsStorageType
     """The storage type that the stats will be written to"""
     env: StatsEnvironment
     """The test running environment from which the statistics will be collected"""
@@ -102,7 +102,7 @@ class StatsConfiguration():
             raise ValueError(
                 '"bucket" must be specified if "type" is "s3"') from None
 
-        return StatsConfiguration(type=storage_type, env=stats_environment, tag=tag,
+        return StatsConfiguration(store=storage_type, env=stats_environment, tag=tag,
                                   path=config_dict.get('path') or '', bucket=config_dict.get('bucket'),
                                   compare=compare_type, comp_tag=comparison_tag)
 

--- a/ops/ccs-ops-misc/load_test/common/stats/stats_config.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/stats_config.py
@@ -106,7 +106,7 @@ class StatsConfiguration():
                 '"bucket" must be specified if "type" is "s3"') from None
 
         return cls(store=storage_type, env=stats_environment, store_tag=storage_tag,
-                   path=config_dict.get('path') or '', bucket=config_dict.get('bucket'),
+                   path=config_dict.get('path') or './', bucket=config_dict.get('bucket'),
                    compare=compare_type, comp_tag=comparison_tag)
 
     def __enum_from_val(val: str, enum_type: Type[E], field_name: str) -> E:

--- a/ops/ccs-ops-misc/load_test/common/stats/stats_config.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/stats_config.py
@@ -4,7 +4,7 @@ import re
 from dataclasses import dataclass
 from typing import Optional, Type, TypeVar
 
-E = TypeVar('E', Enum)
+E = TypeVar('E', bound=Enum)
 
 
 class StatsStorageType(Enum):
@@ -83,20 +83,20 @@ class StatsConfiguration():
             key_val.split('=') for key_val in key_vals_list)}
 
         # Check for required parameters, like type, tag, environment
-        if not set(['type', 'tag', 'env']).issubset(set(config_dict.keys())):
+        if not set(['store', 'store_tag', 'env']).issubset(set(config_dict.keys())):
             raise ValueError(
-                '"type", "tag", and "env" must be specified') from None
+                '"store", "store_tag", and "env" must be specified') from None
 
         # Handle all of the enum-backed fields
         storage_type = _enum_from_val(
-            config_dict['type'], StatsStorageType, 'type')
+            config_dict['store'], StatsStorageType, 'store')
         stats_environment = _enum_from_val(
             config_dict['env'], StatsEnvironment, 'env')
         compare_type = _enum_from_val(
             config_dict['compare'], StatsComparisonType, 'compare') if 'compare' in config_dict else None
 
         # Validate all of the tags passed in
-        storage_tag = _validate_tag(config_dict['tag'], 'tag')
+        storage_tag = _validate_tag(config_dict['store_tag'], 'store_tag')
         comparison_tag = _validate_tag(
             config_dict['comp_tag'], 'comp_tag') if 'comp_tag' in config_dict else storage_tag
 

--- a/ops/ccs-ops-misc/load_test/common/stats/stats_config.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/stats_config.py
@@ -7,27 +7,27 @@ from typing import Optional, Type, TypeVar
 E = TypeVar('E', bound=Enum)
 
 
-class StatsStorageType(Enum):
+class StatsStorageType(str, Enum):
     """Enumeration for each available type of storage for JSON stats"""
-    FILE = 1
+    FILE = 'file'
     """Indicates that aggregated statistics will be stored to a local file"""
-    S3 = 2
+    S3 = 's3'
     """Indicates that aggregated statistics will be stored to an S3 bucket"""
 
 
-class StatsEnvironment(Enum):
+class StatsEnvironment(str, Enum):
     """Enumeration for each possible test running environment"""
-    TEST = 1
+    TEST = 'test'
     """Indicates that the running environment is in testing, using testing resources"""
-    PROD = 2
+    PROD = 'prod'
     """Indicates that the running environment is in production, using production resources"""
 
 
-class StatsComparisonType(Enum):
+class StatsComparisonType(str, Enum):
     """Enumeration for each possible type of stats comparison"""
-    PREVIOUS = 1
+    PREVIOUS = 'previous'
     """Indicates that the comparison will be against the most recent, previous run under a given tag"""
-    AVERAGE = 2
+    AVERAGE = 'average'
     """Indicates that the comparison will be against the average of all runs under a given tag"""
 
 

--- a/ops/ccs-ops-misc/load_test/common/stats/stats_config.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/stats_config.py
@@ -60,7 +60,8 @@ class StatsConfiguration():
                           v in as_dict.items() if v is not None and v != ''}
         return ';'.join([f'{k}={str(v) if not isinstance(v, Enum) else v.name}' for k, v in dict_non_empty.items()])
 
-    def from_key_val_str(key_val_str: str):
+    @staticmethod
+    def from_key_val_str(key_val_str: str) -> 'StatsConfiguration':
         """Constructs a concrete instance of StatsConfiguration from a given string in key-value format seperated
         by semi-colons ("key1=value1;key2=value2").
 

--- a/ops/ccs-ops-misc/load_test/common/stats/stats_config.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/stats_config.py
@@ -42,6 +42,8 @@ class StatsConfiguration():
     """The local parent directory where JSON files will be written to. Used only if type is file, ignored if type is s3"""
     bucket: Optional[str]
     """The AWS S3 Bucket that the JSON will be written to. Used only if type is s3, ignored if type is file"""
+    compare: Optional[StatsComparisonType]
+    """Indicates the type of performance stats comparison that will be done"""
 
     def to_key_val_str(self) -> str:
         """Returns a key-value string representation of this StatsConfiguration instance.
@@ -84,6 +86,8 @@ class StatsConfiguration():
             config_dict['type'], StatsStorageType, 'type')
         stats_environment = _enum_from_val(
             config_dict['env'], StatsEnvironment, 'env')
+        compare_type = _enum_from_val(
+            config_dict['compare'], StatsComparisonType, 'compare') if 'compare' in config_dict else None
 
         tag = config_dict['tag']
         # Tag must follow the BFD Insights data convention constraints for
@@ -98,7 +102,8 @@ class StatsConfiguration():
                 '"bucket" must be specified if "type" is "s3"') from None
 
         return StatsConfiguration(type=storage_type, env=stats_environment, tag=tag,
-                                  path=config_dict.get('path') or '', bucket=config_dict.get('bucket'))
+                                  path=config_dict.get('path') or '', bucket=config_dict.get('bucket'),
+                                  compare=compare_type)
 
 
 def _enum_from_val(val: str, enum_type: Type[Enum], field_name: str):

--- a/ops/ccs-ops-misc/load_test/common/stats/stats_config.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/stats_config.py
@@ -2,8 +2,9 @@ import dataclasses
 from enum import Enum
 import re
 from dataclasses import dataclass
-from typing import Optional, Type
+from typing import Optional, Type, TypeVar
 
+E = TypeVar('E', Enum)
 
 class StatsStorageType(Enum):
     """Enumeration for each available type of storage for JSON stats"""
@@ -105,7 +106,7 @@ class StatsConfiguration():
                                   compare=compare_type, comp_tag=comparison_tag)
 
 
-def _enum_from_val(val: str, enum_type: Type[Enum], field_name: str):
+def _enum_from_val(val: str, enum_type: Type[E], field_name: str) -> E:
     try:
         return enum_type[val.upper()]
     except KeyError:

--- a/ops/ccs-ops-misc/load_test/common/stats/stats_config.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/stats_config.py
@@ -48,8 +48,8 @@ class StatsConfiguration():
     """Indicates the type of performance stats comparison that will be done"""
     comp_tag: Optional[str]
     """Indicates the tag from which comparison statistics will be loaded"""
-    athena_db: Optional[str]
-    """Name of the database to query using Athena if store is s3 and compare is set"""
+    athena_tbl: Optional[str]
+    """Name of the table to query using Athena if store is s3 and compare is set"""
 
     def to_key_val_str(self) -> str:
         """Returns a key-value string representation of this StatsConfiguration instance.
@@ -107,15 +107,15 @@ class StatsConfiguration():
             # Validate that bucket is always specified if S3 is specified
             if not 'bucket' in config_dict:
                 raise ValueError(
-                    '"bucket" must be specified if "type" is "s3"') from None
-            # Validate that the Athena DB is set if compare is set
-            if compare_type != None and not 'athena_db' in config_dict:
+                    '"bucket" must be specified if "store" is "s3"') from None
+            # Validate that the Athena table is set if compare is set
+            if compare_type != None and not 'athena_tbl' in config_dict:
                 raise ValueError(
-                    '"athena_db" must be specified if "type" is "s3" and "compare" is set') from None
+                    '"athena_tbl" must be specified if "store" is "s3" and "compare" is set') from None
 
         return cls(store=storage_type, env=stats_environment, store_tag=storage_tag,
                    path=config_dict.get('path') or './', bucket=config_dict.get('bucket'),
-                   compare=compare_type, comp_tag=comparison_tag, athena_db=config_dict.get('athena_db'))
+                   compare=compare_type, comp_tag=comparison_tag, athena_tbl=config_dict.get('athena_tbl'))
 
     def __enum_from_val(val: str, enum_type: Type[E], field_name: str) -> E:
         try:

--- a/ops/ccs-ops-misc/load_test/common/stats/stats_config.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/stats_config.py
@@ -21,6 +21,14 @@ class StatsEnvironment(Enum):
     """Indicates that the running environment is in production, using production resources"""
 
 
+class StatsComparisonType(Enum):
+    """Enumeration for each possible type of stats comparison"""
+    PREVIOUS = 1
+    """Indicates that the comparison will be against the most recent, previous run under a given tag"""
+    AVERAGE = 2
+    """Indicates that the comparison will be against the average of all runs under a given tag"""
+
+
 @dataclass
 class StatsConfiguration():
     """Dataclass that holds data about where and how aggregated performance statistics are stored"""
@@ -45,7 +53,7 @@ class StatsConfiguration():
         as_dict = dataclasses.asdict(self)
         dict_non_empty = {k: v for k,
                           v in as_dict.items() if v is not None and v != ''}
-        return ';'.join([f'{k}={v}' for k,v in dict_non_empty.items()])
+        return ';'.join([f'{k}={v}' for k, v in dict_non_empty.items()])
 
     def from_key_val_str(key_val_str: str):
         """Constructs a concrete instance of StatsConfiguration from a given string in key-value format seperated

--- a/ops/ccs-ops-misc/load_test/common/stats/stats_loaders.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/stats_loaders.py
@@ -59,30 +59,34 @@ class StatsLoader(ABC):
 
 class StatsFileLoader(StatsLoader):
     def load_previous(self) -> AggregatedStats:
-        # Get a list of all AggregatedStats from stats.json files under path 
+        # Get a list of all AggregatedStats from stats.json files under path
         stats_list = self.__load_stats_from_files()
 
         # Filter those that don't match the config and current run's metadata
-        filtered_stats = [stats for stats in stats_list if self.__verify_metadata(stats.metadata)]
+        filtered_stats = [
+            stats for stats in stats_list if self.__verify_metadata(stats.metadata)]
 
         # Sort them based upon timestamp, greater to lower
-        filtered_stats.sort(key=lambda stats: stats.metadata.timestamp, reverse=True)
+        filtered_stats.sort(
+            key=lambda stats: stats.metadata.timestamp, reverse=True)
 
         # Take the first item, if it exists -- this is the most recent, previous run
         return (filtered_stats[0:1] or [None])[0]
 
     def load_average(self) -> AggregatedStats:
-        raise NotImplementedError('Average stats is not implemented for files at this time.')
+        raise NotImplementedError(
+            'Average stats is not implemented for files at this time.')
 
     def __load_stats_from_files(self, suffix: str = '.stats.json') -> List[AggregatedStats]:
         path = self.stats_config.path
         stats_files = [os.path.join(path, file)
                        for file in os.listdir(path) if file.endswith(suffix)]
-        
+
         aggregated_stats_list = []
         for stats_file in stats_files:
             with open(stats_file) as json_file:
-                aggregated_stats_list.append(AggregatedStats(**json.load(json_file)))
+                aggregated_stats_list.append(
+                    AggregatedStats(**json.load(json_file)))
 
         return aggregated_stats_list
 

--- a/ops/ccs-ops-misc/load_test/common/stats/stats_loaders.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/stats_loaders.py
@@ -66,7 +66,7 @@ class StatsFileLoader(StatsLoader):
         filtered_stats = [stats for stats in stats_list if self.__verify_metadata(stats.metadata)]
 
         # Sort them based upon timestamp, greater to lower
-        filtered_stats.sort(key=lambda x: x.metadata.timestamp, reverse=True)
+        filtered_stats.sort(key=lambda stats: stats.metadata.timestamp, reverse=True)
 
         # Take the first item, if it exists -- this is the most recent, previous run
         return (filtered_stats[0:1] or [None])[0]
@@ -93,8 +93,8 @@ class StatsFileLoader(StatsLoader):
             loaded_metadata.num_total_users == self.metadata.num_total_users,
             loaded_metadata.num_users_per_second == self.metadata.num_users_per_second,
             loaded_metadata.stats_reset_after_spawn == self.metadata.stats_reset_after_spawn,
-            # Pick some delta that the runtimes should be under -- in this case, we're using 0.2
-            loaded_metadata.total_runtime - self.metadata.total_runtime < 0.2
+            # Pick some delta that the runtimes should be under -- in this case, we're using 1 second
+            loaded_metadata.total_runtime - self.metadata.total_runtime < 1.0
         ])
 
 class StatsAthenaLoader(StatsLoader):

--- a/ops/ccs-ops-misc/load_test/common/stats/stats_loaders.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/stats_loaders.py
@@ -187,8 +187,8 @@ class StatsAthenaLoader(StatsLoader):
         # equality check being auto-generated as they either should not be checked
         # (i.e. timestamp) or require a different type of check
         fields_to_exclude = ['timestamp', 'tag', 'total_runtime']
-        filtered_fields = [field for field in fields(StatsMetadata)
-                           if not field in fields_to_exclude]
+        filtered_fields = [field.name for field in fields(StatsMetadata)
+                           if not field.name in fields_to_exclude]
         # Automatically generate a list of equality checks for all of the fields that are
         # necessary to validate to ensure that stats can be compared
         generated_checks = [self.__generate_check_str(field)
@@ -263,10 +263,10 @@ def _get_average_task_stats(all_tasks: List[TaskStats]) -> Optional[TaskStats]:
 
     fields_to_exclude = ['task_name',
                          'request_method', 'response_time_percentiles']
-    fields_to_calculate = [field for field in fields(TaskStats)
-                           if not field in fields_to_exclude]
-    avg_task_stats = {field.name: mean(getattr(task, field) for task in all_tasks)
-                      for field in fields_to_calculate}
+    stats_to_average = [field.name for field in fields(TaskStats)
+                        if not field.name in fields_to_exclude]
+    avg_task_stats = {stat_name: mean(getattr(task, stat_name) for task in all_tasks)
+                      for stat_name in stats_to_average}
 
     common_percents = reduce(lambda prev, next: prev & next.keys(),
                              (task.response_time_percentiles for task in all_tasks), set())

--- a/ops/ccs-ops-misc/load_test/common/stats/stats_loaders.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/stats_loaders.py
@@ -1,0 +1,40 @@
+from abc import ABC, abstractmethod
+
+from common.stats.aggregated_stats import AggregatedStats
+from common.stats.stats_config import StatsConfiguration
+
+
+class StatsLoader(ABC):
+    """Loads AggregatedStats depending on what type of comparison is requested"""
+
+    def __init__(self, stats_config: StatsConfiguration) -> None:
+        self.stats_config = stats_config
+
+    @abstractmethod
+    def load(self) -> AggregatedStats:
+        """Loads an AggregatedStats instance constructed based on what type of comparison is required
+
+        Returns:
+            AggregatedStats: An AggregatedStats instance representing the set of stats requested to load
+        """
+        pass
+
+    @abstractmethod
+    def _load_previous(self) -> AggregatedStats:
+        """Loads an AggregatedStats instance constructed based on the most recent, previous test suite runs' 
+        stats under the tag specified by the user
+
+        Returns:
+            AggregatedStats: An AggregatedStats instance representing the stats of the previous test suite run
+        """
+        pass
+
+    @abstractmethod
+    def _load_average(self) -> AggregatedStats:
+        """Loads an AggregatedStats instance constructed based on the the average of all of the previous test suite
+        runs' stats under the tag specified by the user
+
+        Returns:
+            AggregatedStats: An AggregatedStats instance representing the stats of all specified previous test suite runs
+        """
+        pass

--- a/ops/ccs-ops-misc/load_test/common/stats/stats_loaders.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/stats_loaders.py
@@ -1,5 +1,4 @@
 import boto3
-from ctypes import Array
 from dataclasses import Field, fields
 import time
 from abc import ABC, abstractmethod

--- a/ops/ccs-ops-misc/load_test/common/stats/stats_loaders.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/stats_loaders.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 
 from common.stats.aggregated_stats import AggregatedStats
-from common.stats.stats_config import StatsConfiguration
+from common.stats.stats_config import StatsComparisonType, StatsConfiguration
 
 
 class StatsLoader(ABC):
@@ -10,14 +10,14 @@ class StatsLoader(ABC):
     def __init__(self, stats_config: StatsConfiguration) -> None:
         self.stats_config = stats_config
 
-    @abstractmethod
     def load(self) -> AggregatedStats:
         """Loads an AggregatedStats instance constructed based on what type of comparison is required
 
         Returns:
             AggregatedStats: An AggregatedStats instance representing the set of stats requested to load
         """
-        pass
+        is_avg_compare = self.stats_config.compare == StatsComparisonType.AVERAGE
+        return self._load_average() if is_avg_compare else self._load_previous()
 
     @abstractmethod
     def _load_previous(self) -> AggregatedStats:

--- a/ops/ccs-ops-misc/load_test/common/stats/stats_loaders.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/stats_loaders.py
@@ -137,7 +137,13 @@ class StatsAthenaLoader(StatsLoader):
         return queried_stats[0] if queried_stats else None
 
     def load_average(self) -> Optional[AggregatedStats]:
-        return super().load_average()
+        query = (
+            f'SELECT cast(tasks as JSON) FROM "bfd"."{self.stats_config.athena_tbl}" '
+            f'WHERE {self.__get_where_clause()}'
+        )
+
+        queried_stats = self.__get_stats_from_query(query)
+        return _get_average_all_stats(queried_stats)
 
     def __get_stats_from_query(self, query: str) -> List[AggregatedStats]:
         query_result = self.__run_query(query)

--- a/ops/ccs-ops-misc/load_test/common/stats/stats_loaders.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/stats_loaders.py
@@ -196,7 +196,7 @@ class StatsAthenaLoader(StatsLoader):
         # equality check being auto-generated as they either should not be checked
         # (i.e. timestamp) or require a different type of check
         fields_to_exclude = ['timestamp', 'tag', 'total_runtime']
-        filtered_fields = [field.name for field in fields(StatsMetadata)
+        filtered_fields = [field for field in fields(StatsMetadata)
                            if not field.name in fields_to_exclude]
         # Automatically generate a list of equality checks for all of the fields that are
         # necessary to validate to ensure that stats can be compared

--- a/ops/ccs-ops-misc/load_test/common/stats/stats_loaders.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/stats_loaders.py
@@ -75,12 +75,12 @@ class StatsFileLoader(StatsLoader):
         stats_list = self.__load_stats_from_files()
 
         # Filter those that don't match the config and current run's metadata
-        filtered_stats = [
-            stats for stats in stats_list if self.__verify_metadata(stats.metadata)]
+        filtered_stats = [stats for stats in stats_list
+                          if self.__verify_metadata(stats.metadata)]
 
         # Sort them based upon timestamp, greater to lower
-        filtered_stats.sort(
-            key=lambda stats: stats.metadata.timestamp, reverse=True)
+        filtered_stats.sort(key=lambda stats: stats.metadata.timestamp,
+                            reverse=True)
 
         # Take the first item, if it exists -- this is the most recent, previous run
         return filtered_stats[0] if filtered_stats else None
@@ -186,10 +186,12 @@ class StatsAthenaLoader(StatsLoader):
         # equality check being auto-generated as they either should not be checked
         # (i.e. timestamp) or require a different type of check
         fields_to_exclude = ['timestamp', 'tag', 'total_runtime']
-        filtered_fields = [field for field in fields(StatsMetadata) if not field in fields_to_exclude]
+        filtered_fields = [field for field in fields(StatsMetadata)
+                           if not field in fields_to_exclude]
         # Automatically generate a list of equality checks for all of the fields that are
         # necessary to validate to ensure that stats can be compared
-        generated_checks = [self.__get_equality_check_str(field) for field in filtered_fields]
+        generated_checks = [self.__generate_check_str(field)
+                            for field in filtered_fields]
         explicit_checks = [
             f"metadata.tag='{self.stats_config.comp_tag}'",
             f"(metadata.total_runtime - {self.metadata.total_runtime}) < 1.0",
@@ -197,7 +199,7 @@ class StatsAthenaLoader(StatsLoader):
 
         return ' AND '.join(generated_checks + explicit_checks)
 
-    def __get_equality_check_str(self, field: Field) -> str:
+    def __generate_check_str(self, field: Field) -> str:
         instance_value = getattr(self.metadata, field.name)
         # Anything that's a string should be surrounded by single quotes to denote it as a string
         # in SQL. Otherwise, no quotes should surround it
@@ -221,8 +223,8 @@ class StatsAthenaLoader(StatsLoader):
     def __stats_from_json_list(self, raw_json_list: List[str]) -> List[AggregatedStats]:
         # The serialization from a TaskStats array will give a list of values, so the serialized
         # list will be a list of lists of lists (in inner to outer order: TaskStats -> AggregatedStats -> List[AggregatedStats])
-        serialized_list: List[List[List[Any]]] = [
-            json.loads(json_str) for json_str in raw_json_list]
+        serialized_list: List[List[List[Any]]] = [json.loads(json_str) for json_str
+                                                  in raw_json_list]
         # The metadata is unnecessary here since by the time we've gotten here the metadata for each of the
         # tasks we're serializing here has already been checked
         return [AggregatedStats(metadata=None, tasks=[TaskStats.from_list(values_list) for values_list in agg_tasks_list])

--- a/ops/ccs-ops-misc/load_test/common/stats/stats_loaders.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/stats_loaders.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 
 from common.stats.aggregated_stats import AggregatedStats
-from common.stats.stats_config import StatsComparisonType, StatsConfiguration
+from common.stats.stats_config import StatsComparisonType, StatsConfiguration, StatsStorageType
 
 
 class StatsLoader(ABC):
@@ -38,3 +38,16 @@ class StatsLoader(ABC):
             AggregatedStats: An AggregatedStats instance representing the stats of all specified previous test suite runs
         """
         pass
+
+    @staticmethod
+    def from_config(stats_config: StatsConfiguration) -> 'StatsLoader':
+        """Construct a new concrete instance of StatsLoader that will load from the appropriate store as
+        specified in stats_config
+
+        Args:
+            stats_config (StatsConfiguration): The configuration specified for storing and comparing statistics
+
+        Returns:
+            StatsLoader: A concrete instance of StatsLoader that will load from the store specified in configuration
+        """
+        return StatsFileLoader(stats_config) if stats_config.store == StatsStorageType.FILE else StatsAthenaLoader(stats_config)

--- a/ops/ccs-ops-misc/load_test/common/stats/stats_loaders.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/stats_loaders.py
@@ -1,14 +1,18 @@
 from abc import ABC, abstractmethod
+import json
+import os
+from typing import List
 
-from common.stats.aggregated_stats import AggregatedStats
+from common.stats.aggregated_stats import AggregatedStats, StatsMetadata
 from common.stats.stats_config import StatsComparisonType, StatsConfiguration, StatsStorageType
 
 
 class StatsLoader(ABC):
     """Loads AggregatedStats depending on what type of comparison is requested"""
 
-    def __init__(self, stats_config: StatsConfiguration) -> None:
+    def __init__(self, stats_config: StatsConfiguration, metadata: StatsMetadata) -> None:
         self.stats_config = stats_config
+        self.metadata = metadata
 
     def load(self) -> AggregatedStats:
         """Loads an AggregatedStats instance constructed based on what type of comparison is required
@@ -17,10 +21,10 @@ class StatsLoader(ABC):
             AggregatedStats: An AggregatedStats instance representing the set of stats requested to load
         """
         is_avg_compare = self.stats_config.compare == StatsComparisonType.AVERAGE
-        return self._load_average() if is_avg_compare else self._load_previous()
+        return self.load_average() if is_avg_compare else self.load_previous()
 
     @abstractmethod
-    def _load_previous(self) -> AggregatedStats:
+    def load_previous(self) -> AggregatedStats:
         """Loads an AggregatedStats instance constructed based on the most recent, previous test suite runs' 
         stats under the tag specified by the user
 
@@ -30,7 +34,7 @@ class StatsLoader(ABC):
         pass
 
     @abstractmethod
-    def _load_average(self) -> AggregatedStats:
+    def load_average(self) -> AggregatedStats:
         """Loads an AggregatedStats instance constructed based on the the average of all of the previous test suite
         runs' stats under the tag specified by the user
 
@@ -40,7 +44,7 @@ class StatsLoader(ABC):
         pass
 
     @staticmethod
-    def from_config(stats_config: StatsConfiguration) -> 'StatsLoader':
+    def create(stats_config: StatsConfiguration, metadata: StatsMetadata) -> 'StatsLoader':
         """Construct a new concrete instance of StatsLoader that will load from the appropriate store as
         specified in stats_config
 
@@ -50,4 +54,52 @@ class StatsLoader(ABC):
         Returns:
             StatsLoader: A concrete instance of StatsLoader that will load from the store specified in configuration
         """
-        return StatsFileLoader(stats_config) if stats_config.store == StatsStorageType.FILE else StatsAthenaLoader(stats_config)
+        return StatsFileLoader(stats_config, metadata) if stats_config.store == StatsStorageType.FILE else StatsAthenaLoader(stats_config, metadata)
+
+
+class StatsFileLoader(StatsLoader):
+    def load_previous(self) -> AggregatedStats:
+        # Get a list of all AggregatedStats from stats.json files under path 
+        stats_list = self.__load_stats_from_files()
+
+        # Filter those that don't match the config and current run's metadata
+        filtered_stats = [stats for stats in stats_list if self.__verify_metadata(stats.metadata)]
+
+        # Sort them based upon timestamp, greater to lower
+        filtered_stats.sort(key=lambda x: x.metadata.timestamp, reverse=True)
+
+        # Take the first item, if it exists -- this is the most recent, previous run
+        return (filtered_stats[0:1] or [None])[0]
+
+    def load_average(self) -> AggregatedStats:
+        raise NotImplementedError('Average stats is not implemented for files at this time.')
+
+    def __load_stats_from_files(self, suffix: str = '.stats.json') -> List[AggregatedStats]:
+        path = self.stats_config.path
+        stats_files = [os.path.join(path, file)
+                       for file in os.listdir(path) if file.endswith(suffix)]
+        
+        aggregated_stats_list = []
+        for stats_file in stats_files:
+            with open(stats_file) as json_file:
+                aggregated_stats_list.append(AggregatedStats(**json.load(json_file)))
+
+        return aggregated_stats_list
+
+    def __verify_metadata(self, loaded_metadata: StatsMetadata):
+        return all([
+            loaded_metadata.environment == self.stats_config.env,
+            loaded_metadata.tag == self.stats_config.comp_tag,
+            loaded_metadata.num_total_users == self.metadata.num_total_users,
+            loaded_metadata.num_users_per_second == self.metadata.num_users_per_second,
+            loaded_metadata.stats_reset_after_spawn == self.metadata.stats_reset_after_spawn,
+            # Pick some delta that the runtimes should be under -- in this case, we're using 0.2
+            loaded_metadata.total_runtime - self.metadata.total_runtime < 0.2
+        ])
+
+class StatsAthenaLoader(StatsLoader):
+    def load_previous(self) -> AggregatedStats:
+        return super().load_previous()
+
+    def load_average(self) -> AggregatedStats:
+        return super().load_average()

--- a/ops/ccs-ops-misc/load_test/common/stats/stats_writers.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/stats_writers.py
@@ -30,7 +30,7 @@ class StatsJsonFileWriter(object):
         Args:
             path (str, optional): The _parent_ path of the file to write to disk. Defaults to ''.
         """
-        with open(os.path.join(path, f'{self.stats.running_env.name}-{self.stats.stats_tag}-{int(time.time())}.json'), 'x') as json_file:
+        with open(os.path.join(path, f'{self.stats.running_env.name}-{self.stats.stats_tag}-{int(time.time())}.stats.json'), 'x') as json_file:
             json_file.write(json.dumps(self.stats.all_stats, indent=4))
 
 

--- a/ops/ccs-ops-misc/load_test/common/stats/stats_writers.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/stats_writers.py
@@ -1,7 +1,8 @@
+from dataclasses import asdict
 import time
 import os
 import json
-from common.stats.aggregated_stats import StatsCollector
+from common.stats.aggregated_stats import AggregatedStats
 
 # botocore/boto3 is incompatible with gevent out-of-box causing issues with SSL.
 # We need to monkey patch gevent _before_ importing boto3 to ensure this doesn't happen.
@@ -14,11 +15,11 @@ import boto3
 class StatsJsonFileWriter(object):
     """Writes an AggegratedStats instance to a specified directory path in JSON format"""
 
-    def __init__(self, stats: StatsCollector) -> None:
+    def __init__(self, stats: AggregatedStats) -> None:
         """Creates a new instance of StatsJsonFileWriter given an StatsCollector object
 
         Args:
-            stats (StatsCollector): An StatsCollector object that is used to collect performance statistics
+            stats (AggregatedStats): An AggregatedStats object that represents the stats of a test suite run
         """
         super().__init__()
 
@@ -30,18 +31,18 @@ class StatsJsonFileWriter(object):
         Args:
             path (str, optional): The _parent_ path of the file to write to disk. Defaults to ''.
         """
-        with open(os.path.join(path, f'{self.stats.running_env.name}-{self.stats.stats_tag}-{int(time.time())}.stats.json'), 'x') as json_file:
-            json_file.write(json.dumps(self.stats.all_stats, indent=4))
+        with open(os.path.join(path, f'{self.stats.metadata.environment.name}-{self.stats.metadata.tag}-{int(time.time())}.stats.json'), 'x') as json_file:
+            json_file.write(json.dumps(asdict(self.stats), indent=4))
 
 
 class StatsJsonS3Writer(object):
     """Writes an AggegratedStats instance to a specified S3 bucket in JSON format"""
 
-    def __init__(self, stats: StatsCollector) -> None:
-        """Creates a new instance of StatsJsonS3Writer given an StatsCollector object
+    def __init__(self, stats: AggregatedStats) -> None:
+        """Creates a new instance of StatsJsonS3Writer given an AggregatedStats object
 
         Args:
-            stats (StatsCollector): An StatsCollector object that is used to collect performance statistics
+            stats (AggregatedStats): An AggregatedStats object that represents the stats of a test suite run
         """
         super().__init__()
 
@@ -55,5 +56,7 @@ class StatsJsonS3Writer(object):
         Args:
             bucket (str): The S3 bucket in AWS to write the JSON to
         """
-        self.s3.put_object(
-            Bucket=bucket, Key=f'databases/bfd/test_performance_stats/env={self.stats.running_env.name}/tag={self.stats.stats_tag}/{int(time.time())}.json', Body=json.dumps(self.stats.all_stats))
+        s3_path = f'databases/bfd/test_performance_stats/env={self.stats.metadata.environment.name}/tag={self.stats.metadata.tag}/{int(time.time())}.json'
+        self.s3.put_object(Bucket=bucket,
+                           Key=s3_path,
+                           Body=json.dumps(asdict(self.stats)))

--- a/ops/ccs-ops-misc/load_test/common/stats/stats_writers.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/stats_writers.py
@@ -1,3 +1,5 @@
+"""Members of this file/module are related to writing performance statistics to a user-specified
+data "store" (such as to file or AWS S3)"""
 from dataclasses import asdict
 import time
 import os

--- a/ops/ccs-ops-misc/load_test/common/stats/stats_writers.py
+++ b/ops/ccs-ops-misc/load_test/common/stats/stats_writers.py
@@ -1,7 +1,7 @@
 import time
 import os
 import json
-from common.stats.aggregated_stats import AggregatedStats
+from common.stats.aggregated_stats import StatsCollector
 
 # botocore/boto3 is incompatible with gevent out-of-box causing issues with SSL.
 # We need to monkey patch gevent _before_ importing boto3 to ensure this doesn't happen.
@@ -14,11 +14,11 @@ import boto3
 class StatsJsonFileWriter(object):
     """Writes an AggegratedStats instance to a specified directory path in JSON format"""
 
-    def __init__(self, stats: AggregatedStats) -> None:
-        """Creates a new instance of StatsJsonFileWriter given an AggregatedStats object
+    def __init__(self, stats: StatsCollector) -> None:
+        """Creates a new instance of StatsJsonFileWriter given an StatsCollector object
 
         Args:
-            stats (AggregatedStats): An AggregatedStats object that encodes the aggregated performance statistics of all Locust tasks in the current environment
+            stats (StatsCollector): An StatsCollector object that is used to collect performance statistics
         """
         super().__init__()
 
@@ -37,11 +37,11 @@ class StatsJsonFileWriter(object):
 class StatsJsonS3Writer(object):
     """Writes an AggegratedStats instance to a specified S3 bucket in JSON format"""
 
-    def __init__(self, stats: AggregatedStats) -> None:
-        """Creates a new instance of StatsJsonS3Writer given an AggregatedStats object
+    def __init__(self, stats: StatsCollector) -> None:
+        """Creates a new instance of StatsJsonS3Writer given an StatsCollector object
 
         Args:
-            stats (AggregatedStats): An AggregatedStats object that encodes the aggregated performance statistics of all Locust tasks in the current environment
+            stats (StatsCollector): An StatsCollector object that is used to collect performance statistics
         """
         super().__init__()
 

--- a/ops/ccs-ops-misc/load_test/runtests.py
+++ b/ops/ccs-ops-misc/load_test/runtests.py
@@ -73,7 +73,7 @@ def run_with_params(argv):
         'testNumTotalClients': "100",
         'testCreatedClientsPerSecond': "5",
         'resetStatsAfterClientSpawn': False,
-        'storeStats': None
+        'stats': None
     }
 
     # Dictionary to hold data passed in via the CLI that will be stored in the root config.yml file
@@ -98,13 +98,13 @@ def run_with_params(argv):
         '(Optional, Default 5)'
      '\n--worker_threads="<If >1 the test is run as distributed, and expects this many worker '
         'processes to start, int>" (Optional, Default 1 - non distributed mode)'
-     '\n--storeStats="<If set, stores stats in JSON to S3 or local file. Must follow format: <STORAGE_TYPE>:<RUNNING_ENVIRONMENT>:<TAG>:<PATH_OR_BUCKET>" (Optional)'
+     '\n--stats="<If set, stores stats in JSON to S3 or local file. Must follow format: <STORAGE_TYPE>:<RUNNING_ENVIRONMENT>:<TAG>:<PATH_OR_BUCKET>" (Optional)'
      '\n--resetStats (Optional)')
 
     try:
         opts, _args = getopt.getopt(argv, "h", ["homePath=", "clientCertPath=", "databaseUri=",
         "testHost=", "serverPublicKey=", 'tableSamplePct=', "configPath=", "testRunTime=",
-        "maxClients=", "clientsPerSecond=", "testFile=", "workerThreads=", "storeStats=", "resetStats"])
+        "maxClients=", "clientsPerSecond=", "testFile=", "workerThreads=", "stats=", "resetStats"])
     except getopt.GetoptError as err:
         print(err)
         print(help_string)
@@ -138,11 +138,11 @@ def run_with_params(argv):
             test_file = arg
         elif opt == "--workerThreads":
             worker_threads = arg
-        elif opt == "--storeStats":
+        elif opt == "--stats":
             try:
-                config_data["storeStats"] = StatsStorageConfig.from_arg_str(arg)
+                config_data["stats"] = StatsStorageConfig.from_arg_str(arg)
             except ValueError as err:
-                print(f'--storeStats was invalid: {err}\n')
+                print(f'--stats was invalid: {err}\n')
                 print(help_string)
                 sys.exit()
         elif opt == "--resetStats":

--- a/ops/ccs-ops-misc/load_test/runtests.py
+++ b/ops/ccs-ops-misc/load_test/runtests.py
@@ -98,7 +98,7 @@ def run_with_params(argv):
         '(Optional, Default 5)'
      '\n--worker_threads="<If >1 the test is run as distributed, and expects this many worker '
         'processes to start, int>" (Optional, Default 1 - non distributed mode)'
-     '\n--stats="<If set, stores stats in JSON to S3 or local file. Must follow format: <STORAGE_TYPE>:<RUNNING_ENVIRONMENT>:<TAG>:<PATH_OR_BUCKET>" (Optional)'
+     '\n--stats="<If set, stores stats in JSON to S3 or local file. Key-value list seperated by semi-colons. See README.>" (Optional)'
      '\n--resetStats (Optional)')
 
     try:

--- a/ops/ccs-ops-misc/load_test/runtests.py
+++ b/ops/ccs-ops-misc/load_test/runtests.py
@@ -11,7 +11,7 @@ from multiprocessing import Process
 from common import config, test_setup as setup
 from locust.main import main
 
-from common.stats.stats_config import StatsStorageConfig
+from common.stats.stats_config import StatsConfiguration
 
 def parse_run_time(run_time):
     '''Parse a given run time setting (which Locust accepts as combinations of "1m", "30s", "2h",
@@ -140,7 +140,7 @@ def run_with_params(argv):
             worker_threads = arg
         elif opt == "--stats":
             try:
-                config_data["stats"] = StatsStorageConfig.from_key_val_str(arg)
+                config_data["stats"] = StatsConfiguration.from_key_val_str(arg)
             except ValueError as err:
                 print(f'--stats was invalid: {err}\n')
                 print(help_string)

--- a/ops/ccs-ops-misc/load_test/runtests.py
+++ b/ops/ccs-ops-misc/load_test/runtests.py
@@ -140,7 +140,7 @@ def run_with_params(argv):
             worker_threads = arg
         elif opt == "--stats":
             try:
-                config_data["stats"] = StatsStorageConfig.from_arg_str(arg)
+                config_data["stats"] = StatsStorageConfig.from_key_val_str(arg)
             except ValueError as err:
                 print(f'--stats was invalid: {err}\n')
                 print(help_string)


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BFD-1779](https://jira.cms.gov/browse/BFD-1779)

**User Story or Bug Summary:**
As a BFD engineer, I want to be able to results of performance tests to a baseline, so that I know how performance has been affected by new changes.


---

### What Does This PR Do?
<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

This PR:

* Refactors the original `--storeStats` command-line argument
  * The argument has been renamed to just `--stats`
    * This argument no longer just controls how and where stats are stored, but also how they are _compared_ as well  
  * The argument is now specified in `key=value` format opposed to ";"-delimited format: `--stats="store=<file/s3>;env=<TEST/PROD>;store_tag=;path=;bucket=;compare=<previous/average>;comp_tag=;athena_tbl="`
    * This allows for arbitrary ordering of parameters
    * Which parameters are being set is now much more obvious
  * Some existing parameters have been renamed:
    * `type` --> `store`
    * `tag` --> `store_tag` 
  * **3** new keys/parameters have been added to `--stats`:
    * `compare` -- if set, current stats are compared to either the applicable previous run or average of all applicable previous runs 
      * Can be set to either `previous`, indicating compare against the most recent run, or `average`, indicating compare against the average of _all_ previous runs
    * `comp_tag` -- if set, the tag to compare _against_ (not the tag for which stats will be stored) will be the value of this parameter; defaults to `tag` if unset
      * Intended to be used when comparing across versions which will likely be stored under different tags
    *  `athena_tbl` -- required to be set if `store` is `s3` and `compare` is set; specifies the _name_ of the table that Athena will query for retrieving stats from AWS S3
* Splits `common/stats.py` into five new files/modules:
  * `common/stats/aggregated_stats.py`
    * Contains several new `dataclass`s along with a refactored `AggregatedStats`:
      * The original `AggregatedStats` has been renamed to `StatsCollector`
        * `StatsCollector` is used to collect and create `AggregatedStats` instances 
      * `AggregatedStats` is now a `dataclass` representing a collection of stats about the Locust tasks ran during a test suite run as well as metadata necessary for storage and comparison
      * `TaskStats` -- `dataclass` representing the stats exposed by a single Locust task
      * `StatsMetadata` -- `dataclass` containing the necessary metadata for classifying, storing, and loading a collection of Locust task stats (`TaskStats`)
      * > Essentially, this file contains code that either represents performance statistics, in the case of the `dataclass`s, or collects them (`StatsCollector`)
  * `common/stats/stats_compare.py`
    * Contains new functions handling comparing `AggregatedStats`/`TaskStats`
      * By default every performance statistic is compared to ensure it is no worse than 500%/5x of the set of statistics it is being compared against
    * Also contains a `dataclass`, `StatCompareResult`, that represents the percent magnitude of the current run versus the set of stats it is being compared against for a single stat
      * This class is written to the log if any stats fail a comparison (exceed a percent threshold in magnitude, by default this is `500%` or 5x) such that it will be easy to see which tasks failed and why 
  * `common/stats/stats_config.py`
    * Contains code handling the serialization and deserialization of the `--stats` command-line argument
    * `StatsConfiguration` represents the user-specified values of all of `--stats`'s parameters
  * `common/stats/stats_loaders.py`
    * Contains code related to the _loading_ of the different types of comparison sets (`previous`/`average`)
    * `StatsLoader` exposes a `load()` method which delegate to one of its two child classes, `StatsFileLoader` or `StatsAthenaLoader`, to load either the most applicable, previous set of stats or the most applicable average of _all_ previous stats
  * `common/stats/stats_writers.py`
    * Contains code related to writing out the current test suite run's performance statistics to a given `store`
    * Not much has changed for the classes in this file from the previous iteration besides them being moved 
* Adds logic to the `one_time_teardown()` function in `common/bfd_user_base.py` to compare the current run's statistics against a previous/average set of stats if `compare` is set
* Adds a small piece of documentation about `boto3` to the README
* Adds ignore patterns for `*.stats.json` files and files in `__pycache__` folders

In short, this PR adds the capability for the performance statistics of the current test run to be compared against some sort of benchmark from either a local file or from AWS S3. By default, just like _storing_ stats, this comparison is _opt-in_ and requires a command-line parameter be set (`--stats="...;compare=<average/previous>;..."`). Each stat for each Locust task is compared to the benchmark (i.e. `num_requests`, `average_response_time`, and percentiles) with the result being the percent magnitude between the current stat and benchmark stat (i.e. current is x% of benchmark). Note that this takes into consideration whether a value should be lower or higher; for example, `num_requests` generally is better the larger its value is but `average_response_time` is generally better if it is a lower value. For now, the threshold for failure is 500% (or 5x) of the benchmark. If any tasks fail this check, the run fails (exits with code `1`) and the failing tasks are printed to the log for debugging purposes.

### What Should Reviewers Watch For?
<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items to the following list here -->
* Does this implementation satisfy what features we need for comparing performance statistics?
  * Do we need any other way to benchmark stats? 
* Is the code clear and is it easy to follow what it is doing? 
* Could the code introduced be refactored easily in the future? Is it introducing unnecessary complexity?
* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [x] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [x] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [x] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    