### PR TITLE
PACA-684: Allow blank diag code and bitFlags

### DIFF
--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/source/FissClaimTransformer.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/source/FissClaimTransformer.java
@@ -1122,11 +1122,6 @@ public class FissClaimTransformer {
         from::getRdaPosition,
         to::setRdaPosition);
     to.setLastUpdated(now);
-
-    // At least one of these two fields must have a value for the object to be valid.
-    transformer.validateAtLeastOneIsPresent(
-        namePrefix + RdaFissDiagnosisCode.Fields.diagCd2, from.getDiagCd2(),
-        namePrefix + RdaFissDiagnosisCode.Fields.bitFlags, from.getBitFlags());
     return to;
   }
 

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/FissClaimTransformerTest.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/FissClaimTransformerTest.java
@@ -4,10 +4,8 @@ import static gov.cms.bfd.pipeline.rda.grpc.RdaChange.MIN_SEQUENCE_NUM;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.samePropertyValuesAs;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import com.google.common.collect.ImmutableList;
 import gov.cms.bfd.model.rda.Mbi;
 import gov.cms.bfd.model.rda.RdaFissAuditTrail;
 import gov.cms.bfd.model.rda.RdaFissClaim;
@@ -1329,50 +1327,6 @@ public class FissClaimTransformerTest {
             FissDiagnosisCode.Builder::setRdaPosition,
             RdaFissDiagnosisCode::getRdaPosition,
             RdaFissDiagnosisCode.Fields.rdaPosition);
-  }
-
-  /**
-   * Ensures that a {@link }FissDiagnosisCode} with either {@code diagCd2} or {@code bitFlags}
-   * defined transforms without error but one with neither has an appropriate error.
-   */
-  @Test
-  public void testEitherDiagCd2OrBitFlagsRequired() {
-    final var claimTransformer =
-        new FissClaimTransformer(clock, MbiCache.computedCache(idHasher.getConfig()));
-
-    // neither defined generates an error
-    var fissDiagnosisCode = FissDiagnosisCode.newBuilder().build();
-    var dataTransformer = new DataTransformer();
-    var rdaFissDiagnosisCode =
-        claimTransformer.transformMessageImpl(
-            fissDiagnosisCode, dataTransformer, clock.instant(), "");
-    assertNotNull(rdaFissDiagnosisCode);
-    assertEquals(
-        ImmutableList.of(
-            new DataTransformer.ErrorMessage(
-                RdaFissDiagnosisCode.Fields.diagCd2,
-                String.format(
-                    "expected either %s or %s to have value but neither did",
-                    RdaFissDiagnosisCode.Fields.diagCd2, RdaFissDiagnosisCode.Fields.bitFlags))),
-        dataTransformer.getErrors());
-
-    // only diagCd2 defined is ok
-    fissDiagnosisCode = FissDiagnosisCode.newBuilder().setDiagCd2("x").build();
-    dataTransformer = new DataTransformer();
-    rdaFissDiagnosisCode =
-        claimTransformer.transformMessageImpl(
-            fissDiagnosisCode, dataTransformer, clock.instant(), "");
-    assertNotNull(rdaFissDiagnosisCode);
-    assertEquals(ImmutableList.of(), dataTransformer.getErrors());
-
-    // only bitFlags defined is ok
-    fissDiagnosisCode = FissDiagnosisCode.newBuilder().setBitFlags("x").build();
-    dataTransformer = new DataTransformer();
-    rdaFissDiagnosisCode =
-        claimTransformer.transformMessageImpl(
-            fissDiagnosisCode, dataTransformer, clock.instant(), "");
-    assertNotNull(rdaFissDiagnosisCode);
-    assertEquals(ImmutableList.of(), dataTransformer.getErrors());
   }
 
   // endregion ProcCode tests


### PR DESCRIPTION

<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[PACA-684](https://jira.cms.gov/browse/PACA-684)

**User Story or Bug Summary:**

Occasionally, we receive FISS diagnosis codes records with no data in them. This was previously unexpected behavior, but have confirmed with the RDA API team that this is what they receive from the IDR extracts. We should record this record as is, with just primary key values and the rest of the rows empty.

---

### What Does This PR Do?

Removes the at-least-one-has-value requirement for RdaFissDiagnosisCode `diagCd2`/`bitFlags`.

### What Should Reviewers Watch For?

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items to the following list here -->
* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [x] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [x] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [x] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [x] No

### What Needs to Be Merged and Deployed Before this PR?

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
I have gone through and verified that...:

* [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    