### PR TITLE
PACA-689: Fixes transformMessage not updating metrics properly.

### DIFF
--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/RdaSink.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/RdaSink.java
@@ -139,9 +139,11 @@ public interface RdaSink<TMessage, TClaim> extends AutoCloseable {
    * @param apiVersion appropriate string for the apiSource column of the claim table
    * @param message an RDA API message object of the correct type for this sync
    * @return an appropriate entity object containing the data from the message
+   * @throws DataTransformer.TransformationException if the message is invalid
    */
   @Nonnull
-  TClaim transformMessage(String apiVersion, TMessage message);
+  TClaim transformMessage(String apiVersion, TMessage message)
+      throws DataTransformer.TransformationException;
 
   /**
    * Write the specified collection of entity objects to the database. This write could happen in

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/sink/direct/AbstractClaimRdaSink.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/sink/direct/AbstractClaimRdaSink.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.Nonnull;
 import javax.persistence.EntityManager;
 import lombok.Getter;
 import org.slf4j.Logger;
@@ -258,28 +259,76 @@ abstract class AbstractClaimRdaSink<TMessage, TClaim>
     logger.debug("updated max sequence number: type={} seq={}", claimType, lastSequenceNumber);
   }
 
+  /**
+   * Transforms all of the messages in the collection into {@link RdaChange} objects and returns a
+   * {@link List} of the converted changes.
+   *
+   * @param apiVersion appropriate string for the apiSource column of the claim table
+   * @param messages collection of RDA API message objects of the correct type for this sync
+   * @return the converted claims
+   * @throws DataTransformer.TransformationException if any message in the collection is invalid
+   */
   @VisibleForTesting
   List<RdaChange<TClaim>> transformMessages(String apiVersion, Collection<TMessage> messages)
-      throws ProcessingException {
+      throws DataTransformer.TransformationException {
     var claims = new ArrayList<RdaChange<TClaim>>();
     for (TMessage message : messages) {
-      try {
-        var change = transformMessage(apiVersion, message);
-        metrics.transformSuccesses.mark();
-        claims.add(change);
-      } catch (DataTransformer.TransformationException transformationException) {
-        metrics.transformFailures.mark();
-        try {
-          writeError(apiVersion, message, transformationException);
-        } catch (IOException e) {
-          transformationException.addSuppressed(e);
-        }
-        throw transformationException;
-      }
+      claims.add(transformMessage(apiVersion, message));
     }
     return claims;
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Delegates the actual transformation to derived classes by calling their {@link
+   * #transformMessageImpl} method. Takes care of tracking transformations and errors in {@link
+   * #metrics}.
+   *
+   * @param apiVersion appropriate string for the apiSource column of the claim table
+   * @param message an RDA API message object of the correct type for this sync
+   * @return the converted claim
+   * @throws DataTransformer.TransformationException if the message is invalid
+   */
+  @Nonnull
+  @Override
+  public RdaChange<TClaim> transformMessage(String apiVersion, TMessage message)
+      throws DataTransformer.TransformationException {
+    try {
+      var change = transformMessageImpl(apiVersion, message);
+      metrics.transformSuccesses.mark();
+      return change;
+    } catch (DataTransformer.TransformationException transformationException) {
+      metrics.transformFailures.mark();
+      try {
+        writeError(apiVersion, message, transformationException);
+      } catch (IOException e) {
+        transformationException.addSuppressed(e);
+      }
+      throw transformationException;
+    }
+  }
+
+  /**
+   * Called by {@link #transformMessage} to perform just the message transformation step that is
+   * specific to a particular message/claim combination.
+   *
+   * @param apiVersion appropriate string for the apiSource column of the claim table
+   * @param message an RDA API message object of the correct type for this sync
+   * @return an appropriate entity object containing the data from the message
+   * @throws DataTransformer.TransformationException if the message is invalid
+   */
+  @Nonnull
+  abstract RdaChange<TClaim> transformMessageImpl(String apiVersion, TMessage message)
+      throws DataTransformer.TransformationException;
+
+  /**
+   * Uses {@link EntityManager#merge} to write each claim and its associated meta data to the
+   * database.
+   *
+   * @param maxSeq highest sequence number from claims in the collection
+   * @param changes collection of claims to write to the database
+   */
   private void mergeBatch(long maxSeq, Iterable<RdaChange<TClaim>> changes) {
     boolean commit = false;
     try {
@@ -308,6 +357,12 @@ abstract class AbstractClaimRdaSink<TMessage, TClaim>
     }
   }
 
+  /**
+   * Finds the highest sequence number in a collection of claims.
+   *
+   * @param claims claims to search
+   * @return highest sequence number
+   */
   private long maxSequenceInBatch(Collection<RdaChange<TClaim>> claims) {
     OptionalLong value = claims.stream().mapToLong(RdaChange::getSequenceNumber).max();
     if (!value.isPresent()) {
@@ -319,25 +374,10 @@ abstract class AbstractClaimRdaSink<TMessage, TClaim>
   }
 
   /**
-   * Used by sub-classes to read the highest known sequenceNumber for claims in the database.
+   * Updates the latency metric by adding the age of each claim to the histogram.
    *
-   * @param query JPAQL query string
-   * @return result of the query or empty if no records matched
-   * @throws ProcessingException the processing exception
+   * @param claims claims to process
    */
-  protected Optional<Long> readMaxExistingSequenceNumber(String query) throws ProcessingException {
-    try {
-      logger.info("running query to find max sequence number");
-      Long sequenceNumber = entityManager.createQuery(query, Long.class).getSingleResult();
-      final Optional<Long> answer = Optional.ofNullable(sequenceNumber);
-      logger.info(
-          "max sequence number result is {}", answer.map(n -> Long.toString(n)).orElse("none"));
-      return answer;
-    } catch (Exception ex) {
-      throw new ProcessingException(ex, 0);
-    }
-  }
-
   private void updateLatencyMetric(Collection<RdaChange<TClaim>> claims) {
     for (RdaChange<TClaim> claim : claims) {
       final long nowMillis = clock.millis();
@@ -378,6 +418,12 @@ abstract class AbstractClaimRdaSink<TMessage, TClaim>
     /** The value returned by the latestSequenceNumber gauge. * */
     private final AtomicLong latestSequenceNumberValue;
 
+    /**
+     * Initializes all of the metrics.
+     *
+     * @param klass used to derive metric names
+     * @param appMetrics where to store the metrics
+     */
     private Metrics(Class<?> klass, MetricRegistry appMetrics) {
       final String base = klass.getSimpleName();
       calls = appMetrics.meter(MetricRegistry.name(base, "calls"));
@@ -395,6 +441,11 @@ abstract class AbstractClaimRdaSink<TMessage, TClaim>
       latestSequenceNumberValue = GAUGES.getValueForName(latestSequenceNumberGaugeName);
     }
 
+    /**
+     * Sets the {@link #latestSequenceNumber}
+     *
+     * @param value value to set
+     */
     @VisibleForTesting
     void setLatestSequenceNumber(long value) {
       latestSequenceNumberValue.set(value);

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/sink/direct/FissClaimRdaSink.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/sink/direct/FissClaimRdaSink.java
@@ -40,7 +40,7 @@ public class FissClaimRdaSink extends AbstractClaimRdaSink<FissClaimChange, RdaF
 
   @Nonnull
   @Override
-  public RdaChange<RdaFissClaim> transformMessage(String apiVersion, FissClaimChange message) {
+  RdaChange<RdaFissClaim> transformMessageImpl(String apiVersion, FissClaimChange message) {
     var change = transformer.transformClaim(message);
     change.getClaim().setApiSource(apiVersion);
     return change;

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/sink/direct/McsClaimRdaSink.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/sink/direct/McsClaimRdaSink.java
@@ -42,7 +42,7 @@ public class McsClaimRdaSink extends AbstractClaimRdaSink<McsClaimChange, RdaMcs
 
   @Nonnull
   @Override
-  public RdaChange<RdaMcsClaim> transformMessage(String apiVersion, McsClaimChange message) {
+  RdaChange<RdaMcsClaim> transformMessageImpl(String apiVersion, McsClaimChange message) {
     var change = transformer.transformClaim(message);
     change.getClaim().setApiSource(apiVersion);
     return change;

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/sink/direct/AbstractClaimRdaSinkTest.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/sink/direct/AbstractClaimRdaSinkTest.java
@@ -1,21 +1,22 @@
 package gov.cms.bfd.pipeline.rda.grpc.sink.direct;
 
+import static gov.cms.bfd.pipeline.rda.grpc.RdaPipelineTestUtils.assertMeterReading;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
+import com.zaxxer.hikari.HikariDataSource;
 import gov.cms.bfd.model.rda.MessageError;
 import gov.cms.bfd.model.rda.RdaApiProgress;
 import gov.cms.bfd.model.rda.RdaClaimMessageMetaData;
@@ -25,15 +26,43 @@ import gov.cms.bfd.pipeline.sharedutils.PipelineApplicationState;
 import java.io.IOException;
 import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
+import javax.persistence.EntityTransaction;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 public class AbstractClaimRdaSinkTest {
+  private static final String VERSION = "version";
+
+  private final Clock clock = Clock.fixed(Instant.ofEpochMilli(60_000L), ZoneOffset.UTC);
+
+  @Mock private HikariDataSource dataSource;
+  @Mock private EntityManagerFactory entityManagerFactory;
+  @Mock private EntityManager entityManager;
+  @Mock private EntityTransaction transaction;
+  private MetricRegistry appMetrics;
+  private TestClaimRdaSink sink;
+
+  @BeforeEach
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+    appMetrics = new MetricRegistry();
+    doReturn(entityManager).when(entityManagerFactory).createEntityManager();
+    doReturn(transaction).when(entityManager).getTransaction();
+    doReturn(true).when(entityManager).isOpen();
+    PipelineApplicationState appState =
+        new PipelineApplicationState(appMetrics, dataSource, entityManagerFactory, clock);
+    sink = spy(new TestClaimRdaSink(appState, RdaApiProgress.ClaimType.FISS, true));
+    sink.getMetrics().setLatestSequenceNumber(0);
+  }
 
   /**
    * Checks that claims are processed successfully when no exceptions were thrown by the {@link
@@ -43,39 +72,14 @@ public class AbstractClaimRdaSinkTest {
    */
   @Test
   void shouldTransformValidClaimsSuccessfully() throws IOException {
-    MetricRegistry mockMetricRegistry = mock(MetricRegistry.class);
-    Meter mockMeter = mock(Meter.class);
-    EntityManagerFactory mockEntityManagerFactory = mock(EntityManagerFactory.class);
-    EntityManager mockEntityManager = mock(EntityManager.class);
-    Clock mockClock = mock(Clock.class);
-    PipelineApplicationState mockPipelineApplicationState = mock(PipelineApplicationState.class);
-
-    doReturn(mockEntityManager).when(mockEntityManagerFactory).createEntityManager();
-
-    doReturn(mockEntityManagerFactory).when(mockPipelineApplicationState).getEntityManagerFactory();
-
-    doReturn(mockMeter).when(mockMetricRegistry).meter(anyString());
-
-    doReturn(mockMetricRegistry).when(mockPipelineApplicationState).getMetrics();
-
-    doReturn(mockClock).when(mockPipelineApplicationState).getClock();
-
-    AbstractClaimRdaSink<String, String> sinkSpy =
-        spy(
-            new TestClaimRdaSink(
-                mockPipelineApplicationState, RdaApiProgress.ClaimType.FISS, true));
-
-    final String apiVersion = "version";
     final List<String> messages = List.of("message1", "message2", "message3");
 
     for (String message : messages) {
-      doReturn(createChangeClaimFromMessage(message))
-          .when(sinkSpy)
-          .transformMessage(apiVersion, message);
+      doReturn(createChangeClaimFromMessage(message)).when(sink).transformMessage(VERSION, message);
     }
 
     doNothing()
-        .when(sinkSpy)
+        .when(sink)
         .writeError(anyString(), anyString(), any(DataTransformer.TransformationException.class));
 
     List<RdaChange<String>> expected =
@@ -83,10 +87,10 @@ public class AbstractClaimRdaSinkTest {
 
     AtomicReference<List<RdaChange<String>>> wrapper = new AtomicReference<>();
 
-    assertDoesNotThrow(() -> wrapper.set(sinkSpy.transformMessages(apiVersion, messages)));
+    assertDoesNotThrow(() -> wrapper.set(sink.transformMessages(VERSION, messages)));
 
     assertClaimChangesEquals(expected, wrapper.get());
-    verify(sinkSpy, times(0))
+    verify(sink, times(0))
         .writeError(anyString(), anyString(), any(DataTransformer.TransformationException.class));
   }
 
@@ -101,54 +105,62 @@ public class AbstractClaimRdaSinkTest {
   void shouldNotTransformInvalidClaimsSuccessfully() throws IOException {
     final String badMessage = "message2";
 
-    MetricRegistry mockMetricRegistry = mock(MetricRegistry.class);
-    Meter mockMeter = mock(Meter.class);
-    EntityManagerFactory mockEntityManagerFactory = mock(EntityManagerFactory.class);
-    EntityManager mockEntityManager = mock(EntityManager.class);
-    Clock mockClock = mock(Clock.class);
-    PipelineApplicationState mockPipelineApplicationState = mock(PipelineApplicationState.class);
-
-    doReturn(mockEntityManager).when(mockEntityManagerFactory).createEntityManager();
-
-    doReturn(mockEntityManagerFactory).when(mockPipelineApplicationState).getEntityManagerFactory();
-
-    doReturn(mockMeter).when(mockMetricRegistry).meter(anyString());
-
-    doReturn(mockMetricRegistry).when(mockPipelineApplicationState).getMetrics();
-
-    doReturn(mockClock).when(mockPipelineApplicationState).getClock();
-
-    AbstractClaimRdaSink<String, String> sinkSpy =
-        spy(
-            new TestClaimRdaSink(
-                mockPipelineApplicationState, RdaApiProgress.ClaimType.FISS, true));
-
-    final String apiVersion = "version";
     final List<String> messages = List.of("message1", badMessage, "message3");
 
     for (String message : messages) {
       if (message.equals(badMessage)) {
         doThrow(DataTransformer.TransformationException.class)
-            .when(sinkSpy)
-            .transformMessage(apiVersion, message);
+            .when(sink)
+            .transformMessageImpl(VERSION, message);
       } else {
         doReturn(createChangeClaimFromMessage(message))
-            .when(sinkSpy)
-            .transformMessage(apiVersion, message);
+            .when(sink)
+            .transformMessageImpl(VERSION, message);
       }
     }
 
     doNothing()
-        .when(sinkSpy)
+        .when(sink)
         .writeError(anyString(), anyString(), any(DataTransformer.TransformationException.class));
 
     assertThrows(
         DataTransformer.TransformationException.class,
-        () -> sinkSpy.transformMessages(apiVersion, messages));
+        () -> sink.transformMessages(VERSION, messages));
 
-    verify(sinkSpy, times(1))
+    verify(sink, times(1))
         .writeError(
-            eq(apiVersion), eq(badMessage), any(DataTransformer.TransformationException.class));
+            eq(VERSION), eq(badMessage), any(DataTransformer.TransformationException.class));
+  }
+
+  /** Verify that {@link RdaSink#transformMessage} success updates success metric. */
+  @Test
+  public void testSingleMessageTransformSuccessUpdatesMetric() {
+    sink.transformMessage(VERSION, "message");
+
+    final AbstractClaimRdaSink.Metrics metrics = sink.getMetrics();
+    assertMeterReading(1, "transform successes", metrics.getTransformSuccesses());
+    assertMeterReading(0, "transform failures", metrics.getTransformFailures());
+  }
+
+  /** Verify that {@link RdaSink#transformMessage} failure updates failure metric. */
+  @Test
+  public void testSingleMessageTransformFailureUpdatesMetric() {
+    doThrow(
+            new DataTransformer.TransformationException(
+                "oops", List.of(new DataTransformer.ErrorMessage("field", "oops!"))))
+        .when(sink)
+        .transformMessageImpl(any(), any());
+
+    try {
+      sink.transformMessage(VERSION, "message");
+      fail("should have thrown");
+    } catch (DataTransformer.TransformationException error) {
+      assertEquals("oops", error.getMessage());
+    }
+
+    final AbstractClaimRdaSink.Metrics metrics = sink.getMetrics();
+    assertMeterReading(0, "transform successes", metrics.getTransformSuccesses());
+    assertMeterReading(1, "transform failures", metrics.getTransformFailures());
   }
 
   /**
@@ -212,8 +224,8 @@ public class AbstractClaimRdaSinkTest {
 
     @Nonnull
     @Override
-    public RdaChange<String> transformMessage(String apiVersion, String s) {
-      return null;
+    RdaChange<String> transformMessageImpl(String apiVersion, String s) {
+      return new RdaChange<>(1L, RdaChange.Type.UPDATE, s, Instant.now());
     }
 
     @Override


### PR DESCRIPTION
**JIRA Ticket:**
[PACA-689](https://jira.cms.gov/browse/PACA-689)

**User Story or Bug Summary:**

Due to a difference in which write methods the two classes are using, only the single threaded mode is marking the metrics up. 

---

### What Does This PR Do?

Previously transformation metrics were only updated when `transformMessages()` was called.  This caused `ConcurrentRdaSink` to not update these metrics because it called `transformMessage()` directly.  Now the `transformMessage()` method does all of the metric updates and delegates only the transformation logic to the derived classes.

Also fills in some missing javadocs and refactors the unit test to make it easier to add new tests.

### What Should Reviewers Watch For?


If you're reviewing this PR, please check for these things in particular:
* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [x] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [x] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [x] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    