### PR TITLE
BFD-2063 - handle exportType in DatasetManifestEntry

### DIFF
--- a/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/main/java/gov/cms/bfd/pipeline/ccw/rif/DataSetManifestFactory.java
+++ b/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/main/java/gov/cms/bfd/pipeline/ccw/rif/DataSetManifestFactory.java
@@ -38,6 +38,7 @@ public class DataSetManifestFactory {
    * Constructs a new {@link DataSetManifestFactory} instance.
    *
    * @return the {@link DataSetManifestFactory}
+   * @throws SAXException (any errors encountered will be bubbled up).
    */
   public static DataSetManifestFactory newInstance() throws SAXException {
     if (thisInstance == null) {
@@ -52,8 +53,9 @@ public class DataSetManifestFactory {
    * @param manifestFilename the {@link String} XML filename to read/parse
    * @return the {@link DataSetManifest}
    * @throws JAXBException (any errors encountered will be bubbled up).
+   * @throws SAXException (any errors encountered will be bubbled up).
    */
-  public DataSetManifest parseManifest(String manifestFilename) throws JAXBException {
+  public DataSetManifest parseManifest(String manifestFilename) throws JAXBException, SAXException {
     InputStream manifestStream =
         Thread.currentThread().getContextClassLoader().getResourceAsStream(manifestFilename);
     return parseManifest(manifestStream);
@@ -65,11 +67,12 @@ public class DataSetManifestFactory {
    * valid.
    *
    * @param manifestStream the {@link InputStream} stream of XML to read/parse
-   * @return the {@link DataSetManifest}
    * @throws JAXBException (any errors encountered will be bubbled up).
+   * @throws SAXException (any errors encountered will be bubbled up).
    * @return the {@link DataSetManifest}
    */
-  public static DataSetManifest parseManifest(InputStream manifestStream) throws JAXBException {
+  public static DataSetManifest parseManifest(InputStream manifestStream)
+      throws JAXBException, SAXException {
     JAXBContext jaxbContext = JAXBContext.newInstance(DataSetManifest.class);
     Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
     jaxbUnmarshaller.setSchema(schema);

--- a/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/main/java/gov/cms/bfd/pipeline/ccw/rif/extract/s3/DataSetManifest.java
+++ b/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/main/java/gov/cms/bfd/pipeline/ccw/rif/extract/s3/DataSetManifest.java
@@ -39,6 +39,7 @@ public final class DataSetManifest implements Comparable<DataSetManifest> {
    *
    * @param timestampText the value to use for {@link #getTimestampText()}
    * @param sequenceId the value to use for {@link #getSequenceId()}
+   * @param syntheticData the value to use for {@link #isSyntheticData()}
    * @param entries the value to use for {@link #getEntries()}
    */
   public DataSetManifest(
@@ -58,6 +59,7 @@ public final class DataSetManifest implements Comparable<DataSetManifest> {
    *
    * @param timestamp the value to use for {@link #getTimestampText()}
    * @param sequenceId the value to use for {@link #getSequenceId()}
+   * @param syntheticData the value to use for {@link #isSyntheticData()}
    * @param entries the value to use for {@link #getEntries()}
    */
   public DataSetManifest(
@@ -73,6 +75,7 @@ public final class DataSetManifest implements Comparable<DataSetManifest> {
    *
    * @param timestampText the value to use for {@link #getTimestampText()}
    * @param sequenceId the value to use for {@link #getSequenceId()}
+   * @param syntheticData the value to use for {@link #isSyntheticData()}
    * @param entries the value to use for {@link #getEntries()}
    */
   public DataSetManifest(
@@ -88,6 +91,7 @@ public final class DataSetManifest implements Comparable<DataSetManifest> {
    *
    * @param timestamp the value to use for {@link #getTimestampText()}
    * @param sequenceId the value to use for {@link #getSequenceId()}
+   * @param syntheticData the value to use for {@link #isSyntheticData()}
    * @param entries the value to use for {@link #getEntries()}
    */
   public DataSetManifest(
@@ -190,6 +194,8 @@ public final class DataSetManifest implements Comparable<DataSetManifest> {
 
     @XmlAttribute private final RifFileType type;
 
+    @XmlTransient private final String exportType;
+
     /**
      * Constructs a new {@link DataSetManifestEntry} instance.
      *
@@ -200,6 +206,7 @@ public final class DataSetManifest implements Comparable<DataSetManifest> {
       this.parentManifest = null;
       this.name = name;
       this.type = type;
+      this.exportType = null;
     }
 
     /** This default constructor is required by JAX-B, and should not otherwise be used. */
@@ -207,6 +214,7 @@ public final class DataSetManifest implements Comparable<DataSetManifest> {
     private DataSetManifestEntry() {
       this.name = null;
       this.type = null;
+      this.exportType = null;
     }
 
     /** @return the {@link DataSetManifest} that this {@link DataSetManifestEntry} is a part of */

--- a/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/main/java/gov/cms/bfd/pipeline/ccw/rif/extract/s3/DataSetQueue.java
+++ b/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/main/java/gov/cms/bfd/pipeline/ccw/rif/extract/s3/DataSetQueue.java
@@ -204,12 +204,14 @@ public final class DataSetQueue {
    * @param manifestToProcessKey the {@link S3Object#getKey()} of the S3 object for the manifest to
    *     be read
    * @return the {@link DataSetManifest} that was contained in the specified S3 object
-   * @throws JAXBException
-   * @throws SAXException Any {@link JAXBException}s or {@link SAXException}s that are encountered
-   *     will be bubbled up. These generally indicate that the {@link DataSetManifest} could not be
-   *     parsed because its content was invalid in some way. Note: As of 2017-03-24, this has been
-   *     observed multiple times in production, and care should be taken to account for its
-   *     possibility.
+   * @throws JAXBException Any {@link JAXBException}s that are encountered will be bubbled up. These
+   *     generally indicate that the {@link DataSetManifest} could not be parsed because its content
+   *     was invalid in some way. Note: As of 2017-03-24, this has been observed multiple times in
+   *     production, and care should be taken to account for its possibility.
+   * @throws SAXException Any {@link SAXException}s that are encountered will be bubbled up. These
+   *     generally indicate that the {@link DataSetManifest} could not be parsed because its content
+   *     was invalid in some way. Note: As of 2017-03-24, this has been observed multiple times in
+   *     production, and care should be taken to account for its possibility.
    */
   public static DataSetManifest readManifest(
       AmazonS3 s3Client, ExtractionOptions options, String manifestToProcessKey)

--- a/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/main/resources/bfd-manifest.xsd
+++ b/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/main/resources/bfd-manifest.xsd
@@ -9,6 +9,7 @@
           <xs:complexType>
             <xs:attribute name="name" type="xs:string" use="required" />
             <xs:attribute name="type" type="xs:string" use="required" />
+            <xs:attribute name="exportType" type="xs:string" use="optional" />
           </xs:complexType>
         </xs:element>
       </xs:sequence>

--- a/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/test/resources/manifest-sample-a.xml
+++ b/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/test/resources/manifest-sample-a.xml
@@ -13,6 +13,6 @@
 	<!-- Copy from 
 		https://github.com/HHSIDEAlab/bluebutton-data-pipeline/raw/cbbd-55-s3-support/bluebutton-data-pipeline-sampledata/src/main/resources/rif-static-samples/sample-a-bcarrier.txt
 	-->
-	<entry name="sample-a-bcarrier.txt" type="CARRIER" />
+	<entry name="sample-a-bcarrier.txt" type="CARRIER" exportType="UPDATE" />
 
 </dataSetManifest>

--- a/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/test/resources/manifest-sample-b.xml
+++ b/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/test/resources/manifest-sample-b.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <dataSetManifest xmlns="http://cms.hhs.gov/bluebutton/api/schema/ccw-rif/v9" 
   timestamp="2016-12-19T10:29:51Z" sequenceId="1">
-<entry name="bene.txt" type="BENEFICIARY" />
-<entry name="bcarrier.txt" type="CARRIER" />
-<entry name="dme.txt" type="DME" />
-<entry name="hha.txt" type="HHA" />
-<entry name="hospice.txt" type="HOSPICE" />
-<entry name="inpatient.txt" type="INPATIENT" />
-<entry name="outpatient.txt" type="OUTPATIENT" />
-<entry name="snf.txt" type="SNF" />
-<entry name="pde.txt" type="PDE" />
+<entry name="bene.txt" type="BENEFICIARY" exportType="UPDATE" />
+<entry name="bcarrier.txt" type="CARRIER" exportType="UPDATE" />
+<entry name="dme.txt" type="DME" exportType="UPDATE" />
+<entry name="hha.txt" type="HHA" exportType="UPDATE" />
+<entry name="hospice.txt" type="HOSPICE" exportType="UPDATE" />
+<entry name="inpatient.txt" type="INPATIENT" exportType="UPDATE" />
+<entry name="outpatient.txt" type="OUTPATIENT" exportType="UPDATE" />
+<entry name="snf.txt" type="SNF" exportType="UPDATE" />
+<entry name="pde.txt" type="PDE" exportType="UPDATE" />
 </dataSetManifest>

--- a/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/test/resources/manifest-sample-c.xml
+++ b/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/test/resources/manifest-sample-c.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <dataSetManifest xmlns="http://cms.hhs.gov/bluebutton/api/schema/ccw-rif/v9"
   timestamp=" 2017-02-13T10:10:10Z" sequenceId="121212">
-<entry name="bene_00.txt" type="BENEFICIARY" />
+<entry name="bene_00.txt" type="BENEFICIARY" exportType="INSERT" />
 </dataSetManifest>


### PR DESCRIPTION
**JIRA Ticket:**
[BFD-2063](https://jira.cms.gov/browse/BFD-2063)

**User Story or Bug Summary:**
XML manifests from CCW contain an attribute exportType which fails XML validation; this ticket handles that by treating the exportType as a XmlTransient.

### What Does This PR Do?
Modify _DatasetManifestEntry_ to contain XML attribute _exportType_; this field will be defined as transient and effectively ignored.

Updates test data manifests to include _exportType_ attribute.

### What Should Reviewers Watch For?

The field in question, exportType, has been provided by CCW for some time now. However, at no time has this field every been used in the BFD pipeline loading process. However, since CCW provides that field, we need to at least account for it in our XML Schema (XSD) definition else it will fail schema validation.

Verify that the test data manifests include the exportType field and that any XML schema validation is not impacted by the presence (or absence) 0f this field.

**NOTE:**
The exportType field has been defined as XmlTransient in the DatasetManifestEntry; this means that even though the field is provided by CCW, we simply ignore its presence in the BFD pipeline; in fact there is no getter even defined to access the field. If anyone feels strongly that we should not treat this as XmlTransient, then this behavior can be changed.

### What Security Implications Does This PR Have?

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [X] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [X] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [X] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [X] No

### What Needs to Be Merged and Deployed Before this PR?

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist

I have gone through and verified that...:

* [X] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [X] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [X] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [X] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [X] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [X] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [X] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    