### PR TITLE
BFD-2126: Add ability for pipeline to read and write to a new location for synthetic data

### DIFF
--- a/apps/bfd-pipeline/bfd-pipeline-app/src/test/java/gov/cms/bfd/pipeline/app/PipelineApplicationIT.java
+++ b/apps/bfd-pipeline/bfd-pipeline-app/src/test/java/gov/cms/bfd/pipeline/app/PipelineApplicationIT.java
@@ -201,6 +201,8 @@ public final class PipelineApplicationIT {
               Instant.now(),
               0,
               false,
+              CcwRifLoadJob.S3_PREFIX_PENDING_DATA_SETS,
+              CcwRifLoadJob.S3_PREFIX_COMPLETED_DATA_SETS,
               new DataSetManifestEntry("beneficiaries.rif", RifFileType.BENEFICIARY),
               new DataSetManifestEntry("carrier.rif", RifFileType.CARRIER));
       s3Client.putObject(DataSetTestUtilities.createPutRequest(bucket, manifest));

--- a/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/main/java/gov/cms/bfd/pipeline/ccw/rif/CcwRifLoadJob.java
+++ b/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/main/java/gov/cms/bfd/pipeline/ccw/rif/CcwRifLoadJob.java
@@ -74,13 +74,20 @@ public final class CcwRifLoadJob implements PipelineJob<NullPipelineJobArguments
   /** The directory name that pending/incoming RIF data sets will be pulled from in S3. */
   public static final String S3_PREFIX_PENDING_DATA_SETS = "Incoming";
 
-  /** The directory name that pending/incoming synthetic RIF data sets will be pulled from in S3. */
+  /**
+   * The directory name that pending/incoming synthetic RIF data sets can be pulled from in S3. In
+   * essence this is just a second Incoming folder we can use for organization; it is not
+   * functionally different from {@link #S3_PREFIX_PENDING_DATA_SETS}.
+   */
   public static final String S3_PREFIX_PENDING_SYNTHETIC_DATA_SETS = "Synthetic/Incoming";
 
   /** The directory name that completed/done RIF data sets will be moved to in S3. */
   public static final String S3_PREFIX_COMPLETED_DATA_SETS = "Done";
 
-  /** The directory name that completed/done RIF data sets will be moved to in S3. */
+  /**
+   * The directory name that completed/done RIF data sets loaded from {@link
+   * #S3_PREFIX_PENDING_SYNTHETIC_DATA_SETS} will be moved to in S3.
+   */
   public static final String S3_PREFIX_COMPLETED_SYNTHETIC_DATA_SETS = "Synthetic/Done";
 
   /**
@@ -116,9 +123,17 @@ public final class CcwRifLoadJob implements PipelineJob<NullPipelineJobArguments
       Pattern.compile(
           "^" + S3_PREFIX_PENDING_SYNTHETIC_DATA_SETS + "\\/(.*)\\/([0-9]+)_manifest\\.xml$");
 
+  /**
+   * A regex that can be used for checking for a manifest in the {@link
+   * #S3_PREFIX_COMPLETED_DATA_SETS} location.
+   */
   public static final Pattern REGEX_COMPLETED_MANIFEST =
       Pattern.compile("^" + S3_PREFIX_COMPLETED_DATA_SETS + "\\/(.*)\\/([0-9]+)_manifest\\.xml$");
 
+  /**
+   * A regex that can be used for checking for a manifest in the {@link
+   * #S3_PREFIX_COMPLETED_SYNTHETIC_DATA_SETS} location.
+   */
   public static final Pattern REGEX_COMPLETED_MANIFEST_SYNTHETIC =
       Pattern.compile(
           "^" + S3_PREFIX_COMPLETED_SYNTHETIC_DATA_SETS + "\\/(.*)\\/([0-9]+)_manifest\\.xml$");

--- a/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/main/java/gov/cms/bfd/pipeline/ccw/rif/CcwRifLoadJob.java
+++ b/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/main/java/gov/cms/bfd/pipeline/ccw/rif/CcwRifLoadJob.java
@@ -308,18 +308,22 @@ public final class CcwRifLoadJob implements PipelineJob<NullPipelineJobArguments
     String syntheticPrefix =
         String.format("%s/%s/", S3_PREFIX_PENDING_SYNTHETIC_DATA_SETS, manifest.getTimestampText());
 
-    String sampleManifestName = manifest.getEntries().get(0).getName();
+    String sampleItemLocation = manifest.getEntries().get(0).getName();
 
+    // Do a check and see if the manifest's first file is in the synthetic incoming folder or the
+    // Incoming folder
     if (!s3TaskManager
             .getS3Client()
-            .doesObjectExist(options.getS3BucketName(), prefix + sampleManifestName)
+            .doesObjectExist(options.getS3BucketName(), prefix + sampleItemLocation)
         && !s3TaskManager
             .getS3Client()
-            .doesObjectExist(options.getS3BucketName(), syntheticPrefix + sampleManifestName)) {
+            .doesObjectExist(options.getS3BucketName(), syntheticPrefix + sampleItemLocation)) {
+      // If the file isn't anywhere, let's save some time and bail early; we're still downloading
+      // files
       return false;
     } else if (!s3TaskManager
         .getS3Client()
-        .doesObjectExist(options.getS3BucketName(), prefix + sampleManifestName)) {
+        .doesObjectExist(options.getS3BucketName(), prefix + sampleItemLocation)) {
       prefix = syntheticPrefix;
     }
 

--- a/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/main/java/gov/cms/bfd/pipeline/ccw/rif/CcwRifLoadJob.java
+++ b/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/main/java/gov/cms/bfd/pipeline/ccw/rif/CcwRifLoadJob.java
@@ -303,8 +303,28 @@ public final class CcwRifLoadJob implements PipelineJob<NullPipelineJobArguments
      * option #1.
      */
 
-    String dataSetKeyPrefix =
+    String prefix =
         String.format("%s/%s/", S3_PREFIX_PENDING_DATA_SETS, manifest.getTimestampText());
+    String syntheticPrefix =
+        String.format("%s/%s/", S3_PREFIX_PENDING_SYNTHETIC_DATA_SETS, manifest.getTimestampText());
+
+    String sampleManifestName = manifest.getEntries().get(0).getName();
+
+    if (!s3TaskManager
+            .getS3Client()
+            .doesObjectExist(options.getS3BucketName(), prefix + sampleManifestName)
+        && !s3TaskManager
+            .getS3Client()
+            .doesObjectExist(options.getS3BucketName(), syntheticPrefix + sampleManifestName)) {
+      return false;
+    } else if (!s3TaskManager
+        .getS3Client()
+        .doesObjectExist(options.getS3BucketName(), prefix + sampleManifestName)) {
+      prefix = syntheticPrefix;
+    }
+
+    // Value must be final for lambda expression using them to be happy
+    final String dataSetKeyPrefix = prefix;
 
     ListObjectsV2Request s3BucketListRequest = new ListObjectsV2Request();
     s3BucketListRequest.setBucketName(options.getS3BucketName());

--- a/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/main/java/gov/cms/bfd/pipeline/ccw/rif/CcwRifLoadJob.java
+++ b/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/main/java/gov/cms/bfd/pipeline/ccw/rif/CcwRifLoadJob.java
@@ -74,8 +74,14 @@ public final class CcwRifLoadJob implements PipelineJob<NullPipelineJobArguments
   /** The directory name that pending/incoming RIF data sets will be pulled from in S3. */
   public static final String S3_PREFIX_PENDING_DATA_SETS = "Incoming";
 
+  /** The directory name that pending/incoming synthetic RIF data sets will be pulled from in S3. */
+  public static final String S3_PREFIX_PENDING_SYNTHETIC_DATA_SETS = "Synthetic/Incoming";
+
   /** The directory name that completed/done RIF data sets will be moved to in S3. */
   public static final String S3_PREFIX_COMPLETED_DATA_SETS = "Done";
+
+  /** The directory name that completed/done RIF data sets will be moved to in S3. */
+  public static final String S3_PREFIX_COMPLETED_SYNTHETIC_DATA_SETS = "Synthetic/Done";
 
   /**
    * The {@link Logger} message that will be recorded if/when the {@link CcwRifLoadJob} goes and
@@ -102,8 +108,20 @@ public final class CcwRifLoadJob implements PipelineJob<NullPipelineJobArguments
   public static final Pattern REGEX_PENDING_MANIFEST =
       Pattern.compile("^" + S3_PREFIX_PENDING_DATA_SETS + "\\/(.*)\\/([0-9]+)_manifest\\.xml$");
 
+  /**
+   * A regex for {@link DataSetManifest} keys in S3 for synthetic files. Provides capturing groups
+   * for the {@link DataSetManifestId} fields.
+   */
+  public static final Pattern REGEX_PENDING_MANIFEST_SYNTHETIC =
+      Pattern.compile(
+          "^" + S3_PREFIX_PENDING_SYNTHETIC_DATA_SETS + "\\/(.*)\\/([0-9]+)_manifest\\.xml$");
+
   public static final Pattern REGEX_COMPLETED_MANIFEST =
       Pattern.compile("^" + S3_PREFIX_COMPLETED_DATA_SETS + "\\/(.*)\\/([0-9]+)_manifest\\.xml$");
+
+  public static final Pattern REGEX_COMPLETED_MANIFEST_SYNTHETIC =
+      Pattern.compile(
+          "^" + S3_PREFIX_COMPLETED_SYNTHETIC_DATA_SETS + "\\/(.*)\\/([0-9]+)_manifest\\.xml$");
 
   private final MetricRegistry appMetrics;
   private final ExtractionOptions options;

--- a/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/main/java/gov/cms/bfd/pipeline/ccw/rif/extract/s3/DataSetManifest.java
+++ b/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/main/java/gov/cms/bfd/pipeline/ccw/rif/extract/s3/DataSetManifest.java
@@ -311,6 +311,10 @@ public final class DataSetManifest implements Comparable<DataSetManifest> {
      */
     public static DataSetManifestId parseManifestIdFromS3Key(String s3ManifestKey) {
       Matcher manifestKeyMatcher = CcwRifLoadJob.REGEX_PENDING_MANIFEST.matcher(s3ManifestKey);
+      // If we don't match the normal Incoming, try the synthetic location
+      if (!manifestKeyMatcher.matches()) {
+        manifestKeyMatcher = CcwRifLoadJob.REGEX_PENDING_MANIFEST_SYNTHETIC.matcher(s3ManifestKey);
+      }
       boolean keyMatchesRegex = manifestKeyMatcher.matches();
 
       if (!keyMatchesRegex) return null;

--- a/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/main/java/gov/cms/bfd/pipeline/ccw/rif/extract/s3/DataSetManifest.java
+++ b/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/main/java/gov/cms/bfd/pipeline/ccw/rif/extract/s3/DataSetManifest.java
@@ -34,24 +34,39 @@ public final class DataSetManifest implements Comparable<DataSetManifest> {
   @XmlElement(name = "entry")
   private final List<DataSetManifestEntry> entries;
 
+  /** Denotes the s3 key where the manifest was located when it was first read. */
+  @XmlTransient private String manifestKeyIncomingLocation;
+
+  /**
+   * Denotes the s3 key where the manifest and its files should be placed when it's processing is
+   * complete.
+   */
+  @XmlTransient private String manifestKeyDoneLocation;
+
   /**
    * Constructs a new {@link DataSetManifest} instance.
    *
    * @param timestampText the value to use for {@link #getTimestampText()}
    * @param sequenceId the value to use for {@link #getSequenceId()}
    * @param syntheticData the value to use for {@link #isSyntheticData()}
+   * @param manifestKeyIncomingLocation the value to use for {@link #manifestKeyIncomingLocation}
+   * @param manifestKeyDoneLocation the value to use for {@link #manifestKeyDoneLocation}
    * @param entries the value to use for {@link #getEntries()}
    */
   public DataSetManifest(
       String timestampText,
       int sequenceId,
       boolean syntheticData,
+      String manifestKeyIncomingLocation,
+      String manifestKeyDoneLocation,
       List<DataSetManifestEntry> entries) {
     this.timestampText = timestampText;
     this.sequenceId = sequenceId;
     this.syntheticData = syntheticData;
     this.entries = entries;
     this.entries.forEach(entry -> entry.parentManifest = this);
+    this.manifestKeyIncomingLocation = manifestKeyIncomingLocation;
+    this.manifestKeyDoneLocation = manifestKeyDoneLocation;
   }
 
   /**
@@ -67,7 +82,15 @@ public final class DataSetManifest implements Comparable<DataSetManifest> {
       int sequenceId,
       boolean syntheticData,
       List<DataSetManifestEntry> entries) {
-    this(DateTimeFormatter.ISO_INSTANT.format(timestamp), sequenceId, syntheticData, entries);
+    // This appears to only be used in dead test code, so hardcoding the input/output locations to
+    // the old locations unless we need otherwise
+    this(
+        DateTimeFormatter.ISO_INSTANT.format(timestamp),
+        sequenceId,
+        syntheticData,
+        CcwRifLoadJob.S3_PREFIX_PENDING_DATA_SETS,
+        CcwRifLoadJob.S3_PREFIX_COMPLETED_DATA_SETS,
+        entries);
   }
 
   /**
@@ -76,14 +99,24 @@ public final class DataSetManifest implements Comparable<DataSetManifest> {
    * @param timestampText the value to use for {@link #getTimestampText()}
    * @param sequenceId the value to use for {@link #getSequenceId()}
    * @param syntheticData the value to use for {@link #isSyntheticData()}
+   * @param manifestKeyIncomingLocation the value to use for {@link #manifestKeyIncomingLocation}
+   * @param manifestKeyDoneLocation the value to use for {@link #manifestKeyDoneLocation}
    * @param entries the value to use for {@link #getEntries()}
    */
   public DataSetManifest(
       String timestampText,
       int sequenceId,
       boolean syntheticData,
+      String manifestKeyIncomingLocation,
+      String manifestKeyDoneLocation,
       DataSetManifestEntry... entries) {
-    this(timestampText, sequenceId, syntheticData, Arrays.asList(entries));
+    this(
+        timestampText,
+        sequenceId,
+        syntheticData,
+        manifestKeyIncomingLocation,
+        manifestKeyDoneLocation,
+        Arrays.asList(entries));
   }
 
   /**
@@ -92,14 +125,23 @@ public final class DataSetManifest implements Comparable<DataSetManifest> {
    * @param timestamp the value to use for {@link #getTimestampText()}
    * @param sequenceId the value to use for {@link #getSequenceId()}
    * @param syntheticData the value to use for {@link #isSyntheticData()}
+   * @param manifestKeyIncomingLocation the value to use for {@link #manifestKeyIncomingLocation}
+   * @param manifestKeyDoneLocation the value to use for {@link #manifestKeyDoneLocation}
    * @param entries the value to use for {@link #getEntries()}
    */
   public DataSetManifest(
-      Instant timestamp, int sequenceId, boolean syntheticData, DataSetManifestEntry... entries) {
+      Instant timestamp,
+      int sequenceId,
+      boolean syntheticData,
+      String manifestKeyIncomingLocation,
+      String manifestKeyDoneLocation,
+      DataSetManifestEntry... entries) {
     this(
         DateTimeFormatter.ISO_INSTANT.format(timestamp),
         sequenceId,
         syntheticData,
+        manifestKeyIncomingLocation,
+        manifestKeyDoneLocation,
         Arrays.asList(entries));
   }
 
@@ -157,6 +199,42 @@ public final class DataSetManifest implements Comparable<DataSetManifest> {
   /** @return the list of {@link DataSetManifestEntry} included in this {@link DataSetManifest} */
   public List<DataSetManifestEntry> getEntries() {
     return entries;
+  }
+
+  /**
+   * Sets the {@link #manifestKeyIncomingLocation}.
+   *
+   * @param location the location
+   */
+  public void setManifestKeyIncomingLocation(String location) {
+    this.manifestKeyIncomingLocation = location;
+  }
+
+  /**
+   * Sets the {@link #manifestKeyDoneLocation}.
+   *
+   * @param location the location
+   */
+  public void setManifestKeyDoneLocation(String location) {
+    this.manifestKeyDoneLocation = location;
+  }
+
+  /**
+   * Gets the {@link #manifestKeyIncomingLocation}.
+   *
+   * @return the incoming location key
+   */
+  public String getManifestKeyIncomingLocation() {
+    return manifestKeyIncomingLocation;
+  }
+
+  /**
+   * Gets the {@link #manifestKeyDoneLocation}.
+   *
+   * @return the done location key
+   */
+  public String getManifestKeyDoneLocation() {
+    return manifestKeyDoneLocation;
   }
 
   /** @see java.lang.Comparable#compareTo(java.lang.Object) */
@@ -311,22 +389,18 @@ public final class DataSetManifest implements Comparable<DataSetManifest> {
      */
     public static DataSetManifestId parseManifestIdFromS3Key(String s3ManifestKey) {
       Matcher manifestKeyMatcher = CcwRifLoadJob.REGEX_PENDING_MANIFEST.matcher(s3ManifestKey);
-      // If we don't match the normal Incoming, try the synthetic location
-      if (!manifestKeyMatcher.matches()) {
-        manifestKeyMatcher = CcwRifLoadJob.REGEX_PENDING_MANIFEST_SYNTHETIC.matcher(s3ManifestKey);
-      }
       boolean keyMatchesRegex = manifestKeyMatcher.matches();
 
       if (!keyMatchesRegex) return null;
 
-      String dataSetTimestampText = manifestKeyMatcher.group(1);
+      String dataSetTimestampText = manifestKeyMatcher.group(2);
       try {
         Instant.parse(dataSetTimestampText);
       } catch (DateTimeParseException e) {
         return null;
       }
 
-      int dataSetSequenceId = Integer.parseInt(manifestKeyMatcher.group(2));
+      int dataSetSequenceId = Integer.parseInt(manifestKeyMatcher.group(3));
 
       return new DataSetManifestId(dataSetTimestampText, dataSetSequenceId);
     }

--- a/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/main/java/gov/cms/bfd/pipeline/ccw/rif/extract/s3/DataSetQueue.java
+++ b/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/main/java/gov/cms/bfd/pipeline/ccw/rif/extract/s3/DataSetQueue.java
@@ -134,6 +134,16 @@ public final class DataSetQueue {
   private void addManifestToList(
       DataSetManifest.DataSetManifestId manifestId, String manifestS3Key) {
     DataSetManifest manifest;
+
+    // If the keyspace we're scanning doesnt exist, bail early
+    if (!s3TaskManager.getS3Client().doesObjectExist(options.getS3BucketName(), manifestS3Key)) {
+      LOGGER.warn(
+          "Unable to find keyspace {} in bucket {} while scanning for manifests.",
+          manifestS3Key,
+          options.getS3BucketName());
+      return;
+    }
+
     try {
       manifest = readManifest(s3TaskManager.getS3Client(), options, manifestS3Key);
     } catch (JAXBException | SAXException e) {

--- a/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/main/java/gov/cms/bfd/pipeline/ccw/rif/extract/s3/DataSetTestUtilities.java
+++ b/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/main/java/gov/cms/bfd/pipeline/ccw/rif/extract/s3/DataSetTestUtilities.java
@@ -60,7 +60,7 @@ public class DataSetTestUtilities {
   }
 
   /**
-   * Create put request put object request.
+   * Create put request within a given bucket for a manifest at a keyed location.
    *
    * @param bucket the {@link Bucket} to place the new object in
    * @param manifest the {@link DataSetManifest} to push as an object
@@ -132,7 +132,7 @@ public class DataSetTestUtilities {
   }
 
   /**
-   * Create put request put object request.
+   * Creates a put request, placing the items within the location key inside the given bucket.
    *
    * @param bucket the {@link Bucket} to place the new object in
    * @param manifest the {@link DataSetManifest} to create an object for

--- a/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/main/java/gov/cms/bfd/pipeline/ccw/rif/extract/s3/DataSetTestUtilities.java
+++ b/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/main/java/gov/cms/bfd/pipeline/ccw/rif/extract/s3/DataSetTestUtilities.java
@@ -60,6 +60,22 @@ public class DataSetTestUtilities {
   }
 
   /**
+   * Create put request put object request.
+   *
+   * @param bucket the {@link Bucket} to place the new object in
+   * @param manifest the {@link DataSetManifest} to push as an object
+   * @param location the location to store the manifest, should be {@link
+   *     CcwRifLoadJob#S3_PREFIX_PENDING_DATA_SETS} or {@link
+   *     CcwRifLoadJob#S3_PREFIX_PENDING_SYNTHETIC_DATA_SETS}
+   * @return a {@link PutObjectRequest} for the specified {@link DataSetManifest}
+   */
+  public static PutObjectRequest createPutRequest(
+      Bucket bucket, DataSetManifest manifest, String location) {
+    String keyPrefix = String.format("%s/%s", location, manifest.getTimestampText());
+    return createPutRequest(bucket, keyPrefix, manifest);
+  }
+
+  /**
    * @param bucket the {@link Bucket} to place the new object in
    * @param keyPrefix the S3 key prefix to store the new object under
    * @param manifest the {@link DataSetManifest} to push as an object
@@ -93,6 +109,9 @@ public class DataSetTestUtilities {
   }
 
   /**
+   * Creates a put request, placing the items within the {@link
+   * CcwRifLoadJob#S3_PREFIX_PENDING_DATA_SETS} key inside the given bucket.
+   *
    * @param bucket the {@link Bucket} to place the new object in
    * @param manifest the {@link DataSetManifest} to create an object for
    * @param manifestEntry the {@link DataSetManifestEntry} to create an object for
@@ -104,9 +123,33 @@ public class DataSetTestUtilities {
       DataSetManifest manifest,
       DataSetManifestEntry manifestEntry,
       URL objectContentsUrl) {
-    String keyPrefix =
-        String.format(
-            "%s/%s", CcwRifLoadJob.S3_PREFIX_PENDING_DATA_SETS, manifest.getTimestampText());
+    return createPutRequest(
+        bucket,
+        manifest,
+        manifestEntry,
+        objectContentsUrl,
+        CcwRifLoadJob.S3_PREFIX_PENDING_DATA_SETS);
+  }
+
+  /**
+   * Create put request put object request.
+   *
+   * @param bucket the {@link Bucket} to place the new object in
+   * @param manifest the {@link DataSetManifest} to create an object for
+   * @param manifestEntry the {@link DataSetManifestEntry} to create an object for
+   * @param objectContentsUrl a {@link URL} to the data to push as the new object's content
+   * @param incomingLocation the incoming location, should be {@link
+   *     CcwRifLoadJob#S3_PREFIX_PENDING_DATA_SETS} or {@link
+   *     CcwRifLoadJob#S3_PREFIX_PENDING_SYNTHETIC_DATA_SETS}
+   * @return a {@link PutObjectRequest} for the specified content
+   */
+  public static PutObjectRequest createPutRequest(
+      Bucket bucket,
+      DataSetManifest manifest,
+      DataSetManifestEntry manifestEntry,
+      URL objectContentsUrl,
+      String incomingLocation) {
+    String keyPrefix = String.format("%s/%s", incomingLocation, manifest.getTimestampText());
     return createPutRequest(bucket, keyPrefix, manifest, manifestEntry, objectContentsUrl);
   }
 

--- a/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/main/java/gov/cms/bfd/pipeline/ccw/rif/extract/s3/task/DataSetMoveTask.java
+++ b/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/main/java/gov/cms/bfd/pipeline/ccw/rif/extract/s3/task/DataSetMoveTask.java
@@ -7,7 +7,6 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
 import com.amazonaws.services.s3.transfer.Copy;
 import com.amazonaws.waiters.WaiterParameters;
-import gov.cms.bfd.pipeline.ccw.rif.CcwRifLoadJob;
 import gov.cms.bfd.pipeline.ccw.rif.extract.ExtractionOptions;
 import gov.cms.bfd.pipeline.ccw.rif.extract.s3.DataSetManifest;
 import gov.cms.bfd.sharedutils.exceptions.BadCodeMonkeyException;
@@ -75,20 +74,8 @@ public final class DataSetMoveTask implements Callable<Void> {
 
       // Move the item from where it started into the corresponding output, assume Incoming first
       sourceKey =
-          String.format("%s/%s", CcwRifLoadJob.S3_PREFIX_PENDING_DATA_SETS, s3KeySuffixToMove);
-      targetKey =
-          String.format("%s/%s", CcwRifLoadJob.S3_PREFIX_COMPLETED_DATA_SETS, s3KeySuffixToMove);
-      boolean manifestInIncoming =
-          s3TaskManager.getS3Client().doesObjectExist(options.getS3BucketName(), sourceKey);
-
-      if (!manifestInIncoming) {
-        sourceKey =
-            String.format(
-                "%s/%s", CcwRifLoadJob.S3_PREFIX_PENDING_SYNTHETIC_DATA_SETS, s3KeySuffixToMove);
-        targetKey =
-            String.format(
-                "%s/%s", CcwRifLoadJob.S3_PREFIX_COMPLETED_SYNTHETIC_DATA_SETS, s3KeySuffixToMove);
-      }
+          String.format("%s/%s", manifest.getManifestKeyIncomingLocation(), s3KeySuffixToMove);
+      targetKey = String.format("%s/%s", manifest.getManifestKeyDoneLocation(), s3KeySuffixToMove);
 
       /*
        * Before copying, grab the metadata of the source object to ensure
@@ -129,14 +116,7 @@ public final class DataSetMoveTask implements Callable<Void> {
      */
     for (String s3KeySuffixToMove : s3KeySuffixesToMove) {
       String sourceKey =
-          String.format("%s/%s", CcwRifLoadJob.S3_PREFIX_PENDING_DATA_SETS, s3KeySuffixToMove);
-      boolean manifestInIncoming =
-          s3TaskManager.getS3Client().doesObjectExist(options.getS3BucketName(), sourceKey);
-      if (!manifestInIncoming) {
-        sourceKey =
-            String.format(
-                "%s/%s", CcwRifLoadJob.S3_PREFIX_PENDING_SYNTHETIC_DATA_SETS, s3KeySuffixToMove);
-      }
+          String.format("%s/%s", manifest.getManifestKeyIncomingLocation(), s3KeySuffixToMove);
       DeleteObjectRequest deleteObjectRequest =
           new DeleteObjectRequest(options.getS3BucketName(), sourceKey);
       s3TaskManager.getS3Client().deleteObject(deleteObjectRequest);

--- a/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/main/java/gov/cms/bfd/pipeline/ccw/rif/extract/s3/task/ManifestEntryDownloadTask.java
+++ b/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/main/java/gov/cms/bfd/pipeline/ccw/rif/extract/s3/task/ManifestEntryDownloadTask.java
@@ -5,7 +5,6 @@ import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.transfer.Download;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
-import gov.cms.bfd.pipeline.ccw.rif.CcwRifLoadJob;
 import gov.cms.bfd.pipeline.ccw.rif.extract.ExtractionOptions;
 import gov.cms.bfd.pipeline.ccw.rif.extract.exceptions.AwsFailureException;
 import gov.cms.bfd.pipeline.ccw.rif.extract.exceptions.ChecksumException;
@@ -60,25 +59,14 @@ public final class ManifestEntryDownloadTask implements Callable<ManifestEntryDo
   @Override
   public ManifestEntryDownloadResult call() throws Exception {
     try {
-
-      String location =
-          String.format(
-              "%s/%s/%s",
-              CcwRifLoadJob.S3_PREFIX_PENDING_DATA_SETS,
-              manifestEntry.getParentManifest().getTimestampText(),
-              manifestEntry.getName());
-
-      // Check that our manifest is in Incoming, else check synthetic/incoming
-      if (!s3TaskManager.getS3Client().doesObjectExist(options.getS3BucketName(), location)) {
-        location =
-            String.format(
-                "%s/%s/%s",
-                CcwRifLoadJob.S3_PREFIX_PENDING_SYNTHETIC_DATA_SETS,
-                manifestEntry.getParentManifest().getTimestampText(),
-                manifestEntry.getName());
-      }
-
-      GetObjectRequest objectRequest = new GetObjectRequest(options.getS3BucketName(), location);
+      GetObjectRequest objectRequest =
+          new GetObjectRequest(
+              options.getS3BucketName(),
+              String.format(
+                  "%s/%s/%s",
+                  manifestEntry.getParentManifest().getManifestKeyIncomingLocation(),
+                  manifestEntry.getParentManifest().getTimestampText(),
+                  manifestEntry.getName()));
       Path localTempFile = Files.createTempFile("data-pipeline-s3-temp", ".rif");
 
       Timer.Context downloadTimer =

--- a/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/test/java/gov/cms/bfd/pipeline/ccw/rif/CcwRifLoadJobIT.java
+++ b/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/test/java/gov/cms/bfd/pipeline/ccw/rif/CcwRifLoadJobIT.java
@@ -1,6 +1,7 @@
 package gov.cms.bfd.pipeline.ccw.rif;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.Bucket;
@@ -14,8 +15,10 @@ import gov.cms.bfd.pipeline.ccw.rif.extract.s3.DataSetTestUtilities;
 import gov.cms.bfd.pipeline.ccw.rif.extract.s3.MockDataSetMonitorListener;
 import gov.cms.bfd.pipeline.ccw.rif.extract.s3.S3Utilities;
 import gov.cms.bfd.pipeline.ccw.rif.extract.s3.task.S3TaskManager;
+import java.net.URL;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -72,39 +75,76 @@ public final class CcwRifLoadJobIT {
    */
   @Test
   public void singleDataSetTest() throws Exception {
+    validateLoadAtLocations(
+        List.of(CcwRifLoadJob.S3_PREFIX_PENDING_DATA_SETS),
+        List.of(CcwRifLoadJob.S3_PREFIX_COMPLETED_DATA_SETS));
+  }
+
+  /**
+   * Tests {@link CcwRifLoadJob} when run against a bucket with a single data set within
+   * Synthetic/Incoming.
+   *
+   * @throws Exception (exceptions indicate test failure)
+   */
+  @Test
+  public void singleSyntheticDataSetTest() throws Exception {
+    validateLoadAtLocations(
+        List.of(CcwRifLoadJob.S3_PREFIX_PENDING_SYNTHETIC_DATA_SETS),
+        List.of(CcwRifLoadJob.S3_PREFIX_COMPLETED_SYNTHETIC_DATA_SETS));
+  }
+
+  /**
+   * Tests {@link CcwRifLoadJob} when run with data in the Synthetic/Incoming and Incoming folders.
+   * Data should be read and moved into the respective Done and Synthetic/Done folders.
+   *
+   * @throws Exception (exceptions indicate test failure)
+   */
+  @Test
+  public void multipleDataSetsWithSyntheticTest() throws Exception {
     AmazonS3 s3Client = S3Utilities.createS3Client(new ExtractionOptions("foo"));
     Bucket bucket = null;
     try {
       /*
-       * Create the (empty) bucket to run against, and populate it with a
-       * data set.
+       * Create the (empty) bucket to run against, and populate it with
+       * two data sets.
        */
       bucket = DataSetTestUtilities.createTestBucket(s3Client);
-      ExtractionOptions options = new ExtractionOptions(bucket.getName());
+      ExtractionOptions options =
+          new ExtractionOptions(bucket.getName(), Optional.empty(), Optional.of(1));
       LOGGER.info(
           "Bucket created: '{}:{}'",
           s3Client.getS3AccountOwner().getDisplayName(),
           bucket.getName());
+
       DataSetManifest manifest =
           new DataSetManifest(
               Instant.now(),
               0,
+              false,
+              new DataSetManifestEntry("beneficiaries.rif", RifFileType.BENEFICIARY));
+      DataSetManifest manifestSynthetic =
+          new DataSetManifest(
+              Instant.now().minus(1, ChronoUnit.DAYS),
+              0,
               true,
-              new DataSetManifestEntry("beneficiaries.rif", RifFileType.BENEFICIARY),
-              new DataSetManifestEntry("carrier.rif", RifFileType.CARRIER));
-      s3Client.putObject(DataSetTestUtilities.createPutRequest(bucket, manifest));
-      s3Client.putObject(
-          DataSetTestUtilities.createPutRequest(
-              bucket,
-              manifest,
-              manifest.getEntries().get(0),
-              StaticRifResource.SAMPLE_A_BENES.getResourceUrl()));
-      s3Client.putObject(
-          DataSetTestUtilities.createPutRequest(
-              bucket,
-              manifest,
-              manifest.getEntries().get(1),
-              StaticRifResource.SAMPLE_A_CARRIER.getResourceUrl()));
+              new DataSetManifestEntry("carrier.rif", RifFileType.CARRIER),
+              new DataSetManifestEntry("inpatient.rif", RifFileType.INPATIENT));
+
+      // Add files to each location the test wants them in
+      putSampleFilesInTestBucket(
+          s3Client,
+          bucket,
+          CcwRifLoadJob.S3_PREFIX_PENDING_DATA_SETS,
+          manifest,
+          List.of(StaticRifResource.SAMPLE_A_BENES.getResourceUrl()));
+      putSampleFilesInTestBucket(
+          s3Client,
+          bucket,
+          CcwRifLoadJob.S3_PREFIX_PENDING_SYNTHETIC_DATA_SETS,
+          manifestSynthetic,
+          List.of(
+              StaticRifResource.SAMPLE_A_CARRIER.getResourceUrl(),
+              StaticRifResource.SAMPLE_A_INPATIENT.getResourceUrl()));
 
       // Run the job.
       MockDataSetMonitorListener listener = new MockDataSetMonitorListener();
@@ -117,17 +157,18 @@ public final class CcwRifLoadJobIT {
               options,
               s3TaskManager,
               listener);
+      // Process both sets
+      ccwJob.call();
       ccwJob.call();
 
       // Verify what was handed off to the DataSetMonitorListener.
       assertEquals(0, listener.getNoDataAvailableEvents());
-      assertEquals(1, listener.getDataEvents().size());
-      assertEquals(manifest.getTimestamp(), listener.getDataEvents().get(0).getTimestamp());
-      assertEquals(
-          manifest.getEntries().size(), listener.getDataEvents().get(0).getFileEvents().size());
+      assertEquals(2, listener.getDataEvents().size());
       assertEquals(0, listener.getErrorEvents().size());
 
-      // Verify that the data set was renamed.
+      /*
+       * Verify that the datasets were moved to their respective locations.
+       */
       DataSetTestUtilities.waitForBucketObjectCount(
           s3Client,
           bucket,
@@ -137,9 +178,57 @@ public final class CcwRifLoadJobIT {
       DataSetTestUtilities.waitForBucketObjectCount(
           s3Client,
           bucket,
+          CcwRifLoadJob.S3_PREFIX_PENDING_SYNTHETIC_DATA_SETS,
+          0,
+          java.time.Duration.ofSeconds(10));
+      DataSetTestUtilities.waitForBucketObjectCount(
+          s3Client,
+          bucket,
           CcwRifLoadJob.S3_PREFIX_COMPLETED_DATA_SETS,
           1 + manifest.getEntries().size(),
           java.time.Duration.ofSeconds(10));
+      DataSetTestUtilities.waitForBucketObjectCount(
+          s3Client,
+          bucket,
+          CcwRifLoadJob.S3_PREFIX_COMPLETED_SYNTHETIC_DATA_SETS,
+          1 + manifestSynthetic.getEntries().size(),
+          java.time.Duration.ofSeconds(10));
+      assertTrue(
+          s3Client.doesObjectExist(
+              bucket.getName(),
+              CcwRifLoadJob.S3_PREFIX_COMPLETED_SYNTHETIC_DATA_SETS
+                  + "/"
+                  + manifestSynthetic.getTimestampText()
+                  + "/0_manifest.xml"));
+      assertTrue(
+          s3Client.doesObjectExist(
+              bucket.getName(),
+              CcwRifLoadJob.S3_PREFIX_COMPLETED_SYNTHETIC_DATA_SETS
+                  + "/"
+                  + manifestSynthetic.getTimestampText()
+                  + "/carrier.rif"));
+      assertTrue(
+          s3Client.doesObjectExist(
+              bucket.getName(),
+              CcwRifLoadJob.S3_PREFIX_COMPLETED_SYNTHETIC_DATA_SETS
+                  + "/"
+                  + manifestSynthetic.getTimestampText()
+                  + "/inpatient.rif"));
+      assertTrue(
+          s3Client.doesObjectExist(
+              bucket.getName(),
+              CcwRifLoadJob.S3_PREFIX_COMPLETED_DATA_SETS
+                  + "/"
+                  + manifest.getTimestampText()
+                  + "/0_manifest.xml"));
+      assertTrue(
+          s3Client.doesObjectExist(
+              bucket.getName(),
+              CcwRifLoadJob.S3_PREFIX_COMPLETED_DATA_SETS
+                  + "/"
+                  + manifest.getTimestampText()
+                  + "/beneficiaries.rif"));
+
     } finally {
       if (bucket != null) DataSetTestUtilities.deleteObjectsAndBucket(s3Client, bucket);
     }
@@ -399,6 +488,117 @@ public final class CcwRifLoadJobIT {
           java.time.Duration.ofSeconds(10));
     } finally {
       if (bucket != null) DataSetTestUtilities.deleteObjectsAndBucket(s3Client, bucket);
+    }
+  }
+
+  /**
+   * Validate load given the input locations to load files and output locations to look for the
+   * files once they're loaded.
+   *
+   * @param inputLocations the input locations (bucket keys) where files should be placed
+   * @param outputLocations the output locations (bucket keys) where files are expected to be moved
+   *     after processing
+   * @throws Exception the exception
+   */
+  private void validateLoadAtLocations(List<String> inputLocations, List<String> outputLocations)
+      throws Exception {
+    AmazonS3 s3Client = S3Utilities.createS3Client(new ExtractionOptions("foo"));
+    Bucket bucket = null;
+    try {
+      /*
+       * Create the (empty) bucket to run against, and populate it with a
+       * data set.
+       */
+      bucket = DataSetTestUtilities.createTestBucket(s3Client);
+      ExtractionOptions options = new ExtractionOptions(bucket.getName());
+      LOGGER.info(
+          "Bucket created: '{}:{}'",
+          s3Client.getS3AccountOwner().getDisplayName(),
+          bucket.getName());
+
+      DataSetManifest manifest =
+          new DataSetManifest(
+              Instant.now(),
+              0,
+              false,
+              new DataSetManifestEntry("beneficiaries.rif", RifFileType.BENEFICIARY),
+              new DataSetManifestEntry("carrier.rif", RifFileType.CARRIER));
+
+      // Add files to each location the test wants them in
+      for (String location : inputLocations) {
+        putSampleFilesInTestBucket(
+            s3Client,
+            bucket,
+            location,
+            manifest,
+            List.of(
+                StaticRifResource.SAMPLE_A_BENES.getResourceUrl(),
+                StaticRifResource.SAMPLE_A_CARRIER.getResourceUrl()));
+      }
+
+      // Run the job.
+      MockDataSetMonitorListener listener = new MockDataSetMonitorListener();
+      S3TaskManager s3TaskManager =
+          new S3TaskManager(
+              PipelineTestUtils.get().getPipelineApplicationState().getMetrics(), options);
+      CcwRifLoadJob ccwJob =
+          new CcwRifLoadJob(
+              PipelineTestUtils.get().getPipelineApplicationState().getMetrics(),
+              options,
+              s3TaskManager,
+              listener);
+      ccwJob.call();
+
+      // Verify what was handed off to the DataSetMonitorListener.
+      assertEquals(0, listener.getNoDataAvailableEvents());
+      assertEquals(1, listener.getDataEvents().size());
+      assertEquals(manifest.getTimestamp(), listener.getDataEvents().get(0).getTimestamp());
+      assertEquals(
+          manifest.getEntries().size(), listener.getDataEvents().get(0).getFileEvents().size());
+      assertEquals(0, listener.getErrorEvents().size());
+
+      // Verify that the data set was renamed.
+      for (String location : inputLocations) {
+        DataSetTestUtilities.waitForBucketObjectCount(
+            s3Client, bucket, location, 0, java.time.Duration.ofSeconds(10));
+      }
+
+      for (String location : outputLocations) {
+        DataSetTestUtilities.waitForBucketObjectCount(
+            s3Client,
+            bucket,
+            location,
+            1 + manifest.getEntries().size(),
+            java.time.Duration.ofSeconds(10));
+      }
+    } finally {
+      if (bucket != null) DataSetTestUtilities.deleteObjectsAndBucket(s3Client, bucket);
+    }
+  }
+
+  /**
+   * Put sample files in test specified bucket and key in s3.
+   *
+   * @param s3Client the s3 client
+   * @param bucket the bucket to use for the test
+   * @param location the key under which to put the file
+   * @param manifest the manifest to use for the load files
+   * @param resourcesToAdd the resource URLs to add to the bucket, see {@link StaticRifResource} for
+   *     resource lists, should be in the order of the manifest
+   */
+  private void putSampleFilesInTestBucket(
+      AmazonS3 s3Client,
+      Bucket bucket,
+      String location,
+      DataSetManifest manifest,
+      List<URL> resourcesToAdd) {
+    s3Client.putObject(DataSetTestUtilities.createPutRequest(bucket, manifest, location));
+    int index = 0;
+    for (URL resource : resourcesToAdd) {
+      s3Client.putObject(
+          DataSetTestUtilities.createPutRequest(
+              bucket, manifest, manifest.getEntries().get(index), resource, location));
+      index++;
     }
   }
 }

--- a/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/test/java/gov/cms/bfd/pipeline/ccw/rif/extract/s3/DataSetManifestTest.java
+++ b/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/test/java/gov/cms/bfd/pipeline/ccw/rif/extract/s3/DataSetManifestTest.java
@@ -231,6 +231,21 @@ public final class DataSetManifestTest {
   }
 
   /**
+   * Verifies that {@link DataSetManifestId}s can be round-tripped as expected when using the
+   * synthetic load key.
+   */
+  @Test
+  public void manifestSyntheticIdRoundtrip() {
+    String s3Key =
+        CcwRifLoadJob.S3_PREFIX_PENDING_SYNTHETIC_DATA_SETS
+            + "/2017-07-11T00:00:00.000Z/1_manifest.xml";
+    DataSetManifestId manifestId = DataSetManifestId.parseManifestIdFromS3Key(s3Key);
+
+    assertEquals(
+        s3Key, manifestId.computeS3Key(CcwRifLoadJob.S3_PREFIX_PENDING_SYNTHETIC_DATA_SETS));
+  }
+
+  /**
    * Just a simple little app that will use JAXB to marshall a sample {@link DataSetManifest} to
    * XML. This was used as the basis for the test resources used in these tests.
    *

--- a/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/test/java/gov/cms/bfd/pipeline/ccw/rif/extract/s3/DataSetManifestTest.java
+++ b/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/test/java/gov/cms/bfd/pipeline/ccw/rif/extract/s3/DataSetManifestTest.java
@@ -258,6 +258,8 @@ public final class DataSetManifestTest {
             Instant.now(),
             0,
             true,
+            CcwRifLoadJob.S3_PREFIX_PENDING_DATA_SETS,
+            CcwRifLoadJob.S3_PREFIX_COMPLETED_DATA_SETS,
             new DataSetManifestEntry("foo.xml", RifFileType.BENEFICIARY),
             new DataSetManifestEntry("bar.xml", RifFileType.PDE));
 

--- a/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/test/java/gov/cms/bfd/pipeline/ccw/rif/extract/s3/task/ManifestEntryDownloadTaskIT.java
+++ b/apps/bfd-pipeline/bfd-pipeline-ccw-rif/src/test/java/gov/cms/bfd/pipeline/ccw/rif/extract/s3/task/ManifestEntryDownloadTaskIT.java
@@ -59,6 +59,8 @@ public final class ManifestEntryDownloadTaskIT {
               Instant.now(),
               0,
               false,
+              CcwRifLoadJob.S3_PREFIX_PENDING_DATA_SETS,
+              CcwRifLoadJob.S3_PREFIX_COMPLETED_DATA_SETS,
               new DataSetManifestEntry("beneficiaries.rif", RifFileType.BENEFICIARY));
 
       // upload beneficiary sample file to S3 bucket created above


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BFD-2126](https://jira.cms.gov/browse/BFD-2126)

**User Story or Bug Summary:**
<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->
As a BFD engineer, I would like to have a second location that the ETL loads from, so that I can leave the Incoming folder uncluttered when I have hundreds of weeks future data folders created during synthetic data generation.

---

### What Does This PR Do?
<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

Updates a number of places needed to read loads from a new location, Synthetic/Incoming, and write the finished files from this location into Synthetic/Done. This will allow us to keep synthetic "future" loads in a storage location that does not clutter up the standard pipeline Incoming/Done folders.

- Add two new S3 prefix locations that the pipeline uses, Synthetic/Incoming and Synthetic/Done
    - Synthetic/Incoming is treated the same as Incoming for all intents and purposes, this is simply a second load location for organization and separation concerns
    - Synthetic/Done will be used to store any loads detected from within Synthetic/Incoming to keep the regular Done folder uncluttered for ease of debugging real loads in production
- In various places where we check the manifests/files, there is a switch that will verify if we're loading from Incoming or Synthetic/Incoming, so that we can grab the files from the right location, and move them to the corresponding location
    - Since this info on the manifest parent key isnt readily available in most places, we check the key by checking if the manifest (or one of its files) exists in one key (Incoming) or the other (Synthetic/Incoming); it should only ever exist in one place so this check should be sufficient
- Small refactoring where needed to aid in readability/reusability on areas touched
- Adds IT tests to check that items can be read from Synthetic/Incoming and are written out to Synthetic/Done

### What Should Reviewers Watch For?
<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items to the following list here -->
* Verify all PR security questions and checklists have been completed and addressed.
* If you know of any documentation pointing to the load locations of pipeline, let me know so I can update them

### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [x] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [x] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [x] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    