### PR TITLE
BFD-2178: Make Load Tests safer and improve associated documentation

### DIFF
--- a/apps/utils/locust_tests/services/server-load/Jenkinsfile
+++ b/apps/utils/locust_tests/services/server-load/Jenkinsfile
@@ -81,8 +81,8 @@ spec:
 
     string(name: 'COASTING_TIME',
            defaultValue: '10',
-           description: 'The amount of time the load test should continue for after receiving a '
-                        + 'scaling notification. Does not effect operator stop signals')
+           description: 'The amount of time, in seconds, the load test should continue for after '
+                        + 'receiving a scaling notification. Does not effect operator stop signals')
 
     string(name: 'WARM_INSTANCE_TARGET',
            defaultValue: '7',

--- a/apps/utils/locust_tests/services/server-load/Jenkinsfile
+++ b/apps/utils/locust_tests/services/server-load/Jenkinsfile
@@ -130,8 +130,12 @@ spec:
                 + "log group. Note that it can take a few moments for the controller to begin "
                 + "running tests")
 
+          runtimeLimit = params.TEST_RUNTIME_LIMIT.toInteger()
+          coastingTime = params.COASTING_TIME.toInteger()
+          maxRuntime = params.STOP_ON_SCALING ? runtimeLimit + coastingTime
+                                              : runtimeLimit
           try {
-            timeout(time: (params.TEST_RUNTIME_LIMIT.toInteger() + 600), unit: 'SECONDS') {
+            timeout(time: (maxRuntime + 600), unit: 'SECONDS') {
               input 'Once the run is finished, click either Abort or Proceed to cleanup the test'
             }
           } catch(err) {}

--- a/apps/utils/locust_tests/services/server-load/Jenkinsfile
+++ b/apps/utils/locust_tests/services/server-load/Jenkinsfile
@@ -76,13 +76,18 @@ spec:
 
     string(name: 'TEST_RUNTIME_LIMIT',
            defaultValue: '630',
-           description: 'The maximum runtime, in seconds, for the current load test. Acts as a '
-                        + 'failsafe against runaway load testing')
+           description: 'Runtime limit in seconds. If STOP_ON_SCALING is false, this limit is the '
+                        + 'total amount of time the load test has to run. If STOP_ON_SCALING is '
+                        + 'true, this limit indicates the amount of time to check for scaling '
+                        + 'notifications during a test run before stopping. In this case, the '
+                        + 'total maximum runtime is assumed to be '
+                        + 'TEST_RUNTIME_LIMIT + COASTING_TIME')
 
     string(name: 'COASTING_TIME',
            defaultValue: '10',
            description: 'The amount of time, in seconds, the load test should continue for after '
-                        + 'receiving a scaling notification. Does not effect operator stop signals')
+                        + 'receiving a scaling notification. Ignored if STOP_ON_SCALING is false. '
+                        + 'Ends immediately on operator stop signal')
 
     string(name: 'WARM_INSTANCE_TARGET',
            defaultValue: '7',

--- a/apps/utils/locust_tests/services/server-load/Jenkinsfile
+++ b/apps/utils/locust_tests/services/server-load/Jenkinsfile
@@ -96,9 +96,9 @@ spec:
 
     booleanParam(name: 'STOP_ON_SCALING',
                  defaultValue: true,
-                 description: 'Whether the load test run should end once receiving a scaling '
-                              + 'notification. Set to false for scenarios where a static load test '
-                              + 'is desired')
+                 description: 'Whether the load test run should end, if COASTING_TIME is zero, or '
+                              + 'start coasting once receiving a scaling notification. Set to '
+                              + 'false for scenarios where a static load test is desired')
 
     booleanParam(name: 'STOP_ON_NODE_LIMIT',
                  defaultValue: true,

--- a/apps/utils/locust_tests/services/server-load/controller/controller.py
+++ b/apps/utils/locust_tests/services/server-load/controller/controller.py
@@ -195,10 +195,13 @@ def _main():
             break
 
     if has_scaling_target_hit and coasting_time > 0:
-        print(f"Coasting after scaling event for {coasting_time} seconds...")
+        print(
+            f"Coasting after scaling event for {coasting_time} seconds, or until the Locust process"
+            " has ended..."
+        )
 
         coast_until_time = datetime.now() + timedelta(seconds=coasting_time)
-        while datetime.now() < coast_until_time:
+        while datetime.now() < coast_until_time and locust_process.poll() is None:
             messages = check_queue(
                 queue=queue,
                 timeout=1,

--- a/apps/utils/locust_tests/services/server-load/controller/controller.py
+++ b/apps/utils/locust_tests/services/server-load/controller/controller.py
@@ -153,7 +153,7 @@ def _main():
         if spawn_count == 0
         else datetime.now() + timedelta(seconds=node_spawn_time + 1)
     )
-    while locust_process.returncode is None:
+    while locust_process.poll() is None:
         if datetime.now() >= runtime_limit_end:
             print(f"User provided runtime of {runtime_limit} seconds has been exceeded, stopping")
             break
@@ -216,14 +216,14 @@ def _main():
     queue.send_message(MessageBody=json.dumps(QUEUE_STOP_SIGNAL_FILTERS[0]))
     print("Stop signal sent successfully")
 
-    if locust_process.returncode:
-        # If returncode is not None, then the locust process has finished on its own and we do not
+    if locust_process.poll():
+        # If poll() is not None, then the locust process has finished on its own and we do not
         # need to end it manually
         print("Locust master process ended without intervention, stopping...")
         return
 
     if not has_received_stop:
-        print("Waiting an addiitional 10 seconds to allow worker nodes to submit statistics...")
+        print("Waiting an additional 10 seconds to allow worker nodes to submit statistics...")
         time.sleep(10)
         print("10 second wait period has elapsed")
 

--- a/apps/utils/locust_tests/services/server-load/controller/controller.py
+++ b/apps/utils/locust_tests/services/server-load/controller/controller.py
@@ -196,7 +196,19 @@ def _main():
 
     if has_scaling_target_hit and coasting_time > 0:
         print(f"Coasting after scaling event for {coasting_time} seconds...")
-        time.sleep(coasting_time)
+
+        coast_until_time = datetime.now() + timedelta(seconds=coasting_time)
+        while datetime.now() < coast_until_time:
+            messages = check_queue(
+                queue=queue,
+                timeout=1,
+            )
+
+            if any(filter_message_by_keys(msg, QUEUE_STOP_SIGNAL_FILTERS) for msg in messages):
+                has_received_stop = True
+                print("Stop signal encountered, stopping")
+                break
+
         print("Coasting time complete")
 
     # Unconditionally send a stop signal to the queue to force all nodes to stop

--- a/apps/utils/locust_tests/services/server-load/node/node.py
+++ b/apps/utils/locust_tests/services/server-load/node/node.py
@@ -173,10 +173,13 @@ def handler(event, context):
         return
 
     if has_scaling_target_hit and coasting_time > 0:
-        print(f"Coasting after scaling event for {coasting_time} seconds before stopping...")
+        print(
+            f"Coasting after scaling event for {coasting_time} seconds, or until the Locust process"
+            " has ended..."
+        )
 
         coast_until_time = datetime.now() + timedelta(seconds=coasting_time)
-        while datetime.now() < coast_until_time:
+        while datetime.now() < coast_until_time and process.poll() is None:
             messages = check_queue(
                 queue=queue,
                 timeout=1,

--- a/apps/utils/locust_tests/services/server-load/node/node.py
+++ b/apps/utils/locust_tests/services/server-load/node/node.py
@@ -1,10 +1,10 @@
-"""A lambda function that coordinates running a Locuster worker node in a swarm of many Locust
+"""A lambda function that coordinates running a Locust worker node in a swarm of many Locust
 workers all communicating with a single Locust master, the "controller"."""
 
-import asyncio
 import datetime
 import functools
 import os
+import subprocess
 import sys
 import urllib.parse
 from dataclasses import dataclass
@@ -66,10 +66,6 @@ def handler(event, context):
     Handles execution of a worker node.
     """
 
-    asyncio.run(_async_handler(event))
-
-
-async def _async_handler(event):
     try:
         invoke_event = InvokeEvent(**event)
     except TypeError as ex:
@@ -126,24 +122,27 @@ async def _async_handler(event):
         f"master-port: {invoke_event.locust_port}"
     )
 
-    process = await asyncio.create_subprocess_exec(
-        "locust",
-        f"--locustfile={os.path.join(locust_tests_dir, 'high_volume_suite.py')}",
-        f"--host={invoke_event.host}",
-        f"--database-uri={db_dsn}",
-        f"--client-cert-path={cert_path}",
-        "--worker",
-        f"--master-host={invoke_event.controller_ip}",
-        f"--master-port={invoke_event.locust_port}",
-        "--headless",
-        "--only-summary",
+    process = subprocess.Popen(
+        [
+            "locust",
+            f"--locustfile={os.path.join(locust_tests_dir, 'high_volume_suite.py')}",
+            f"--host={invoke_event.host}",
+            f"--database-uri={db_dsn}",
+            f"--client-cert-path={cert_path}",
+            "--worker",
+            f"--master-host={invoke_event.controller_ip}",
+            f"--master-port={invoke_event.locust_port}",
+            "--headless",
+            "--only-summary",
+        ],
         cwd=locust_tests_dir,
+        stderr=subprocess.STDOUT,
     )
 
     print(f"Started locust worker with pid {process.pid}")
 
     has_scaling_target_hit = False
-    while process.returncode is None:
+    while process.poll() is None:
         scale_or_stop_events = check_queue(
             queue=queue,
             timeout=1,
@@ -167,8 +166,8 @@ async def _async_handler(event):
             )
             break
 
-    if process.returncode:
-        # If returncode is not None, then the locust process has finished on its own and we do not
+    if process.poll():
+        # If poll() is not None, then the locust process has finished on its own and we do not
         # need to end it manually
         print("Locust worker process ended without intervention, stopping...")
         return
@@ -196,12 +195,5 @@ async def _async_handler(event):
         print("Could not terminate Locust worker subprocess")
         print(f"Received exception {e}")
 
-    await process.wait()
-
-    # Accessing a protected member on purpose to work around known problem with
-    # orphaned processes in asyncio.
-    # If the process is already closed, this is a noop.
-    # pylint: disable=protected-access
-    process._transport.close()
-
+    process.wait()
     print("Locust worker node process has been stopped")

--- a/ops/terraform/services/server/server-load/variables.tf
+++ b/ops/terraform/services/server/server-load/variables.tf
@@ -59,13 +59,13 @@ variable "user_spawn_rate" {
 }
 
 variable "test_runtime_limit" {
-  description = "The maximum runtime, in seconds, for the current load test. Acts as a failsafe against runaway load testing"
+  description = "Runtime limit in seconds. If stop_on_scaling is false, this limit is the total amount of time the load test has to run. If stop_on_scaling is true, this limit indicates the amount of time to check for scaling notifications during a test run before stopping"
   type        = number
   default     = 0
 }
 
 variable "coasting_time" {
-  description = "The amount of time, in seconds, the load test should continue for after receiving a scaling notification. Does not effect operator stop signals"
+  description = "The amount of time, in seconds, the load test should continue for after receiving a scaling notification. Ignored if stop_on_scaling is false. Ends immediately on operator stop signal"
   type        = number
   default     = 0
 }

--- a/ops/terraform/services/server/server-load/variables.tf
+++ b/ops/terraform/services/server/server-load/variables.tf
@@ -77,7 +77,7 @@ variable "warm_instance_target" {
 }
 
 variable "stop_on_scaling" {
-  description = "Whether the load test run should end once receiving a scaling notification. Set to false for scenarios where a static load test is desired"
+  description = "Whether the load test run should end, if coasting_time is zero, or start coasting once receiving a scaling notification. Set to false for scenarios where a static load test is desired"
   type        = bool
   default     = true
 }

--- a/ops/terraform/services/server/server-load/variables.tf
+++ b/ops/terraform/services/server/server-load/variables.tf
@@ -65,7 +65,7 @@ variable "test_runtime_limit" {
 }
 
 variable "coasting_time" {
-  description = "The amount of time the load test should continue for after receiving a scaling notification. Does not effect operator stop signals"
+  description = "The amount of time, in seconds, the load test should continue for after receiving a scaling notification. Does not effect operator stop signals"
   type        = number
   default     = 0
 }


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BFD-2178](https://jira.cms.gov/browse/BFD-2178)

**User Story or Bug Summary:**

<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->

As a BFD Engineer, I want the Load Tests to be safe to run and to immediately stop when I choose to
stop them. Additionally, I want the documentation (including Job parameter descriptions) associated
to the Load Tests to be as clear and accurate as possible so that there is no question what the Load
Tests behavior is.

---

### What Does This PR Do?

<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

This PR:

- Changes the descriptions of several parameters to be more accurate and more precise about their
  behaviors
- Changes the way the Jenkins job timeout is calculated if `STOP_ON_SCALING` is `true` such that
  `COASTING_TIME` is also accounted for in the timeout
- Removes all `async` code from `node.py`, replacing it with non-`async` equivalents from the
  `subprocess` module
- Replaces the naive `time.sleep()` that constituted "coasting time" with a loop that constantly
  polls for a stop signal. Previously, if an operator sent a stop signal during the coasting period
  nothing would happen. Now, if a stop signal is received during the coasting period, the load test
  will end as expected
- Fixes the way the Locust subprocess's status for both the Controller and Node is checked by using
  `poll()` instead of `returncode`

### What Should Reviewers Watch For?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:

<!-- Add some items to the following list here -->

- Do the new descriptions for `TEST_RUNTIME_LIMIT`, `COASTING_TIME`, and `STOP_ON_SCALING` make
  sense?
- Does the code make sense?
- Verify all PR security questions and checklists have been completed and addressed.

### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

- If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

  - Does this PR add any new software dependencies?
    - [ ] Yes
    - [x] No
  - Does this PR modify or invalidate any of our security controls?
    - [ ] Yes
    - [x] No
  - Does this PR store or transmit data that was not stored or transmitted before?
    - [ ] Yes
    - [x] No

- If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
  - Do you think this PR requires additional review of its security implications for other reasons?
    - [ ] Yes
    - [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

- N/A

### Submitter Checklist

<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

- [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
- [x] This PR is reasonably limited in scope, to help ensure that:
  1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
  2. There isn't too much of a burden on reviewers.
  3. Any problems it causes have a small "blast radius".
  4. It'll be easier to rollback if that becomes necessary.
- [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
- [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
- [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
- [x] Reviews are requested from both:
  - At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
  - Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
- [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
  - Please review the standards every few months to ensure you're familiar with them.
