### PR TITLE
BFD-2164: Enable default S3 server-side encryption

### DIFF
--- a/ops/terraform/env/global/s3/legacy.tf
+++ b/ops/terraform/env/global/s3/legacy.tf
@@ -11,6 +11,15 @@ resource "aws_s3_bucket_public_access_block" "cf-bfd-management-vpc" {
   restrict_public_buckets = true
 }
 
+resource "aws_s3_bucket_server_side_encryption_configuration" "cf-bfd-management-vpc" {
+  bucket = aws_s3_bucket.cf-bfd-management-vpc.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
 resource "aws_s3_bucket" "cf-bfd-prod-vpc" {
   bucket = "cf-bfd-prod-vpc"
 }
@@ -22,6 +31,15 @@ resource "aws_s3_bucket_public_access_block" "cf-bfd-prod-vpc" {
   block_public_policy     = true
   ignore_public_acls      = true
   restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "cf-bfd-prod-vpc" {
+  bucket = aws_s3_bucket.cf-bfd-prod-vpc.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
 }
 
 resource "aws_s3_bucket" "cf-bfd-prod-sbx-vpc" {
@@ -37,6 +55,15 @@ resource "aws_s3_bucket_public_access_block" "cf-bfd-prod-sbx-vpc" {
   restrict_public_buckets = true
 }
 
+resource "aws_s3_bucket_server_side_encryption_configuration" "cf-bfd-prod-sbx-vpc" {
+  bucket = aws_s3_bucket.cf-bfd-prod-sbx-vpc.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
 resource "aws_s3_bucket" "cf-templates-13lbg6e67ga5v-us-east-1" {
   bucket = "cf-templates-13lbg6e67ga5v-us-east-1"
 }
@@ -50,6 +77,15 @@ resource "aws_s3_bucket_public_access_block" "cf-templates-13lbg6e67ga5v-us-east
   restrict_public_buckets = true
 }
 
+resource "aws_s3_bucket_server_side_encryption_configuration" "cf-templates-13lbg6e67ga5v-us-east-1" {
+  bucket = aws_s3_bucket.cf-templates-13lbg6e67ga5v-us-east-1.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
 resource "aws_s3_bucket" "bfd-config" {
   bucket = "bfd-config-${local.account_id}"
 }
@@ -61,4 +97,35 @@ resource "aws_s3_bucket_public_access_block" "bfd-config" {
   block_public_policy     = true
   ignore_public_acls      = true
   restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "bfd-config" {
+  bucket = aws_s3_bucket.bfd-config.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket" "cf-bfd-vpc-template" {
+  bucket = "cf-bfd-vpc-template"
+}
+
+resource "aws_s3_bucket_public_access_block" "cf-bfd-vpc-template" {
+  bucket = aws_s3_bucket.cf-bfd-vpc-template.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "cf-bfd-vpc-template" {
+  bucket = aws_s3_bucket.cf-bfd-vpc-template.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
 }

--- a/ops/terraform/env/global/s3/synthea.tf
+++ b/ops/terraform/env/global/s3/synthea.tf
@@ -1,0 +1,21 @@
+resource "aws_s3_bucket" "synthea" {
+  bucket = "bfd-synthea"
+}
+
+resource "aws_s3_bucket_public_access_block" "synthea" {
+  bucket = aws_s3_bucket.synthea.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "synthea" {
+  bucket = aws_s3_bucket.synthea.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}

--- a/ops/terraform/env/global/s3/temporary.tf
+++ b/ops/terraform/env/global/s3/temporary.tf
@@ -2,7 +2,6 @@ resource "aws_s3_bucket" "aws-glue-scripts" {
   bucket = "aws-glue-scripts-${local.account_id}-us-east-1"
 }
 
-
 resource "aws_s3_bucket_public_access_block" "aws-glue-scripts" {
   bucket = aws_s3_bucket.aws-glue-scripts.id
 
@@ -10,6 +9,15 @@ resource "aws_s3_bucket_public_access_block" "aws-glue-scripts" {
   block_public_policy     = true
   ignore_public_acls      = true
   restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "aws-glue-scripts" {
+  bucket = aws_s3_bucket.aws-glue-scripts.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
 }
 
 resource "aws_s3_bucket" "aws-athena-query-results" {
@@ -25,6 +33,16 @@ resource "aws_s3_bucket_public_access_block" "aws-athena-query-results" {
   restrict_public_buckets = true
 }
 
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "aws-athena-query-results" {
+  bucket = aws_s3_bucket.aws-athena-query-results.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
 resource "aws_s3_bucket" "aws-glue-temporary" {
   bucket = "aws-glue-temporary-${local.account_id}-us-east-1"
 }
@@ -36,4 +54,35 @@ resource "aws_s3_bucket_public_access_block" "aws-glue-temporary" {
   block_public_policy     = true
   ignore_public_acls      = true
   restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "aws-glue-temporary" {
+  bucket = aws_s3_bucket.aws-glue-temporary.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket" "aws-glue-assets" {
+  bucket = "aws-glue-assets-${local.account_id}-us-east-1"
+}
+
+resource "aws_s3_bucket_public_access_block" "aws-glue-assets" {
+  bucket = aws_s3_bucket.aws-glue-assets.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "aws-glue-assets" {
+  bucket = aws_s3_bucket.aws-glue-assets.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
 }


### PR DESCRIPTION
**JIRA Ticket:**
[BFD-2164](https://jira.cms.gov/browse/BFD-2164)

**User Story or Bug Summary:**
This successfully remediates Security Hub Findings associated with AWS Foundational Security Best Practices v1.0.0 S3.4: _S3 buckets should have server-side encryption enabled_.

---

### What Does This PR Do?
- import additional, unmanaged S3 buckets into the global module (glue-assets, cf-bfd-vpc-template, bfd-synthea)
- apply appropriate default encryption settings for each bucket in the global module where necessary

### What Should Reviewers Watch For?
* Verify all PR security questions and checklists have been completed and addressed.

### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [x] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [x] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [x] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    