### PR TITLE
BFD-2166: Encrypt SNS topics

### DIFF
--- a/ops/terraform/env/global/kms/.terraform-docs.yml
+++ b/ops/terraform/env/global/kms/.terraform-docs.yml
@@ -1,0 +1,50 @@
+formatter: markdown table
+sections:
+  show:
+    - requirements
+    - resources
+    - data-sources
+
+# this `content` string is implemented as a golang template https://pkg.go.dev/text/template
+# updates here correspond to `{{ .Content }}` in `output.template` setting below
+content: |-
+    {{ .Requirements }}
+
+    <!-- GENERATED WITH `terraform-docs .`
+         Manually updating the README.md will be overwritten.
+         For more details, see the file '.terraform-docs.yml' or
+         https://terraform-docs.io/user-guide/configuration/
+    -->
+
+    {{ .Inputs }}
+
+    <!-- GENERATED WITH `terraform-docs .`
+         Manually updating the README.md will be overwritten.
+         For more details, see the file '.terraform-docs.yml' or
+         https://terraform-docs.io/user-guide/configuration/
+    -->
+
+    {{ .Resources }}
+
+output:
+  file: README.md
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    <!-- GENERATED WITH `terraform-docs .`
+         Manually updating the README.md will be overwritten.
+         For more details, see the file '.terraform-docs.yml' or
+         https://terraform-docs.io/user-guide/configuration/
+    -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->
+
+sort:
+  enabled: true
+  by: required
+
+settings:
+  indent: 2
+  default: true
+  required: true
+  type: true

--- a/ops/terraform/env/global/kms/README.md
+++ b/ops/terraform/env/global/kms/README.md
@@ -1,0 +1,46 @@
+# BFD Global KMS Definitions
+
+This module is home, _if temporarily_, to the _path-to-production_ environment-specific AWS KMS CMKs.
+
+**WARNING: This module is incomplete.**
+
+**WARNING: This module lacks automated application. Changes here must be applied manually.**
+
+**NOTE: If you're manipulating this state manually, you must verify that you're operating in the appropriate workspace for the targeted environment.**
+
+<!-- BEGIN_TF_DOCS -->
+<!-- GENERATED WITH `terraform-docs .`
+     Manually updating the README.md will be overwritten.
+     For more details, see the file '.terraform-docs.yml' or
+     https://terraform-docs.io/user-guide/configuration/
+-->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4 |
+
+<!-- GENERATED WITH `terraform-docs .`
+Manually updating the README.md will be overwritten.
+For more details, see the file '.terraform-docs.yml' or
+https://terraform-docs.io/user-guide/configuration/
+-->
+
+
+
+<!-- GENERATED WITH `terraform-docs .`
+Manually updating the README.md will be overwritten.
+For more details, see the file '.terraform-docs.yml' or
+https://terraform-docs.io/user-guide/configuration/
+-->
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_kms_alias.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
+| [aws_kms_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_user.kms_key_admins](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_user) | data source |
+| [aws_ssm_parameter.kms_key_admins](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+<!-- END_TF_DOCS -->

--- a/ops/terraform/env/global/kms/main.tf
+++ b/ops/terraform/env/global/kms/main.tf
@@ -1,15 +1,147 @@
 provider "aws" {
-  version = "~> 3.44.0"
+  version = "~> 4"
   region  = "us-east-1"
 }
 
-resource "aws_kms_key" "state_kms_key" {
-  description             = "bfd-tf-state"
-  deletion_window_in_days = 10
-  enable_key_rotation     = true
+locals {
+  account_id     = data.aws_caller_identity.current.account_id
+  env            = terraform.workspace
+  kms_key_alias  = "alias/bfd-${local.env}-cmk"
+  kms_key_admins = sort([for user in values(data.aws_iam_user.kms_key_admins) : user.arn])
+
+  shared_tags = {
+    Environment = local.env
+    application = "bfd"
+    business    = "oeda"
+    stack       = local.env
+  }
 }
 
-resource "aws_kms_alias" "state_kms_alias" {
-  name          = "alias/bfd-tf-state"
-  target_key_id = aws_kms_key.state_kms_key.key_id
+data "aws_caller_identity" "current" {}
+
+# TODO: populating this SSM value isn't defined anywhere yet.
+data "aws_ssm_parameter" "kms_key_admins" {
+  name = "/bfd/global/terraform/sensitive/kms_key_admins"
+}
+
+# TODO: this may fail on subsequent versions of terraform with sensitive value incompatibility with for_each statements
+#       and might require wrapping in a call to `nonsensitive()`
+data "aws_iam_user" "kms_key_admins" {
+  for_each  = toset(split(" ", data.aws_ssm_parameter.kms_key_admins.value))
+  user_name = each.value
+}
+
+resource "aws_kms_key" "this" {
+  enable_key_rotation                = true
+  bypass_policy_lockout_safety_check = false
+  tags                               = local.shared_tags
+  policy = jsonencode(
+    {
+      "Version" : "2012-10-17",
+      "Id" : "key-consolepolicy-3",
+      "Statement" : [
+        {
+          "Sid" : "Enable IAM User Permissions",
+          "Effect" : "Allow",
+          "Principal" : {
+            "AWS" : "arn:aws:iam::${local.account_id}:root"
+          },
+          "Action" : "kms:*",
+          "Resource" : "*"
+        },
+        {
+          "Sid" : "Allow access for Key Administrators",
+          "Effect" : "Allow",
+          "Principal" : {
+            "AWS" : local.kms_key_admins
+          },
+          "Action" : [
+            "kms:Create*",
+            "kms:Describe*",
+            "kms:Enable*",
+            "kms:List*",
+            "kms:Put*",
+            "kms:Update*",
+            "kms:Revoke*",
+            "kms:Disable*",
+            "kms:Get*",
+            "kms:TagResource",
+            "kms:UntagResource",
+            "kms:ScheduleKeyDeletion",
+            "kms:CancelKeyDeletion"
+          ],
+          "Resource" : "*"
+        },
+        {
+          "Sid" : "Allow use of the key",
+          "Effect" : "Allow",
+          "Principal" : {
+            "AWS" : [
+              "arn:aws:iam::${local.account_id}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
+            ]
+          },
+          "Action" : [
+            "kms:Encrypt",
+            "kms:Decrypt",
+            "kms:ReEncryptTo",
+            "kms:GenerateDataKey",
+            "kms:GenerateDataKeyWithoutPlaintext",
+            "kms:DescribeKey"
+          ],
+          "Resource" : "*"
+        },
+        {
+          "Sid" : "Allow attachment of persistent resources",
+          "Effect" : "Allow",
+          "Principal" : {
+            "AWS" : [
+              "arn:aws:iam::${local.account_id}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
+            ]
+          },
+          "Action" : [
+            "kms:CreateGrant",
+            "kms:ListGrants",
+            "kms:RevokeGrant"
+          ],
+          "Resource" : "*",
+          "Condition" : {
+            "Bool" : {
+              "kms:GrantIsForAWSResource" : "true"
+            }
+          }
+        },
+        {
+          "Sid" : "Allow CloudWatch to use the key to encrypt log groups",
+          "Effect" : "Allow",
+          "Principal" : {
+            "Service" : "logs.us-east-1.amazonaws.com"
+          },
+          "Action" : [
+            "kms:Encrypt",
+            "kms:Decrypt",
+            "kms:ReEncrypt",
+            "kms:GenerateDataKey",
+            "kms:Describe"
+          ],
+          "Resource" : "*"
+        },
+        {
+          "Sid" : "Allow_CloudWatch_for_CMK",
+          "Effect" : "Allow",
+          "Principal" : {
+            "Service" : "cloudwatch.amazonaws.com"
+          },
+          "Action" : [
+            "kms:Decrypt",
+            "kms:GenerateDataKey*"
+          ],
+          "Resource" : "*"
+        }
+      ]
+  })
+}
+
+resource "aws_kms_alias" "this" {
+  name          = local.kms_key_alias
+  target_key_id = aws_kms_key.this.arn
 }

--- a/ops/terraform/modules/resources/iam/main.tf
+++ b/ops/terraform/modules/resources/iam/main.tf
@@ -78,6 +78,7 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_xray_policy" {
   policy_arn = data.aws_iam_policy.cloudwatch_xray_policy.arn
 }
 
+# TODO: Separate SSM and KMS statements
 resource "aws_iam_policy" "ssm" {
   name        = "bfd-${var.env_config.env}-${local.service}-ssm-parameters"
   description = "Permissions to /bfd/${var.env_config.env}/common/nonsensitive, /bfd/${var.env_config.env}/${local.service} SSM hierarchies"
@@ -101,7 +102,13 @@ resource "aws_iam_policy" "ssm" {
     {
       "Effect": "Allow",
       "Action": [
-        "kms:Decrypt"
+        "kms:Decrypt",
+        "kms:GenerateDataKey",
+        "kms:ReEncrypt",
+        "kms:DescribeKey",
+        "kms:CreateGrant",
+        "kms:ListGrants",
+        "kms:RevokeGrant"
       ],
       "Resource": [
         "${data.aws_kms_key.master_key.arn}"

--- a/ops/terraform/modules/stateful/main.tf
+++ b/ops/terraform/modules/stateful/main.tf
@@ -2,12 +2,12 @@
 # Stateful resources for an environment and associated KMS needed by both stateful and stateless resources
 
 locals {
-  account_id        = data.aws_caller_identity.current.account_id
-  azs               = ["us-east-1a", "us-east-1b", "us-east-1c"]
-  env_config        = { env = var.env_config.env, tags = var.env_config.tags, vpc_id = data.aws_vpc.main.id, zone_id = module.local_zone.zone_id }
-  is_prod           = substr(var.env_config.env, 0, 4) == "prod"
-  victor_ops_url    = var.victor_ops_url
-  enable_victor_ops = local.is_prod # only wake people up for prod alarms
+  account_id                       = data.aws_caller_identity.current.account_id
+  azs                              = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  env_config                       = { env = var.env_config.env, tags = var.env_config.tags, vpc_id = data.aws_vpc.main.id, zone_id = module.local_zone.zone_id }
+  is_prod                          = substr(var.env_config.env, 0, 4) == "prod"
+  victor_ops_url                   = var.victor_ops_url
+  enable_victor_ops                = local.is_prod # only wake people up for prod alarms
   cloudwatch_sns_topic_policy_spec = <<-EOF
 {
   "Version": "2008-10-17",
@@ -132,7 +132,7 @@ resource "aws_sns_topic" "cloudwatch_alarms" {
 }
 
 resource "aws_sns_topic_policy" "cloudwatch_alarms" {
-  arn = aws_sns_topic.cloudwatch_alarms.arn
+  arn    = aws_sns_topic.cloudwatch_alarms.arn
   policy = format(local.cloudwatch_sns_topic_policy_spec, aws_sns_topic.cloudwatch_alarms.arn, aws_sns_topic.cloudwatch_alarms.arn)
 }
 
@@ -153,7 +153,7 @@ resource "aws_sns_topic" "cloudwatch_ok" {
 }
 
 resource "aws_sns_topic_policy" "cloudwatch_ok" {
-  arn = aws_sns_topic.cloudwatch_ok.arn
+  arn    = aws_sns_topic.cloudwatch_ok.arn
   policy = format(local.cloudwatch_sns_topic_policy_spec, aws_sns_topic.cloudwatch_ok.arn, aws_sns_topic.cloudwatch_ok.arn)
 }
 

--- a/ops/terraform/modules/stateful/main.tf
+++ b/ops/terraform/modules/stateful/main.tf
@@ -8,6 +8,50 @@ locals {
   is_prod           = substr(var.env_config.env, 0, 4) == "prod"
   victor_ops_url    = var.victor_ops_url
   enable_victor_ops = local.is_prod # only wake people up for prod alarms
+  cloudwatch_sns_topic_policy_spec = <<-EOF
+{
+  "Version": "2008-10-17",
+  "Id": "__default_policy_ID",
+  "Statement": [
+    {
+        "Sid": "Allow_Publish_Alarms",
+        "Effect": "Allow",
+        "Principal":
+        {
+            "Service": [
+                "cloudwatch.amazonaws.com"
+            ]
+        },
+        "Action": "sns:Publish",
+        "Resource": "%s"
+    },
+    {
+      "Sid": "__default_statement_ID",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": [
+        "SNS:GetTopicAttributes",
+        "SNS:SetTopicAttributes",
+        "SNS:AddPermission",
+        "SNS:RemovePermission",
+        "SNS:DeleteTopic",
+        "SNS:Subscribe",
+        "SNS:ListSubscriptionsByTopic",
+        "SNS:Publish",
+        "SNS:Receive"
+      ],
+      "Resource": "%s",
+      "Condition": {
+        "StringEquals": {
+          "AWS:SourceOwner": "${local.account_id}"
+        }
+      }
+    }
+  ]
+}
+EOF
 }
 
 data "aws_caller_identity" "current" {}
@@ -31,11 +75,6 @@ data "aws_vpc" "main" {
 # kms 
 data "aws_kms_key" "master_key" {
   key_id = "alias/bfd-${var.env_config.env}-cmk"
-}
-
-# sns kms key
-data "aws_kms_key" "sns_key" {
-  key_id = "alias/aws/sns"
 }
 
 # subnets
@@ -86,11 +125,15 @@ module "local_zone" {
 ## CloudWatch SNS Topics for Alarms
 #
 resource "aws_sns_topic" "cloudwatch_alarms" {
-  name         = "bfd-${var.env_config.env}-cloudwatch-alarms"
-  display_name = "BFD Cloudwatch Alarm. Created by Terraform."
-  tags         = var.env_config.tags
-  
-  kms_master_key_id = data.aws_kms_key.sns_key.id
+  name              = "bfd-${var.env_config.env}-cloudwatch-alarms"
+  display_name      = "BFD Cloudwatch Alarm. Created by Terraform."
+  tags              = var.env_config.tags
+  kms_master_key_id = data.aws_kms_key.master_key.id
+}
+
+resource "aws_sns_topic_policy" "cloudwatch_alarms" {
+  arn = aws_sns_topic.cloudwatch_alarms.arn
+  policy = format(local.cloudwatch_sns_topic_policy_spec, aws_sns_topic.cloudwatch_alarms.arn, aws_sns_topic.cloudwatch_alarms.arn)
 }
 
 resource "aws_sns_topic_subscription" "alarm" {
@@ -106,7 +149,12 @@ resource "aws_sns_topic" "cloudwatch_ok" {
   display_name = "BFD Cloudwatch OK notifications. Created by Terraform."
   tags         = var.env_config.tags
 
-  kms_master_key_id = data.aws_kms_key.sns_key.id
+  kms_master_key_id = data.aws_kms_key.master_key.arn
+}
+
+resource "aws_sns_topic_policy" "cloudwatch_ok" {
+  arn = aws_sns_topic.cloudwatch_ok.arn
+  policy = format(local.cloudwatch_sns_topic_policy_spec, aws_sns_topic.cloudwatch_ok.arn, aws_sns_topic.cloudwatch_ok.arn)
 }
 
 resource "aws_sns_topic_subscription" "ok" {

--- a/ops/terraform/services/server/server-load/README.md
+++ b/ops/terraform/services/server/server-load/README.md
@@ -22,7 +22,7 @@ https://terraform-docs.io/user-guide/configuration/
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_coasting_time"></a> [coasting\_time](#input\_coasting\_time) | The amount of time the load test should continue for after receiving a scaling notification. Does not effect operator stop signals | `number` | `0` | no |
+| <a name="input_coasting_time"></a> [coasting\_time](#input\_coasting\_time) | The amount of time, in seconds, the load test should continue for after receiving a scaling notification. Ignored if stop\_on\_scaling is false. Ends immediately on operator stop signal | `number` | `0` | no |
 | <a name="input_container_image_tag_node_override"></a> [container\_image\_tag\_node\_override](#input\_container\_image\_tag\_node\_override) | Overrides the Container image URI used by the built load suite worker node lambda | `string` | `null` | no |
 | <a name="input_create_locust_instance"></a> [create\_locust\_instance](#input\_create\_locust\_instance) | When true, create the locust instance | `bool` | `false` | no |
 | <a name="input_initial_worker_nodes"></a> [initial\_worker\_nodes](#input\_initial\_worker\_nodes) | The number of initial Locust worker nodes to spawn before checking for stop signals. Useful for static load tests | `number` | `0` | no |
@@ -32,9 +32,9 @@ https://terraform-docs.io/user-guide/configuration/
 | <a name="input_node_spawn_time"></a> [node\_spawn\_time](#input\_node\_spawn\_time) | The amount of time to wait between spawning more Lambda Locust worker nodes. Does not affect initial spawned nodes | `number` | `10` | no |
 | <a name="input_sqs_queue_name"></a> [sqs\_queue\_name](#input\_sqs\_queue\_name) | The name of the SQS queue that will be polled for scaling notifications or stop signals | `string` | `"bfd-test-server-load"` | no |
 | <a name="input_stop_on_node_limit"></a> [stop\_on\_node\_limit](#input\_stop\_on\_node\_limit) | Whether the load test run should end once the maximum Lambda worker node limit is reached. Set to false for scenarios where a static load test is desired | `bool` | `true` | no |
-| <a name="input_stop_on_scaling"></a> [stop\_on\_scaling](#input\_stop\_on\_scaling) | Whether the load test run should end once receiving a scaling notification. Set to false for scenarios where a static load test is desired | `bool` | `true` | no |
+| <a name="input_stop_on_scaling"></a> [stop\_on\_scaling](#input\_stop\_on\_scaling) | Whether the load test run should end, if coasting\_time is zero, or start coasting once receiving a scaling notification. Set to false for scenarios where a static load test is desired | `bool` | `true` | no |
 | <a name="input_test_host"></a> [test\_host](#input\_test\_host) | The URL under test -- should match the given environment | `string` | `"https://test.bfd.cms.gov"` | no |
-| <a name="input_test_runtime_limit"></a> [test\_runtime\_limit](#input\_test\_runtime\_limit) | The maximum runtime, in seconds, for the current load test. Acts as a failsafe against runaway load testing | `number` | `0` | no |
+| <a name="input_test_runtime_limit"></a> [test\_runtime\_limit](#input\_test\_runtime\_limit) | Runtime limit in seconds. If stop\_on\_scaling is false, this limit is the total amount of time the load test has to run. If stop\_on\_scaling is true, this limit indicates the amount of time to check for scaling notifications during a test run before stopping | `number` | `0` | no |
 | <a name="input_user_spawn_rate"></a> [user\_spawn\_rate](#input\_user\_spawn\_rate) | The rate at which simulated Locust users (not worker nodes) will spawn. Set this equal to max\_spawned\_users if all users should be spawned immediately | `number` | `1` | no |
 | <a name="input_warm_instance_target"></a> [warm\_instance\_target](#input\_warm\_instance\_target) | The number of BFD Server instances to target before scaling causes the load test to stop | `number` | `0` | no |
 

--- a/ops/terraform/services/server/server-load/signaling.tf
+++ b/ops/terraform/services/server/server-load/signaling.tf
@@ -4,9 +4,9 @@ resource "aws_sqs_queue" "this" {
   visibility_timeout_seconds = 0
 }
 
-# TODO: Consider relying on existing SNS topic used by the cloudwatch alarms instead
 resource "aws_sns_topic" "this" {
-  name = local.queue_name
+  name              = local.queue_name
+  kms_master_key_id = local.kms_key_id
 }
 
 resource "aws_autoscaling_notification" "this" {


### PR DESCRIPTION
**JIRA Ticket:**
[BFD-2166](https://jira.cms.gov/browse/BFD-2166)

**User Story or Bug Summary:**
_In part_, this successfully remediates Security Hub Findings associated with AWS Foundational Security Best Practices v1.0.0 SNS.1: _SNS topics should be encrypted at-rest using AWS KMS_.

---

### What Does This PR Do?
- Revive, repurpose, and extend env/global/kms module as a home (if temporarily) for path-to-production KMS CMKs
- Generally tidy existing CMK policies, removing errant statements
- Extend AWSServiceRoleForAutoScaling permissions to allow the environment-specific CMK to support encrypted ASG-to-SNS topic signaling
- Modify CMK policies, introduce non-default SNS topic policies to allow for encrypted cloudwatch alarm-to-SNS topic signaling
- Encrypt bfd-server-load and bfd-server cloudwatch SNS topics (3 topics per environment) with appropriate CMK

**NOTE:** Most of our SNS topics were prepared for encryption as part of #1327, however the set of `stateful` modules exhibited considerable drift at the time and could **not be applied**. Work since had us refactor aspects of these so-called `stateful` modules and we can now apply changes via terraform once more.

#### Future Work
- In addressing immediate security concerns, we're reviving portions of the terraform codebase that we had all but agreed to dismantle. The CMKs need a more permanent home that's consistent with our strategy
- Extending the CMK permissions for bfd-server/fhir was done through a policy that's ostensibly for SSM access. This should be done in an alternative policy, which is top-of-mind in coming work that will have us refactor the modules supporting blue/green deployments.
- The CMK policies rely on so-called kms key administrators, whose AWS IAM User names are stored in AWS SSM Parameter Store. These were added without much thought to a maintenance strategy. Maintaining the AWS SSM Parameter Store Hierarchies for non-path-to-production values needs to be addressed, `mgmt` et al.

### What Should Reviewers Watch For?
<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items to the following list here -->
* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [x] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [x] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [x] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    