### PR TITLE
PACA-850: Add alerts for RDA API claim latency

### DIFF
--- a/ops/terraform/services/pipeline/README.md
+++ b/ops/terraform/services/pipeline/README.md
@@ -36,6 +36,7 @@ https://terraform-docs.io/user-guide/configuration/
 | [aws_cloudwatch_dashboard.bfd-pipeline-dashboard](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_dashboard) | resource |
 | [aws_cloudwatch_log_metric_filter.pipeline-messages-datasetfailed-count](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_metric_filter) | resource |
 | [aws_cloudwatch_log_metric_filter.pipeline-messages-error-count](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_metric_filter) | resource |
+| [aws_cloudwatch_metric_alarm.pipeline-max-claim-latency-exceeded](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.pipeline-messages-datasetfailed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.pipeline-messages-error](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_iam_access_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_access_key) | resource |

--- a/ops/terraform/services/pipeline/cloudwatch.tf
+++ b/ops/terraform/services/pipeline/cloudwatch.tf
@@ -84,8 +84,9 @@ resource "aws_cloudwatch_metric_alarm" "pipeline-max-claim-latency-exceeded" {
   metric_name = "${local.rda_pipeline_latency_alert.metrics[count.index].sink_name}.extract.latency.millis.max"
   namespace   = "bfd-${local.env}/bfd-pipeline"
 
-  alarm_actions = local.alarm_actions
-  ok_actions    = local.ok_actions
+  # TODO: Address in BFD-2146 with info/notice escalations.
+  # alarm_actions =
+  # ok_actions    =
 
   datapoints_to_alarm = local.pipeline_messages_datasetfailed.datapoints
   treat_missing_data  = "notBreaching"

--- a/ops/terraform/services/pipeline/cloudwatch.tf
+++ b/ops/terraform/services/pipeline/cloudwatch.tf
@@ -81,7 +81,7 @@ resource "aws_cloudwatch_metric_alarm" "pipeline-max-claim-latency-exceeded" {
   threshold           = local.rda_pipeline_latency_alert.threshold
   alarm_description   = "${local.rda_pipeline_latency_alert.metrics[count.index].claim_type} claim processing is falling behind (max latency exceeded) in APP-ENV: bfd-${local.env}"
 
-  metric_name = "${local.rda_pipeline_latency_alert.metrics[count.index].sink_name}.extract.latency.millis.max"
+  metric_name = "${local.rda_pipeline_latency_alert.metrics[count.index].sink_name}.change.latency.millis.avg"
   namespace   = "bfd-${local.env}/bfd-pipeline"
 
   # TODO: Address in BFD-2146 with info/notice escalations.

--- a/ops/terraform/services/pipeline/cloudwatch.tf
+++ b/ops/terraform/services/pipeline/cloudwatch.tf
@@ -68,3 +68,25 @@ resource "aws_cloudwatch_metric_alarm" "pipeline-messages-datasetfailed" {
   datapoints_to_alarm = local.pipeline_messages_datasetfailed.datapoints
   treat_missing_data  = "notBreaching"
 }
+
+# Creates alarms for FissClaimRdaSink.extract.latency.millis.max and 
+# McsClaimRdaSink.extract.latency.millis.max.
+resource "aws_cloudwatch_metric_alarm" "pipeline-max-claim-latency-exceeded" {
+  count               = length(local.rda_pipeline_latency_alert.metrics)
+  alarm_name          = "bfd-${local.env}-pipeline-max-${local.rda_pipeline_latency_alert.metrics[count.index].claim_type}-claim-latency-exceeded"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = local.rda_pipeline_latency_alert.eval_periods
+  period              = local.rda_pipeline_latency_alert.period
+  statistic           = "Maximum"
+  threshold           = local.rda_pipeline_latency_alert.threshold
+  alarm_description   = "${local.rda_pipeline_latency_alert.metrics[count.index].claim_type} claim processing is falling behind (max latency exceeded) in APP-ENV: bfd-${local.env}"
+
+  metric_name = "${local.rda_pipeline_latency_alert.metrics[count.index].sink_name}.extract.latency.millis.max"
+  namespace   = "bfd-${local.env}/bfd-pipeline"
+
+  alarm_actions = local.alarm_actions
+  ok_actions    = local.ok_actions
+
+  datapoints_to_alarm = local.pipeline_messages_datasetfailed.datapoints
+  treat_missing_data  = "notBreaching"
+}

--- a/ops/terraform/services/pipeline/iam.tf
+++ b/ops/terraform/services/pipeline/iam.tf
@@ -55,7 +55,7 @@ resource "aws_iam_policy" "etl-rw-s3" {
             aws_s3_bucket.this.arn,
             # NOTE: Only included in the prod environment for CCW verification
             # TODO: Remove after CCW Verification is complete, ca Q1 2023.
-            "%{ if local.is_prod }${aws_s3_bucket.ccw-verification[0].arn}%{ endif }"
+            "%{if local.is_prod}${aws_s3_bucket.ccw-verification[0].arn}%{endif}"
           ]
         },
         {
@@ -69,7 +69,7 @@ resource "aws_iam_policy" "etl-rw-s3" {
             "${aws_s3_bucket.this.arn}/*",
             # NOTE: Only included in the prod environment for CCW verification
             # TODO: Remove after CCW Verification is complete, ca Q1 2023.
-            "%{ if local.is_prod }${aws_s3_bucket.ccw-verification[0].arn}/*%{ endif }"
+            "%{if local.is_prod}${aws_s3_bucket.ccw-verification[0].arn}/*%{endif}"
           ]
         }
       ]

--- a/ops/terraform/services/pipeline/main.tf
+++ b/ops/terraform/services/pipeline/main.tf
@@ -50,14 +50,14 @@ locals {
 
   # Used by alarms for RDA claim ingestion latency metrics.  Metric time unit is milliseconds.
   # 28800000 ms == 8 hours
-  rda_pipeline_latency_alert {
+  rda_pipeline_latency_alert = {
     period       = "300"
     eval_periods = "1"
     threshold    = "28800000"
     datapoints   = "1"
     metrics = [
-      { sink_name = "FissClaimRdaSink" , claim_type = "fiss"},
-      { sink_name = "McsClaimRdaSink" , claim_type = "mcs"},
+      { sink_name = "FissClaimRdaSink", claim_type = "fiss" },
+      { sink_name = "McsClaimRdaSink", claim_type = "mcs" },
     ]
   }
 

--- a/ops/terraform/services/pipeline/main.tf
+++ b/ops/terraform/services/pipeline/main.tf
@@ -48,6 +48,19 @@ locals {
     datapoints   = "1"
   }
 
+  # Used by alarms for RDA claim ingestion latency metrics.  Metric time unit is milliseconds.
+  # 28800000 ms == 8 hours
+  rda_pipeline_latency_alert {
+    period       = "300"
+    eval_periods = "1"
+    threshold    = "28800000"
+    datapoints   = "1"
+    metrics = [
+      { sink_name = "FissClaimRdaSink" , claim_type = "fiss"},
+      { sink_name = "McsClaimRdaSink" , claim_type = "mcs"},
+    ]
+  }
+
   log_groups = {
     messages = "/bfd/${local.env}/bfd-pipeline/messages.txt"
   }


### PR DESCRIPTION
**JIRA Ticket:**
[PACA-850](https://jira.cms.gov/browse/PACA-850)

**User Story or Bug Summary:**

As a PACA/BFD engineer I need to be alerted when the RDA ETL pipeline jobs are falling behind.

---

### What Does This PR Do?

Creates alerts in CloudWatch to trigger when the appropriate micrometer latency metric exceeds our published SLO value.  The alerting threshold is 8 hours (encoded in milliseconds, 8 * 60 * 60 * 1000).  The metric names used for the alerts are:

- FissClaimRdaSink.change.latency.millis.avg
- McsClaimRdaSink.change.latency.millis.avg

### What Should Reviewers Watch For?

If you're reviewing this PR, please check for these things in particular:

* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [x] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [x] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [x] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] The data dictionary has been updated with any field mapping changes, if any were made.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    