### PR TITLE
PACA-856: Refine cloudwatch micrometer metrics

### DIFF
--- a/apps/bfd-pipeline/bfd-pipeline-app/src/main/java/gov/cms/bfd/pipeline/app/AppConfiguration.java
+++ b/apps/bfd-pipeline/bfd-pipeline-app/src/main/java/gov/cms/bfd/pipeline/app/AppConfiguration.java
@@ -25,6 +25,7 @@ import java.io.Serializable;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
@@ -311,6 +312,15 @@ public final class AppConfiguration extends BaseAppConfiguration implements Seri
    * false. Can be used when testing the pipeline locally to monitor metrics as the pipeline runs.
    */
   public static final String ENV_VAR_MICROMETER_JMX_ENABLED = "MICROMETER_JMX_ENABLED";
+
+  /**
+   * List of metric names that are allowed to be published to Cloudwatch by Micrometer. Using an
+   * allowed list avoids increasing AWS charges as new metrics are defined for use in NewRelic that
+   * are not necessary in Cloudwatch. These need to be the base metric names, not one of the several
+   * auto-generated aggregate metric names with suffixes like {@code .avg}.
+   */
+  public static Set<String> MICROMETER_CW_ALLOWED_METRIC_NAMES =
+      Set.of("FissClaimRdaSink.change.latency.millis", "McsClaimRdaSink.change.latency.millis");
 
   /**
    * Instance of {@link MicrometerConfigHelper} used to create a {@link CloudWatchConfig} instance.

--- a/apps/bfd-pipeline/bfd-pipeline-app/src/main/java/gov/cms/bfd/pipeline/app/PipelineApplication.java
+++ b/apps/bfd-pipeline/bfd-pipeline-app/src/main/java/gov/cms/bfd/pipeline/app/PipelineApplication.java
@@ -1,5 +1,7 @@
 package gov.cms.bfd.pipeline.app;
 
+import static gov.cms.bfd.pipeline.app.AppConfiguration.MICROMETER_CW_ALLOWED_METRIC_NAMES;
+
 import ch.qos.logback.classic.LoggerContext;
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsyncClient;
 import com.codahale.metrics.MetricRegistry;
@@ -30,6 +32,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.instrument.dropwizard.DropwizardConfig;
 import io.micrometer.core.instrument.dropwizard.DropwizardMeterRegistry;
@@ -111,7 +114,11 @@ public final class PipelineApplication {
       final var cloudWatchRegistry =
           new CloudWatchMeterRegistry(
               cloudwatchRegistryConfig, micrometerClock, new AmazonCloudWatchAsyncClient());
-      cloudWatchRegistry.config().commonTags(commonTags);
+      cloudWatchRegistry
+          .config()
+          .meterFilter(
+              MeterFilter.denyUnless(
+                  id -> MICROMETER_CW_ALLOWED_METRIC_NAMES.contains(id.getName())));
       appMeters.add(cloudWatchRegistry);
       LOGGER.info("Added CloudWatchMeterRegistry.");
     }


### PR DESCRIPTION
**JIRA Ticket:**
[PACA-856](https://jira.cms.gov/browse/PACA-856)

**User Story or Bug Summary:**

As a BFD engineer I want to be able to send only the necessary metrics to Cloudwatch from the ETL pipeline.
Optimize costs by reducing number of metrics sent to Cloudwatch
Allow definition of a single alarm per environment that works regardless of the EC2 instance the pipeline is running on.

---

### What Does This PR Do?

Install a `MetricFilter` to ensure that only a list of approved metrics are transmitted to cloudwatch.  For simplicity sake the list is currently hard coded but an environment variable could be added at a later date to make the list configurable.

**Note:** This filter will also prevent Micrometer JVM metrics from being transmitted to Cloudwatch.  They will still be published to NewRelic and/or JMX (if enabled).


### What Should Reviewers Watch For?

If you're reviewing this PR, please check for these things in particular:

* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [x] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [x] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [x] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [x] No

### What Needs to Be Merged and Deployed Before this PR?

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* Run the branch in AWS to verify that the metric filter works as correctly with cloudwatch prior to merging.


### Submitter Checklist

I have gone through and verified that...:

* [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] The data dictionary has been updated with any field mapping changes, if any were made.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    