### PR TITLE
BFD-868: Fix Filtering in GHA Workflows

### DIFF
--- a/.github/workflows/ci-java.yml
+++ b/.github/workflows/ci-java.yml
@@ -5,13 +5,19 @@ env:
   # workflow file matchers - workflow jobs will only run if matching files are found
   # please see https://github.com/CMSgov/beneficiary-fhir-data/pull/773 for why we
   # are using this workflow logic
-  workflow_files_re: >
-    (^apps/bfd- |
-    ^apps/Dockerfile |
-    ^apps/pom.xml |
-    ^ops/ansible |
-    ^.github/workflows/ci-ansible.yml |
-    ^.github/workflows/ci-java.yml)
+  # NOTE: I can't find anything in the spec that suggests that '\' is used as a string-continuation
+  # symbol. However, see the following StackOverflow post for an example:
+  # https://stackoverflow.com/questions/6268391/is-there-a-way-to-represent-a-long-string-that-doesnt-have-any-whitespace-on-mul
+  workflow_files_re: "(\
+  ^apps/pom.xml|\
+  ^apps/Dockerfile|\
+  ^apps/bfd-|\
+  ^ops/ansible/roles/bfd-db-migrator/|\
+  ^ops/ansible/roles/bfd-pipeline/|\
+  ^ops/ansible/roles/bfd-server/|\
+  ^.github/workflows/ci-ansible.yml|\
+  ^.github/workflows/ci-java.yml\
+  )"
 
 jobs:
   workflow:


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BFD-868](https://jira.cms.gov/browse/BFD-868)

**User Story or Bug Summary:**
(re)Enable GHA Workflow Filtering

This work originally appeared in the change set addressing BFD-2334; while helpful to the testing effort, it has little to do with the subject of that Jira issue.

---

### What Does This PR Do?
This is a modest change and fix to the extended regexp pattern(s) employed by the _Checking workflow_ job to avoid lengthy builds/re-builds with `mvn` (and other consequences like the ansible role tests) when there aren't any relevant changes to evaluate.

As before, unrelated changes like RFCs or runbooks (encoded as markdown files), will no longer trigger the long-tail tasks included in the _CI - Java_ workflow (`ci-java.yml`), resulting in more focused, speedier review for these change sets.

The issue is just a matter of spacing:

Working examples include the following output in GHA when using the logic in *this* branch:
`(^apps/pom.xml|^apps/Dockerfile|^apps/bfd-|^ops/ansible/roles/bfd-db-migrator/|^ops/ansible/roles/bfd-pipeline/|^ops/ansible/roles/bfd-server/|^.github/workflows/ci-ansible.yml|^.github/workflows/ci-java.yml)`

Compared to non-working examples, there are errant spaces included in the extended pattern:
`(^apps/bfd- | ^apps/Dockerfile | ^apps/pom.xml | ^ops/ansible | ^.github/workflows/ci-ansible.yml | ^.github/workflows/ci-java.yml)`

What's more, this is even more targeted, triggering builds when the ansible roles subject to testing change, as opposed to triggering tests on all changes to the `ops/ansible` directories, where tests are relevant or otherwise.

### What Should Reviewers Watch For?
<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items to the following list here -->
* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [x] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [x] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [x] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] The data dictionary has been updated with any field mapping changes, if any were made.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    