### PR TITLE
BFD-2351: Implement Availability SLO CloudWatch Alarms and add visuals for Availability SLIs to CloudWatch Dashboards

### DIFF
--- a/ops/terraform/modules/resources/bfd_cw_dashboards/templates/bfd-dashboard-slos.tftpl
+++ b/ops/terraform/modules/resources/bfd_cw_dashboards/templates/bfd-dashboard-slos.tftpl
@@ -628,7 +628,7 @@
                 "setPeriodToTimeRange": false,
                 "trend": true,
                 "singleValueFullPrecision": true,
-                "title": "% Uptime per Month",
+                "title": "% Uptime over 30-day Period",
                 "stacked": false,
                 "annotations": {
                     "horizontal": [

--- a/ops/terraform/modules/resources/bfd_cw_dashboards/templates/bfd-dashboard-slos.tftpl
+++ b/ops/terraform/modules/resources/bfd_cw_dashboards/templates/bfd-dashboard-slos.tftpl
@@ -610,13 +610,13 @@
         },
         {
             "height": 6,
-            "width": 12,
+            "width": 8,
             "y": 36,
-            "x": 0,
+            "x": 8,
             "type": "metric",
             "properties": {
                 "metrics": [
-                    [ { "expression": "100*(m1/(m1+m2))", "label": "% Uptime", "id": "e1", "yAxis": "left", "region": "us-east-1" } ],
+                    [ { "expression": "100*(m1/(m1+m2))", "label": "% Uptime", "id": "e1", "yAxis": "left", "region": "us-east-1", "period": 86400 } ],
                     [ "${namespace}", "availability/success", { "id": "m1", "label": "Count of Successful Checks", "visible": false } ],
                     [ ".", "availability/failure", { "id": "m2", "label": "Count of Failing Checks", "visible": false } ]
                 ],
@@ -624,17 +624,17 @@
                 "view": "timeSeries",
                 "region": "us-east-1",
                 "stat": "Sum",
-                "period": 2592000,
+                "period": 86400,
                 "setPeriodToTimeRange": false,
                 "trend": true,
                 "singleValueFullPrecision": true,
-                "title": "% Uptime over 30-day Period",
+                "title": "% Uptime over 24-Hour Period",
                 "stacked": false,
                 "annotations": {
                     "horizontal": [
                         {
                             "label": "Alert threshold",
-                            "value": 99.8
+                            "value": 99
                         },
                         {
                             "label": "Warning threshold",
@@ -656,9 +656,9 @@
         },
         {
             "height": 6,
-            "width": 12,
+            "width": 8,
             "y": 36,
-            "x": 12,
+            "x": 16,
             "type": "metric",
             "properties": {
                 "metrics": [
@@ -691,6 +691,41 @@
                     "left": {
                         "label": "Count",
                         "showUnits": false
+                    },
+                    "right": {
+                        "showUnits": false
+                    }
+                }
+            }
+        },
+        {
+            "height": 6,
+            "width": 8,
+            "y": 36,
+            "x": 0,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ { "expression": "100*(m1/(m1+m2))", "label": "% Uptime", "id": "e1", "yAxis": "left", "region": "us-east-1" } ],
+                    [ "${namespace}", "availability/success", { "id": "m1", "label": "Count of Successful Checks", "visible": false } ],
+                    [ ".", "availability/failure", { "id": "m2", "label": "Count of Failing Checks", "visible": false } ]
+                ],
+                "sparkline": false,
+                "view": "gauge",
+                "region": "us-east-1",
+                "stat": "Sum",
+                "period": 2592000,
+                "setPeriodToTimeRange": false,
+                "trend": true,
+                "singleValueFullPrecision": true,
+                "title": "% Uptime over 30-day Period",
+                "stacked": false,
+                "yAxis": {
+                    "left": {
+                        "max": 100,
+                        "label": "% Uptime",
+                        "showUnits": false,
+                        "min": 99.8
                     },
                     "right": {
                         "showUnits": false

--- a/ops/terraform/modules/resources/bfd_cw_dashboards/templates/bfd-dashboard-slos.tftpl
+++ b/ops/terraform/modules/resources/bfd_cw_dashboards/templates/bfd-dashboard-slos.tftpl
@@ -607,6 +607,96 @@
                 },
                 "title": "/v*/fhir/* 24-hour Error rate (HTTP 5XX)"
             }
+        },
+        {
+            "height": 6,
+            "width": 12,
+            "y": 36,
+            "x": 0,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ { "expression": "100*(m1/(m1+m2))", "label": "% Uptime", "id": "e1", "yAxis": "left", "region": "us-east-1" } ],
+                    [ "${namespace}", "availability/success", { "id": "m1", "label": "Count of Successful Checks", "visible": false } ],
+                    [ ".", "availability/failure", { "id": "m2", "label": "Count of Failing Checks", "visible": false } ]
+                ],
+                "sparkline": false,
+                "view": "timeSeries",
+                "region": "us-east-1",
+                "stat": "Sum",
+                "period": 2592000,
+                "setPeriodToTimeRange": false,
+                "trend": true,
+                "singleValueFullPrecision": true,
+                "title": "% Uptime per Month",
+                "stacked": false,
+                "annotations": {
+                    "horizontal": [
+                        {
+                            "label": "Alert threshold",
+                            "value": 99.8
+                        },
+                        {
+                            "label": "Warning threshold",
+                            "value": 100
+                        }
+                    ]
+                },
+                "yAxis": {
+                    "left": {
+                        "max": 100,
+                        "label": "% Uptime",
+                        "showUnits": false
+                    },
+                    "right": {
+                        "showUnits": false
+                    }
+                }
+            }
+        },
+        {
+            "height": 6,
+            "width": 12,
+            "y": 36,
+            "x": 12,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ { "expression": "FILL(METRICS(), 0)", "label": "", "id": "e1" } ],
+                    [ "${namespace}", "availability/failure", { "id": "m2", "label": "Sum of Failed Checks over 5 Minutes", "visible": false } ]
+                ],
+                "sparkline": false,
+                "view": "timeSeries",
+                "region": "us-east-1",
+                "stat": "Sum",
+                "period": 300,
+                "setPeriodToTimeRange": false,
+                "trend": true,
+                "singleValueFullPrecision": true,
+                "title": "Failed Uptime Checks over 5 Minute Period",
+                "stacked": false,
+                "annotations": {
+                    "horizontal": [
+                        {
+                            "label": "Alert Threshold",
+                            "value": 3
+                        },
+                        {
+                            "label": "Warning Threshold",
+                            "value": 1
+                        }
+                    ]
+                },
+                "yAxis": {
+                    "left": {
+                        "label": "Count",
+                        "showUnits": false
+                    },
+                    "right": {
+                        "showUnits": false
+                    }
+                }
+            }
         }
     ]
 }

--- a/ops/terraform/modules/resources/bfd_cw_dashboards/templates/bfd-dashboard-slos.tftpl
+++ b/ops/terraform/modules/resources/bfd_cw_dashboards/templates/bfd-dashboard-slos.tftpl
@@ -638,7 +638,7 @@
                         },
                         {
                             "label": "Warning threshold",
-                            "value": 100
+                            "value": 99.8
                         }
                     ]
                 },

--- a/ops/terraform/modules/resources/bfd_cw_dashboards/templates/bfd-dashboard.tftpl
+++ b/ops/terraform/modules/resources/bfd_cw_dashboards/templates/bfd-dashboard.tftpl
@@ -127,7 +127,7 @@
         {
             "height": 4,
             "width": 24,
-            "y": 36,
+            "y": 40,
             "x": 0,
             "type": "metric",
             "properties": {
@@ -149,7 +149,7 @@
         {
             "height": 4,
             "width": 24,
-            "y": 40,
+            "y": 44,
             "x": 0,
             "type": "metric",
             "properties": {
@@ -474,6 +474,29 @@
                 "region": "us-east-1",
                 "stat": "Average",
                 "period": 60
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 36,
+            "width": 24,
+            "height": 4,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "100*(m1/(m1+m2))", "label": "% Uptime", "id": "e1", "yAxis": "left", "region": "us-east-1" } ],
+                    [ "${namespace}", "availability/success", { "id": "m1", "label": "Count of Successful Checks" } ],
+                    [ ".", "availability/failure", { "id": "m2", "label": "Count of Failing Checks" } ]
+                ],
+                "sparkline": false,
+                "view": "singleValue",
+                "region": "us-east-1",
+                "stat": "Sum",
+                "period": 2592000,
+                "setPeriodToTimeRange": false,
+                "trend": true,
+                "singleValueFullPrecision": true,
+                "title": "Availability over Last 30 Days"
             }
         }
     ]

--- a/ops/terraform/modules/resources/bfd_server_slo_alarms/main.tf
+++ b/ops/terraform/modules/resources/bfd_server_slo_alarms/main.tf
@@ -102,15 +102,22 @@ locals {
   }
 
   availability_slo_uptime_percent_configs = {
-    slo_availability_uptime_percent_30days_warning = {
+    # CloudWatch Alarms have an upper limit of 1 day periods. Unfortunately, our SLO for
+    # availability is on a monthly-basis rather than daily, so this alarm does not exactly model
+    # that SLO. However, these alarms do give us more immediate and actionable feedback when the BFD
+    # Server is falling over, so there is some upside. The thresholds for warning and alert have
+    # been modified slightly with the significantly smaller period in-mind, and any failing checks
+    # at all (between 100% and 99.8% uptime per-day) will be caught by the other availability alarm
+    # TODO: Determine some method of alarming on the agreed-upon monthly availability SLO
+    slo_availability_uptime_percent_24hr_warning = {
       type      = "warning"
-      period    = 30 * 24 * 60 * 60
-      threshold = "100"
-    }
-    slo_availability_uptime_percent_30days_alert = {
-      type      = "alert"
-      period    = 30 * 24 * 60 * 60
+      period    = 24 * 60 * 60
       threshold = "99.8"
+    }
+    slo_availability_uptime_percent_24hr_alert = {
+      type      = "alert"
+      period    = 24 * 60 * 60
+      threshold = "99"
     }
   }
 

--- a/ops/terraform/modules/resources/bfd_server_slo_alarms/main.tf
+++ b/ops/terraform/modules/resources/bfd_server_slo_alarms/main.tf
@@ -1229,7 +1229,7 @@ resource "aws_cloudwatch_metric_alarm" "slo_availability_failures_sum" {
   threshold           = each.value.threshold
 
   alarm_description = join("", [
-    "The sum of failed availability checks exceeded or was equal to ${upper(each.value.type)}",
+    "The sum of failed availability checks exceeded or was equal to ${upper(each.value.type)} ",
     "SLO threshold of ${each.value.threshold} failures in ${each.value.period / 60} minute(s) ",
     "for ${local.app} in ${var.env} environment.",
     "\n\n${local.dashboard_message_fragment}"

--- a/ops/terraform/modules/resources/bfd_server_slo_alarms/main.tf
+++ b/ops/terraform/modules/resources/bfd_server_slo_alarms/main.tf
@@ -23,6 +23,8 @@ locals {
     claimresponse_resources_latency_by_kb = "http-requests/latency-by-kb/claimresponse-all-with-resources"
     all_responses_count                   = "http-requests/count/all"
     all_http500s_count                    = "http-requests/count/500-responses"
+    availability_success_count            = "availability/success"
+    availability_failure_count            = "availability/failure"
   }
 
   partners = {
@@ -83,6 +85,32 @@ locals {
       type      = "warning"
       period    = 24 * 60 * 60
       threshold = "0.001"
+    }
+  }
+
+  availability_slo_failure_sum_configs = {
+    slo_availability_failures_sum_5m_alert = {
+      type      = "alert"
+      period    = 60 * 5
+      threshold = "3"
+    }
+    slo_availability_failures_sum_5m_warning = {
+      type      = "warning"
+      period    = 60 * 5
+      threshold = "1"
+    }
+  }
+
+  availability_slo_uptime_percent_configs = {
+    slo_availability_uptime_percent_30days_warning = {
+      type      = "warning"
+      period    = 30 * 24 * 60 * 60
+      threshold = "100"
+    }
+    slo_availability_uptime_percent_30days_alert = {
+      type      = "alert"
+      period    = 30 * 24 * 60 * 60
+      threshold = "99.8"
     }
   }
 
@@ -1188,4 +1216,87 @@ resource "aws_cloudwatch_metric_alarm" "slo_http500_count_percent" {
 
   datapoints_to_alarm = "1"
   treat_missing_data  = "notBreaching"
+}
+
+resource "aws_cloudwatch_metric_alarm" "slo_availability_failures_sum" {
+  for_each = local.availability_slo_failure_sum_configs
+
+  alarm_name          = "${local.app}-${var.env}-${replace(each.key, "_", "-")}"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  period              = each.value.period
+  statistic           = "Sum"
+  threshold           = each.value.threshold
+
+  alarm_description = join("", [
+    "The sum of failed availability checks exceeded or was equal to ${upper(each.value.type)}",
+    "SLO threshold of ${each.value.threshold} failures in ${each.value.period / 60} minute(s) ",
+    "for ${local.app} in ${var.env} environment.",
+    "\n\n${local.dashboard_message_fragment}"
+  ])
+
+  metric_name = local.metrics.availability_failure_count
+  namespace   = local.namespace
+
+  alarm_actions = each.value.type == "alert" ? local.alert_arn : local.warning_arn
+  ok_actions    = local.ok_arn
+
+  datapoints_to_alarm = "1"
+  treat_missing_data  = "notBreaching"
+}
+
+resource "aws_cloudwatch_metric_alarm" "slo_availability_uptime_percent" {
+  for_each = local.availability_slo_uptime_percent_configs
+
+  alarm_name          = "${local.app}-${var.env}-${replace(each.key, "_", "-")}"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "1"
+  threshold           = each.value.threshold
+
+  alarm_description = join("", [
+    "The alarm transitioned to the ALARM state due to one of the following occurring:\n",
+    "* Percent uptime over ${each.value.period / (24 * 60 * 60)} day(s) dropped below ",
+    "${upper(each.value.type)} SLO threshold of ${each.value.threshold}% for ${local.app} in ",
+    "${var.env} environment.\n",
+    "* No data was reported by the availability checker Jenkins pipeline; the pipeline may have ",
+    "stopped running",
+    "\n\n${local.dashboard_message_fragment}"
+  ])
+
+  metric_query {
+    id          = "e1"
+    expression  = "100*(m1/(m1+m2))"
+    label       = "% Uptime"
+    return_data = "true"
+  }
+
+  metric_query {
+    id = "m1"
+
+    metric {
+      metric_name = local.metrics.availability_success_count
+      namespace   = local.namespace
+      period      = each.value.period
+      stat        = "Sum"
+      unit        = "Count"
+    }
+  }
+
+  metric_query {
+    id = "m2"
+
+    metric {
+      metric_name = local.metrics.availability_failure_count
+      namespace   = local.namespace
+      period      = each.value.period
+      stat        = "Sum"
+      unit        = "Count"
+    }
+  }
+
+  alarm_actions = each.value.type == "alert" ? local.alert_arn : local.warning_arn
+  ok_actions    = local.ok_arn
+
+  datapoints_to_alarm = "1"
+  treat_missing_data  = "breaching"
 }


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BFD-2351](https://jira.cms.gov/browse/BFD-2351)

**User Story or Bug Summary:**

<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->

As a BFD Engineer, I want to know when the BFD is out of SLO for availability, so that I know when
there is an issue that requires prompt action by the BFD team.

---

### What Does This PR Do?

<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

This PR implements CloudWatch Alarms covering our Availability SLOs for uptime percentage ~~over 30 days (a month)~~ 24 hours as well as an additional alarm that covers more immediate uptime failures. Additionally, visuals showing metrics for availability have been added to both BFD Server CloudWatch dashboards. In more detail:

- Two distinct CloudWatch SLO Alarms have been added:
  - A CloudWatch Alarm covering ~~both warning and alert thresholds for our monthly percent uptime
    availability SLOs~~ a 24 hour period of uptime percentage with the following warning and alert thresholds (check comments below for motivations behind changing the alarm period):
    - Warning: Less than 99.8% uptime (approximately 3 minutes) over a 24-hour period
    - Alert: Less than 99% uptime (approximately 15 minutes) over a 24-hour period
    - This alarm will also alarm if no data is found
  - A CloudWatch Alarm covering more _immediate_ failures, checking for failed availability checks
    over a 5 minute period with the following alert and warning thresholds:
    - Warning: 1 failed check over a 5 minute period (essentially 1 of 5 availability checks failed)
    - Alert: 3 failed checks over a 5 minute period (essentially 3 of 5 availability checks failed)
- Visuals showing percent uptime, number of successful availability checks and number of failing checks for the normal BFD Server CloudWatch Dashboard
- Three new visuals for the BFD Server SLOs CloudWatch Dashboard: 
  - A gauge chart showing _monthly_ percent uptime with a minimum value of 99.8%, corresponding to our availability SLO
  - A line chart corresponding to the 24-hour uptime percentage CloudWatch Alarm showing the current uptime percentage and how it compares to the warning and alert thresholds for said alarm
  - A line chart corresponding to the 5-minute availability failure CloudWatch Alarm showing the number of failed availability checks for the current environment compared to the warning and alert thresholds for said alarm
 
Out-of-band of this PR the changes to the dashboards have been applied to `test` and can be viewed
right now. All other changes have been validated to be correct via `terraform plan` and will be
applied when this PR is merged.

### What Should Reviewers Watch For?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:

<!-- Add some items to the following list here -->

- Verify all PR security questions and checklists have been completed and addressed.

### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

- If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

  - Does this PR add any new software dependencies?
    - [ ] Yes
    - [x] No
  - Does this PR modify or invalidate any of our security controls?
    - [ ] Yes
    - [x] No
  - Does this PR store or transmit data that was not stored or transmitted before?
    - [ ] Yes
    - [x] No

- If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
  - Do you think this PR requires additional review of its security implications for other reasons?
    - [ ] Yes
    - [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

- N/A

### Submitter Checklist

<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

- [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
- [x] This PR is reasonably limited in scope, to help ensure that:
  1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
  2. There isn't too much of a burden on reviewers.
  3. Any problems it causes have a small "blast radius".
  4. It'll be easier to rollback if that becomes necessary.
- [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
- [x] The data dictionary has been updated with any field mapping changes, if any were made.
- [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
- [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
- [x] Reviews are requested from both:
  - At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
  - Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
- [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
  - Please review the standards every few months to ensure you're familiar with them.
