### PR TITLE
BFD-2330 : Prevent Postgres JDBC driver from leaking PII/PHI data during BatchUpdateException

### DIFF
--- a/apps/bfd-pipeline/bfd-pipeline-app/pom.xml
+++ b/apps/bfd-pipeline/bfd-pipeline-app/pom.xml
@@ -98,7 +98,6 @@
 			<!-- JDBC driver for working with PostgreSQL DBs on Java 8+ (JDBC 4.2). -->
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<!-- HSQL is used in this project's integration tests, which means it

--- a/apps/bfd-pipeline/bfd-pipeline-app/src/main/java/gov/cms/bfd/pipeline/app/PipelineApplication.java
+++ b/apps/bfd-pipeline/bfd-pipeline-app/src/main/java/gov/cms/bfd/pipeline/app/PipelineApplication.java
@@ -193,14 +193,12 @@ public final class PipelineApplication {
             ((PgConnection) pSqlConnection).getLogServerErrorDetail());
       }
     } finally {
-      /*
       if (dbConn != null) {
         try {
           dbConn.close();
         } catch (Exception ex) {
         }
       }
-      */
     }
 
     /*

--- a/apps/bfd-pipeline/bfd-pipeline-app/src/main/java/gov/cms/bfd/pipeline/app/PipelineApplication.java
+++ b/apps/bfd-pipeline/bfd-pipeline-app/src/main/java/gov/cms/bfd/pipeline/app/PipelineApplication.java
@@ -14,6 +14,7 @@ import com.newrelic.telemetry.OkHttpPoster;
 import com.newrelic.telemetry.SenderConfiguration;
 import com.newrelic.telemetry.metrics.MetricBatchSender;
 import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.pool.HikariProxyConnection;
 import gov.cms.bfd.pipeline.ccw.rif.CcwRifLoadJob;
 import gov.cms.bfd.pipeline.ccw.rif.CcwRifLoadOptions;
 import gov.cms.bfd.pipeline.ccw.rif.extract.RifFilesProcessor;
@@ -40,6 +41,7 @@ import io.micrometer.core.instrument.util.HierarchicalNameMapper;
 import io.micrometer.jmx.JmxConfig;
 import io.micrometer.jmx.JmxMeterRegistry;
 import java.lang.Thread.UncaughtExceptionHandler;
+import java.sql.DatabaseMetaData;
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.List;
@@ -47,6 +49,8 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import org.postgresql.core.BaseConnection;
+import org.postgresql.jdbc.PgConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -168,6 +172,36 @@ public final class PipelineApplication {
     // Create a pooled data source for use by any registered jobs.
     final HikariDataSource pooledDataSource =
         PipelineApplicationState.createPooledDataSource(appConfig.getDatabaseOptions(), appMetrics);
+
+    HikariProxyConnection dbConn = null;
+    try {
+      dbConn = (HikariProxyConnection) pooledDataSource.getConnection();
+      DatabaseMetaData dbmeta = dbConn.getMetaData();
+      String dbName = dbmeta.getDatabaseProductName();
+      LOGGER.info(
+          "Database: {}, Driver version: major: {}, minor: {}; JDBC version, major: {}, minor: {}",
+          dbName,
+          dbmeta.getDriverMajorVersion(),
+          dbmeta.getDriverMinorVersion(),
+          dbmeta.getJDBCMajorVersion(),
+          dbmeta.getJDBCMinorVersion());
+
+      if (dbName.equals("PostgreSQL")) {
+        BaseConnection pSqlConnection = dbConn.unwrap(BaseConnection.class);
+        LOGGER.info(
+            "pgjdbc, logServerDetail: {}",
+            ((PgConnection) pSqlConnection).getLogServerErrorDetail());
+      }
+    } finally {
+      /*
+      if (dbConn != null) {
+        try {
+          dbConn.close();
+        } catch (Exception ex) {
+        }
+      }
+      */
+    }
 
     /*
      * Create all jobs and run their smoke tests.

--- a/ops/ansible/roles/bfd-pipeline/templates/bfd-pipeline-service.sh.j2
+++ b/ops/ansible/roles/bfd-pipeline/templates/bfd-pipeline-service.sh.j2
@@ -66,5 +66,5 @@ export BFD_ENV_NAME='{{ env_name_std }}'
 # export DATA_SET_TYPE_ALLOWED="BENEFICIARY"
 
 exec "{{ data_pipeline_dir }}/bfd-pipeline-app-1.0.0-SNAPSHOT/bfd-pipeline-app.sh" \
-	-Djava.io.tmpdir={{ data_pipeline_tmp_dir }} \
+	-Djava.io.tmpdir={{ data_pipeline_tmp_dir }} -Dorg.jboss.logging.provider=slf4j \
 	&>> "{{ data_pipeline_dir }}/bluebutton-data-pipeline.log"

--- a/ops/terraform/services/pipeline/README.md
+++ b/ops/terraform/services/pipeline/README.md
@@ -22,6 +22,7 @@ https://terraform-docs.io/user-guide/configuration/
 |------|-------------|------|---------|:--------:|
 | <a name="input_ami_id_override"></a> [ami\_id\_override](#input\_ami\_id\_override) | BFD Pipeline override ami-id. Defaults to latest pipeline/etl AMI from `master`. | `string` | `null` | no |
 | <a name="input_force_etl_user_creation"></a> [force\_etl\_user\_creation](#input\_force\_etl\_user\_creation) | Force an etl service account creation; only `prod` typically creates an etl service account. | `string` | `false` | no |
+| <a name="input_jdbc_suffix"></a> [jdbc\_suffix](#input\_jdbc\_suffix) | boolean controlling logging of detail SQL values if a BatchUpdateException occurs; false disables detail logging | `string` | `"?logServerErrorDetail=false"` | no |
 
 <!-- GENERATED WITH `terraform-docs .`
 Manually updating the README.md will be overwritten.
@@ -36,6 +37,7 @@ https://terraform-docs.io/user-guide/configuration/
 | [aws_cloudwatch_dashboard.bfd-pipeline-dashboard](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_dashboard) | resource |
 | [aws_cloudwatch_log_metric_filter.pipeline-messages-datasetfailed-count](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_metric_filter) | resource |
 | [aws_cloudwatch_log_metric_filter.pipeline-messages-error-count](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_metric_filter) | resource |
+| [aws_cloudwatch_metric_alarm.pipeline-log-availability-1hr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.pipeline-max-claim-latency-exceeded](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.pipeline-messages-datasetfailed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.pipeline-messages-error](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
@@ -70,6 +72,8 @@ https://terraform-docs.io/user-guide/configuration/
 | [aws_security_group.rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
 | [aws_security_group.vpn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
 | [aws_sns_topic.alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/sns_topic) | data source |
+| [aws_sns_topic.bfd_notices_slack_alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/sns_topic) | data source |
+| [aws_sns_topic.bfd_test_slack_alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/sns_topic) | data source |
 | [aws_sns_topic.ok](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/sns_topic) | data source |
 | [aws_ssm_parameters_by_path.nonsensitive](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameters_by_path) | data source |
 | [aws_ssm_parameters_by_path.nonsensitive_common](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameters_by_path) | data source |

--- a/ops/terraform/services/pipeline/main.tf
+++ b/ops/terraform/services/pipeline/main.tf
@@ -4,6 +4,7 @@ locals {
   layer            = "data"
   established_envs = ["test", "prod-sbx", "prod"]
   create_etl_user  = local.is_prod || var.force_etl_user_creation
+  jdbc_suffix      = var.jdbc_suffix
 
   # NOTE: Some resources use a 'pipeline' name while others use 'etl'. There's no simple solution for renaming all resources.
   # We must tolerate this for now.

--- a/ops/terraform/services/pipeline/main.tf
+++ b/ops/terraform/services/pipeline/main.tf
@@ -127,7 +127,7 @@ resource "aws_instance" "this" {
     account_id      = local.account_id
     env             = local.env
     pipeline_bucket = aws_s3_bucket.this.bucket
-    writer_endpoint = "jdbc:postgresql://${local.rds_writer_endpoint}:5432/fhirdb"
+    writer_endpoint = "jdbc:postgresql://${local.rds_writer_endpoint}:5432/fhirdb${local.jdbc_suffix}"
   })
 
   volume_tags = merge(

--- a/ops/terraform/services/pipeline/variables.tf
+++ b/ops/terraform/services/pipeline/variables.tf
@@ -9,3 +9,9 @@ variable "force_etl_user_creation" {
   description = "Force an etl service account creation; only `prod` typically creates an etl service account."
   type        = string
 }
+
+variable "jdbc_suffix" {
+  default     = "?logServerErrorDetail=false"
+  description = "boolean controlling logging of detail SQL values if a BatchUpdateException occurs; false disables detail logging"
+  type        = string
+}


### PR DESCRIPTION
**JIRA Ticket:**
[BFD-2330](https://jira.cms.gov/browse/BFD-2330)

**User Story or Bug Summary:**
ETL pipeline can leak PII/PHI data if it encounters a SQL exception during insert or update operation.

### What Does This PR Do?

This PR leverages a recent bugfix to the Postgres JDBC driver that enables control over whether the driver will output detailed SQL that encountered an Exception.

It accomplishes this by leveraging the _logServerErrorDetail_ flag that can be set during the setup of the Postgres DataSource:
- true (the default) will output detailed SQL, which may include PII data.
- false will disable the detailed output (but still provide call stack info)

### What Should Reviewers Watch For?

The bulk of the changes are tied to pipeline ops changes that disable detailed SQL output in the Postgres JDBC driver.

In addition to the ops changes, there were (very) minor code changes to the PipelineApplication to log JDBC version info during pipeline startup as well as the state of the _logServerErrorDetail_ flag.

**NOTE:**
The changes only pertain to Postgres; thus there are no changes that can be added to IT testing unless/until the ITs use Postgres as a data store.

Therefore to test the efficacy of this change, a reviewer would have to:
- use Postgres as a db
- set the flag in the JDBC URL to disable detailed SQL output
- introduce a scenario in the BFD Pipeline that would trigger a SQL exception; for example, the easiest way is try to perform an INSERT into the Beneficiary table for a bene_id that already exists.

Enclosed is a log of the Pipeline encountering a BatchUpdateException with the _logServerErrorDetail_ flag set to false; note that this change does not effect stack trace information nor does it spill PII data. It does however, show the SQL that triggered the exception, but does not include actual data values in the SQL:

<summary><details>
 
```
2023-01-18T17:07:05.000Z 2277 [main] INFO  gov.cms.bfd.pipeline.app.PipelineApplication - Application starting up!
2023-01-18T17:07:05.456Z 2277 [main] INFO  gov.cms.bfd.pipeline.app.PipelineApplication - Application configured: ', databaseOptions=DatabaseOptions [databaseUrl=jdbc:postgresql://bfd-2276-aurora-cluster-node-0.clyryngdhnko.us-east-1.rds.amazonaws.com:5432/fhirdb?logServerErrorDetail=false, databaseUsername=***, databasePassword=***, maxPoolSize=40], metricsOptions=MetricOptions [newRelicMetricHost=https://gov-metric-api.newrelic.com, newRelicMetricPath=/metric/v1, newRelicMetricPath=/metric/v1, newRelicAppName=BFD Pipeline (2277), newRelicMetricPeriod=null, newRelicMetricKey=***, hostname=ip-10-232-51-7.ec2.internal]AppConfiguration [ccwRifLoadOptions=CcwRifLoadOptions [extractionOptions=ExtractionOptions [s3BucketName=bfd2330-test, allowedRifFileType=null], loadOptions=LoadAppOptions [hicnHashIterations=42, hicnHashPepper=***, loaderThreads=20, idempotencyRequired=false, filteringNonNullAndNon2023Benes=true]], rdaLoadOptions=null]'
2023-01-18T17:07:05.518Z 2277 [main] INFO  gov.cms.bfd.pipeline.app.PipelineApplication - Added DropwizardMeterRegistry.
2023-01-18T17:07:05.552Z 2277 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Starting...
2023-01-18T17:07:06.251Z 2277 [main] INFO  com.zaxxer.hikari.pool.HikariPool - HikariPool-1 - Added connection org.postgresql.jdbc.PgConnection@721eb7df
2023-01-18T17:07:06.313Z 2277 [main] INFO  com.zaxxer.hikari.HikariDataSource - HikariPool-1 - Start completed.
2023-01-18T17:07:06.324Z 2277 [main] INFO  gov.cms.bfd.pipeline.app.PipelineApplication - Database: PostgreSQL, Driver version: major: 42, minor: 5; JDBC version, major: 4, minor: 2
2023-01-18T17:07:06.324Z 2277 [main] INFO  gov.cms.bfd.pipeline.app.PipelineApplication - pgjdbc, logServerDetail: false
2023-01-18T17:07:06.481Z 2277 [main] INFO  org.hibernate.jpa.internal.util.LogHelper - HHH000204: Processing PersistenceUnitInfo [name: gov.cms.bfd]
2023-01-18T17:07:06.557Z 2277 [main] INFO  org.hibernate.Version - HHH000412: Hibernate ORM core version 5.6.10.Final
2023-01-18T17:07:06.924Z 2277 [main] INFO  org.hibernate.annotations.common.Version - HCANN000001: Hibernate Commons Annotations {5.1.2.Final}
2023-01-18T17:07:07.365Z 2277 [main] INFO  org.hibernate.dialect.Dialect - HHH000400: Using dialect: org.hibernate.dialect.PostgreSQL10Dialect
2023-01-18T17:07:07.998Z 2277 [main] WARN  org.hibernate.boot.internal.SessionFactoryOptionsBuilder - class org.hibernate.tool.schema.Action cannot be cast to class java.lang.String (org.hibernate.tool.schema.Action is in unnamed module of loader 'app'; java.lang.String is in module java.base of loader 'bootstrap')  Ignoring
2023-01-18T17:07:08.115Z 2277 [main] INFO  org.hibernate.validator.internal.util.Version - HV000001: Hibernate Validator 6.2.3.Final
2023-01-18T17:07:10.028Z 2277 [main] INFO  org.hibernate.engine.transaction.jta.platform.internal.JtaPlatformInitiator - HHH000490: Using JtaPlatform implementation: [org.hibernate.engine.transaction.jta.platform.internal.NoJtaPlatform]
2023-01-18T17:07:10.517Z 2277 [main] INFO  gov.cms.bfd.pipeline.app.PipelineApplication - Registered CcwRifLoadJob.
2023-01-18T17:07:10.517Z 2277 [main] INFO  gov.cms.bfd.pipeline.app.PipelineApplication - RDA API jobs are not enabled in app configuration.
2023-01-18T17:07:10.518Z 2277 [main] INFO  gov.cms.bfd.pipeline.app.PipelineApplication - smoke test running: job=gov.cms.bfd.pipeline.ccw.rif.CcwRifLoadJob
2023-01-18T17:07:10.518Z 2277 [main] INFO  gov.cms.bfd.pipeline.app.PipelineApplication - smoke test successful: job=gov.cms.bfd.pipeline.ccw.rif.CcwRifLoadJob
2023-01-18T17:07:10.558Z 2277 [main] INFO  gov.cms.bfd.pipeline.app.PipelineApplication - Job processing started.
2023-01-18T17:07:31.446Z 2277 [pool-3-thread-3] WARN  gov.cms.bfd.pipeline.ccw.rif.extract.s3.DataSetQueue - Unable to find keyspace Synthetic/Incoming/2023-01-06T12:00:00Z/150129_manifest.xml in bucket bfd2330-test while scanning for manifests.
2023-01-18T17:07:31.447Z 2277 [pool-3-thread-3] INFO  gov.cms.bfd.pipeline.ccw.rif.CcwRifLoadJob - Found data set to process: 'DataSetManifest [timestamp=2023-01-06T12:00:00Z, sequenceId=150129, syntheticData=false, entries=[DataSetManifestEntry [parentManifest.getTimestamp()=2023-01-06T12:00:00Z, parentManifest.getSequenceId()=150129, name=bene_test.txt, type=BENEFICIARY]]]'. There were '1' total pending data sets and '0' completed ones.
2023-01-18T17:07:31.503Z 2277 [pool-3-thread-3] INFO  gov.cms.bfd.pipeline.ccw.rif.CcwRifLoadJob - Data set ready. Processing it...
2023-01-18T17:07:31.504Z 2277 [pool-3-thread-3] INFO  gov.cms.bfd.pipeline.ccw.rif.CcwRifLoadJob - Data set syntheticData indicator is: false
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by gov.cms.bfd.pipeline.ccw.rif.extract.s3.TaskExecutor (file:/Users/colinchristophermackenzie/dev/bfd2330_orig/apps/bfd-pipeline/bfd-pipeline-app/target/pipeline-app/bfd-pipeline-app-1.0.0-SNAPSHOT/lib/bfd-pipeline-ccw-rif-1.0.0-SNAPSHOT.jar) to field java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.time
WARNING: Please consider reporting this to the maintainers of gov.cms.bfd.pipeline.ccw.rif.extract.s3.TaskExecutor
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
2023-01-18T17:07:31.533Z 2277 [pool-3-thread-3] INFO  gov.cms.bfd.pipeline.ccw.rif.extract.s3.S3RifFile - Waiting for RIF file download: '2023-01-06T12:00:00Z.150129:bene_test.txt'...
2023-01-18T17:07:31.720Z 2277 [pool-3-thread-3] INFO  gov.cms.bfd.pipeline.ccw.rif.extract.s3.S3RifFile - RIF file downloaded: '2023-01-06T12:00:00Z.150129:bene_test.txt'.
2023-01-18T17:07:31.741Z 2277 [pool-3-thread-3] INFO  gov.cms.bfd.pipeline.ccw.rif.load.RifLoader - Configured to load with '20' threads, a queue of '200', and a batch size of '100'.
2023-01-18T17:07:31.743Z 2277 [pool-3-thread-3] INFO  gov.cms.bfd.pipeline.ccw.rif.load.RifLoader - Processing 'RifFileRecords [sourceEvent=RifFileEvent [file=S3RifFile [manifestEntry=DataSetManifestEntry [parentManifest.getTimestamp()=2023-01-06T12:00:00Z, parentManifest.getSequenceId()=150129, name=bene_test.txt, type=BENEFICIARY], manifestEntryDownload.localPath=/tmp/data-pipeline-s3-temp18408730501223957284.rif], parentFilesEvent.timestamp=2023-01-06T12:00:00Z]]'...
2023-01-18T17:07:32.231Z 2277 [pool-3-thread-3] INFO  gov.cms.bfd.pipeline.ccw.rif.load.RifLoader - Inserting LoadedFile 6142 of type BENEFICIARY created at 2023-01-18T17:07:32.063665Z
2023-01-18T17:07:32.376Z 2277 [pool-5-thread-1] INFO  org.hibernate.engine.jdbc.batch.internal.AbstractBatchImpl - HHH000010: On release of batch it still contained JDBC statements
2023-01-18T17:07:32.377Z 2277 [pool-5-thread-1] ERROR org.hibernate.engine.jdbc.batch.internal.BatchingBatch - HHH000315: Exception executing batch [java.sql.BatchUpdateException: Batch entry 0 <unknown> was aborted: ERROR: duplicate key value violates unique constraint "beneficiaries_pkey"  **Call getNextException to see other errors in the batch.], SQL:** insert into beneficiaries (age, rfrnc_yr, bene_link_key, death_dt, bene_birth_dt, bene_county_cd, crnt_bic, city_name, drvd_line_1_adr, drvd_line_2_adr, drvd_line_3_adr, drvd_line_4_adr, drvd_line_5_adr, drvd_line_6_adr, state_cd, state_cnty_zip_cd, bene_esrd_ind, efivepct, mdcr_entlmt_buyin_4_ind, mdcr_entlmt_buyin_8_ind, mdcr_entlmt_buyin_12_ind, mdcr_entlmt_buyin_2_ind, mdcr_entlmt_buyin_1_ind, mdcr_entlmt_buyin_7_ind, mdcr_entlmt_buyin_6_ind, mdcr_entlmt_buyin_3_ind, mdcr_entlmt_buyin_5_ind, mdcr_entlmt_buyin_11_ind, mdcr_entlmt_buyin_10_ind, mdcr_entlmt_buyin_9_ind, bene_entlmt_rsn_curr, bene_entlmt_rsn_orig, fips_state_cnty_apr_cd, fips_state_cnty_aug_cd, fips_state_cnty_dec_cd, fips_state_cnty_feb_cd, fips_state_cnty_jan_cd, fips_state_cnty_jul_cd, fips_state_cnty_jun_cd, fips_state_cnty_mar_cd, fips_state_cnty_may_cd, fips_state_cnty_nov_cd, fips_state_cnty_oct_cd, fips_state_cnty_sept_cd, bene_crnt_hic_num, hicn_unhashed, hmo_mo_cnt, hmo_4_ind, hmo_8_ind, hmo_12_ind, hmo_2_ind, hmo_1_ind, hmo_7_ind, hmo_6_ind, hmo_3_ind, hmo_5_ind, hmo_11_ind, hmo_10_ind, hmo_9_ind, last_updated, efctv_bgn_dt, mbi_hash, efctv_end_dt, meta_dual_elgbl_stus_apr_cd, meta_dual_elgbl_stus_aug_cd, meta_dual_elgbl_stus_dec_cd, meta_dual_elgbl_stus_feb_cd, meta_dual_elgbl_stus_jan_cd, meta_dual_elgbl_stus_jul_cd, meta_dual_elgbl_stus_jun_cd, meta_dual_elgbl_stus_mar_cd, meta_dual_elgbl_stus_may_cd, meta_dual_elgbl_stus_nov_cd, meta_dual_elgbl_stus_oct_cd, meta_dual_elgbl_stus_sept_cd, mbi_num, covstart, bene_mdcr_status_cd, mdcr_stus_apr_cd, mdcr_stus_aug_cd, mdcr_stus_dec_cd, mdcr_stus_feb_cd, mdcr_stus_jan_cd, mdcr_stus_jul_cd, mdcr_stus_jun_cd, mdcr_stus_mar_cd, mdcr_stus_may_cd, mdcr_stus_nov_cd, mdcr_stus_oct_cd, mdcr_stus_sept_cd, dual_mo_cnt, rds_mo_cnt, bene_gvn_name, bene_mdl_name, bene_srnm_name, a_mo_cnt, bene_pta_trmntn_cd, b_mo_cnt, bene_ptb_trmntn_cd, ptc_cntrct_apr_id, ptc_cntrct_aug_id, ptc_cntrct_dec_id, ptc_cntrct_feb_id, ptc_cntrct_jan_id, ptc_cntrct_jul_id, ptc_cntrct_jun_id, ptc_cntrct_mar_id, ptc_cntrct_may_id, ptc_cntrct_nov_id, ptc_cntrct_oct_id, ptc_cntrct_sept_id, ptc_pbp_apr_id, ptc_pbp_aug_id, ptc_pbp_dec_id, ptc_pbp_feb_id, ptc_pbp_jan_id, ptc_pbp_jul_id, ptc_pbp_jun_id, ptc_pbp_mar_id, ptc_pbp_may_id, ptc_pbp_nov_id, ptc_pbp_oct_id, ptc_pbp_sept_id, ptc_plan_type_apr_cd, ptc_plan_type_aug_cd, ptc_plan_type_dec_cd, ptc_plan_type_feb_cd, ptc_plan_type_jan_cd, ptc_plan_type_jul_cd, ptc_plan_type_jun_cd, ptc_plan_type_mar_cd, ptc_plan_type_may_cd, ptc_plan_type_nov_cd, ptc_plan_type_oct_cd, ptc_plan_type_sept_cd, ptd_cntrct_apr_id, ptd_cntrct_aug_id, ptd_cntrct_dec_id, ptd_cntrct_feb_id, ptd_cntrct_jan_id, ptd_cntrct_jul_id, ptd_cntrct_jun_id, ptd_cntrct_mar_id, ptd_cntrct_may_id, ptd_cntrct_nov_id, ptd_cntrct_oct_id, ptd_cntrct_sept_id, cst_shr_grp_apr_cd, cst_shr_grp_aug_cd, cst_shr_grp_dec_cd, cst_shr_grp_feb_cd, cst_shr_grp_jan_cd, cst_shr_grp_jul_cd, cst_shr_grp_jun_cd, cst_shr_grp_mar_cd, cst_shr_grp_may_cd, cst_shr_grp_nov_cd, cst_shr_grp_oct_cd, cst_shr_grp_sept_cd, plan_cvrg_mo_cnt, ptd_pbp_apr_id, ptd_pbp_aug_id, ptd_pbp_dec_id, ptd_pbp_feb_id, ptd_pbp_jan_id, ptd_pbp_jul_id, ptd_pbp_jun_id, ptd_pbp_mar_id, ptd_pbp_may_id, ptd_pbp_nov_id, ptd_pbp_oct_id, ptd_pbp_sept_id, rds_apr_ind, rds_aug_ind, rds_dec_ind, rds_feb_ind, rds_jan_ind, rds_jul_ind, rds_jun_ind, rds_mar_ind, rds_may_ind, rds_nov_ind, rds_oct_ind, rds_sept_ind, ptd_sgmt_apr_id, ptd_sgmt_aug_id, ptd_sgmt_dec_id, ptd_sgmt_feb_id, ptd_sgmt_jan_id, ptd_sgmt_jul_id, ptd_sgmt_jun_id, ptd_sgmt_mar_id, ptd_sgmt_may_id, ptd_sgmt_nov_id, ptd_sgmt_oct_id, ptd_sgmt_sept_id, bene_zip_cd, bene_race_cd, rti_race_cd, sample_group, bene_sex_ident_cd, enrl_src, buyin_mo_cnt, state_code, v_dod_sw, bene_id) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
2023-01-18T17:07:32.378Z 2277 [pool-5-thread-1] WARN  org.hibernate.engine.jdbc.spi.SqlExceptionHelper - SQL Error: 0, SQLState: 23505
2023-01-18T17:07:32.378Z 2277 [pool-5-thread-1] ERROR org.hibernate.engine.jdbc.spi.SqlExceptionHelper - Batch entry 0 <unknown> was aborted: ERROR: duplicate key value violates unique constraint "beneficiaries_pkey"  Call getNextException to see other errors in the batch.
2023-01-18T17:07:32.378Z 2277 [pool-5-thread-1] ERROR org.hibernate.engine.jdbc.spi.SqlExceptionHelper - ERROR: duplicate key value violates unique constraint "beneficiaries_pkey"
2023-01-18T17:07:32.418Z 2277 [pool-5-thread-1] WARN  gov.cms.bfd.pipeline.ccw.rif.load.RifLoader - Failed to load 'BENEFICIARY' record.
javax.persistence.RollbackException: Error while committing the transaction
        at org.hibernate.internal.ExceptionConverterImpl.convertCommitException(ExceptionConverterImpl.java:81)
        at org.hibernate.engine.transaction.internal.TransactionImpl.commit(TransactionImpl.java:104)
        at gov.cms.bfd.pipeline.ccw.rif.load.RifLoader.process(RifLoader.java:516)
        at gov.cms.bfd.pipeline.ccw.rif.load.RifLoader.lambda$processAsync$2(RifLoader.java:347)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: javax.persistence.PersistenceException: org.hibernate.exception.ConstraintViolationException: could not execute batch
        at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:154)
        at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:181)
        at org.hibernate.internal.ExceptionConverterImpl.convertCommitException(ExceptionConverterImpl.java:65)
        ... 8 common frames omitted
Caused by: org.hibernate.exception.ConstraintViolationException: could not execute batch
        at org.hibernate.exception.internal.SQLStateConversionDelegate.convert(SQLStateConversionDelegate.java:109)
        at org.hibernate.exception.internal.StandardSQLExceptionConverter.convert(StandardSQLExceptionConverter.java:37)
        at org.hibernate.engine.jdbc.spi.SqlExceptionHelper.convert(SqlExceptionHelper.java:113)
        at org.hibernate.engine.jdbc.batch.internal.BatchingBatch.performExecution(BatchingBatch.java:135)
        at org.hibernate.engine.jdbc.batch.internal.BatchingBatch.doExecuteBatch(BatchingBatch.java:110)
        at org.hibernate.engine.jdbc.batch.internal.AbstractBatchImpl.execute(AbstractBatchImpl.java:153)
        at org.hibernate.engine.jdbc.internal.JdbcCoordinatorImpl.getBatch(JdbcCoordinatorImpl.java:187)
        at org.hibernate.persister.entity.AbstractEntityPersister.insert(AbstractEntityPersister.java:3355)
        at org.hibernate.persister.entity.AbstractEntityPersister.insert(AbstractEntityPersister.java:3908)
        at org.hibernate.action.internal.EntityInsertAction.execute(EntityInsertAction.java:107)
        at org.hibernate.engine.spi.ActionQueue.executeActions(ActionQueue.java:604)
        at org.hibernate.engine.spi.ActionQueue.lambda$executeActions$1(ActionQueue.java:478)
        at java.base/java.util.LinkedHashMap.forEach(LinkedHashMap.java:684)
        at org.hibernate.engine.spi.ActionQueue.executeActions(ActionQueue.java:475)
        at org.hibernate.event.internal.AbstractFlushingEventListener.performExecutions(AbstractFlushingEventListener.java:344)
        at org.hibernate.event.internal.DefaultFlushEventListener.onFlush(DefaultFlushEventListener.java:40)
        at org.hibernate.event.service.internal.EventListenerGroupImpl.fireEventOnEachListener(EventListenerGroupImpl.java:107)
        at org.hibernate.internal.SessionImpl.doFlush(SessionImpl.java:1407)
        at org.hibernate.internal.SessionImpl.managedFlush(SessionImpl.java:489)
        at org.hibernate.internal.SessionImpl.flushBeforeTransactionCompletion(SessionImpl.java:3290)
        at org.hibernate.internal.SessionImpl.beforeTransactionCompletion(SessionImpl.java:2425)
        at org.hibernate.engine.jdbc.internal.JdbcCoordinatorImpl.beforeTransactionCompletion(JdbcCoordinatorImpl.java:449)
        at org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorImpl.beforeCompletionCallback(JdbcResourceLocalTransactionCoordinatorImpl.java:183)
        at org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorImpl.access$300(JdbcResourceLocalTransactionCoordinatorImpl.java:40)
        at org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorImpl$TransactionDriverControlImpl.commit(JdbcResourceLocalTransactionCoordinatorImpl.java:281)
        at org.hibernate.engine.transaction.internal.TransactionImpl.commit(TransactionImpl.java:101)
        ... 7 common frames omitted
Caused by: java.sql.BatchUpdateException: Batch entry 0 <unknown> was aborted: ERROR: duplicate key value violates unique constraint "beneficiaries_pkey"  Call getNextException to see other errors in the batch.
        at org.postgresql.jdbc.BatchResultHandler.handleError(BatchResultHandler.java:165)
        at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2367)
        at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:560)
        at org.postgresql.jdbc.PgStatement.internalExecuteBatch(PgStatement.java:893)
        at org.postgresql.jdbc.PgStatement.executeBatch(PgStatement.java:916)
        at org.postgresql.jdbc.PgPreparedStatement.executeBatch(PgPreparedStatement.java:1684)
        at com.zaxxer.hikari.pool.ProxyStatement.executeBatch(ProxyStatement.java:127)
        at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeBatch(HikariProxyPreparedStatement.java)
        at org.hibernate.engine.jdbc.batch.internal.BatchingBatch.performExecution(BatchingBatch.java:125)
        ... 29 common frames omitted
Caused by: org.postgresql.util.PSQLException: ERROR: duplicate key value violates unique constraint "beneficiaries_pkey"
        at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2676)
        at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2366)
        ... 36 common frames omitted
2023-01-18T17:07:32.423Z 2277 [pool-5-thread-1] ERROR gov.cms.bfd.pipeline.app.PipelineApplication - Data set failed with an unhandled error. Application will exit.
gov.cms.bfd.pipeline.ccw.rif.load.RifLoadFailure: Failed to load 'BENEFICIARY' records.
        at gov.cms.bfd.pipeline.ccw.rif.load.RifLoader.process(RifLoader.java:530)
        at gov.cms.bfd.pipeline.ccw.rif.load.RifLoader.lambda$processAsync$2(RifLoader.java:347)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: javax.persistence.RollbackException: Error while committing the transaction
        at org.hibernate.internal.ExceptionConverterImpl.convertCommitException(ExceptionConverterImpl.java:81)
        at org.hibernate.engine.transaction.internal.TransactionImpl.commit(TransactionImpl.java:104)
        at gov.cms.bfd.pipeline.ccw.rif.load.RifLoader.process(RifLoader.java:516)
        ... 6 common frames omitted
Caused by: javax.persistence.PersistenceException: org.hibernate.exception.ConstraintViolationException: could not execute batch
        at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:154)
        at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:181)
        at org.hibernate.internal.ExceptionConverterImpl.convertCommitException(ExceptionConverterImpl.java:65)
        ... 8 common frames omitted
Caused by: org.hibernate.exception.ConstraintViolationException: could not execute batch
        at org.hibernate.exception.internal.SQLStateConversionDelegate.convert(SQLStateConversionDelegate.java:109)
        at org.hibernate.exception.internal.StandardSQLExceptionConverter.convert(StandardSQLExceptionConverter.java:37)
        at org.hibernate.engine.jdbc.spi.SqlExceptionHelper.convert(SqlExceptionHelper.java:113)
        at org.hibernate.engine.jdbc.batch.internal.BatchingBatch.performExecution(BatchingBatch.java:135)
        at org.hibernate.engine.jdbc.batch.internal.BatchingBatch.doExecuteBatch(BatchingBatch.java:110)
        at org.hibernate.engine.jdbc.batch.internal.AbstractBatchImpl.execute(AbstractBatchImpl.java:153)
        at org.hibernate.engine.jdbc.internal.JdbcCoordinatorImpl.getBatch(JdbcCoordinatorImpl.java:187)
        at org.hibernate.persister.entity.AbstractEntityPersister.insert(AbstractEntityPersister.java:3355)
        at org.hibernate.persister.entity.AbstractEntityPersister.insert(AbstractEntityPersister.java:3908)
        at org.hibernate.action.internal.EntityInsertAction.execute(EntityInsertAction.java:107)
        at org.hibernate.engine.spi.ActionQueue.executeActions(ActionQueue.java:604)
        at org.hibernate.engine.spi.ActionQueue.lambda$executeActions$1(ActionQueue.java:478)
        at java.base/java.util.LinkedHashMap.forEach(LinkedHashMap.java:684)
        at org.hibernate.engine.spi.ActionQueue.executeActions(ActionQueue.java:475)
        at org.hibernate.event.internal.AbstractFlushingEventListener.performExecutions(AbstractFlushingEventListener.java:344)
        at org.hibernate.event.internal.DefaultFlushEventListener.onFlush(DefaultFlushEventListener.java:40)
        at org.hibernate.event.service.internal.EventListenerGroupImpl.fireEventOnEachListener(EventListenerGroupImpl.java:107)
        at org.hibernate.internal.SessionImpl.doFlush(SessionImpl.java:1407)
        at org.hibernate.internal.SessionImpl.managedFlush(SessionImpl.java:489)
        at org.hibernate.internal.SessionImpl.flushBeforeTransactionCompletion(SessionImpl.java:3290)
        at org.hibernate.internal.SessionImpl.beforeTransactionCompletion(SessionImpl.java:2425)
        at org.hibernate.engine.jdbc.internal.JdbcCoordinatorImpl.beforeTransactionCompletion(JdbcCoordinatorImpl.java:449)
        at org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorImpl.beforeCompletionCallback(JdbcResourceLocalTransactionCoordinatorImpl.java:183)
        at org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorImpl.access$300(JdbcResourceLocalTransactionCoordinatorImpl.java:40)
        at org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorImpl$TransactionDriverControlImpl.commit(JdbcResourceLocalTransactionCoordinatorImpl.java:281)
        at org.hibernate.engine.transaction.internal.TransactionImpl.commit(TransactionImpl.java:101)
        ... 7 common frames omitted
Caused by: java.sql.BatchUpdateException: Batch entry 0 <unknown> was aborted: ERROR: duplicate key value violates unique constraint "beneficiaries_pkey"  Call getNextException to see other errors in the batch.
        at org.postgresql.jdbc.BatchResultHandler.handleError(BatchResultHandler.java:165)
        at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2367)
        at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:560)
        at org.postgresql.jdbc.PgStatement.internalExecuteBatch(PgStatement.java:893)
        at org.postgresql.jdbc.PgStatement.executeBatch(PgStatement.java:916)
        at org.postgresql.jdbc.PgPreparedStatement.executeBatch(PgPreparedStatement.java:1684)
        at com.zaxxer.hikari.pool.ProxyStatement.executeBatch(ProxyStatement.java:127)
        at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeBatch(HikariProxyPreparedStatement.java)
        at org.hibernate.engine.jdbc.batch.internal.BatchingBatch.performExecution(BatchingBatch.java:125)
        ... 29 common frames omitted
Caused by: org.postgresql.util.PSQLException: ERROR: duplicate key value violates unique constraint "beneficiaries_pkey"
        at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2676)
        at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2366)
        ... 36 common frames omitted
2023-01-18T17:07:32.425Z 2277 [Thread-0] INFO  gov.cms.bfd.pipeline.app.PipelineApplication - Application is shutting down...
2023-01-18T17:07:32.425Z 2277 [Thread-0] INFO  gov.cms.bfd.pipeline.app.PipelineManager - Stopping PipelineManager...
2023-01-18T17:07:32.426Z 2277 [Thread-0] INFO  gov.cms.bfd.pipeline.app.PipelineManager - Shut down job executor, without cancelling existing jobs.
2023-01-18T17:07:32.431Z 2277 [Thread-0] INFO  gov.cms.bfd.pipeline.app.PipelineManager - Waiting for jobs to stop, which may take A WHILE. (Message will repeat every ten minutes, until complete.)
2023-01-18T17:07:32.432Z 2277 [pool-3-thread-2] INFO  gov.cms.bfd.pipeline.sharedutils.jobs.store.PipelineJobRecordStore - Job completed: jobRecord='PipelineJobRecord [id=1, jobType=gov.cms.bfd.pipeline.app.scheduler.SchedulerJob, jobArguments=null, createdTime=2023-01-18T17:07:10.557415Z, canceledTime=Optional.empty, enqueuedTime=Optional[2023-01-18T17:07:20.560631Z], startedTime=Optional[2023-01-18T17:07:20.560946Z], completedTime=Optional[2023-01-18T17:07:32.432089Z], outcome=Optional[NOTHING_TO_DO], failure=Optional.empty]'
2023-01-18T17:07:32.438Z 2277 [pool-3-thread-1] INFO  gov.cms.bfd.pipeline.sharedutils.jobs.store.PipelineJobRecordStore - Job completed: jobRecord='PipelineJobRecord [id=0, jobType=gov.cms.bfd.pipeline.app.volunteer.VolunteerJob, jobArguments=null, createdTime=2023-01-18T17:07:10.529441Z, canceledTime=Optional.empty, enqueuedTime=Optional[2023-01-18T17:07:10.530441Z], startedTime=Optional[2023-01-18T17:07:10.552333Z], completedTime=Optional[2023-01-18T17:07:32.438731Z], outcome=Optional[WORK_DONE], failure=Optional.empty]'
2023-01-18T17:09:31.531Z 2277 [metrics-logger-reporter-2-thread-1] INFO  gov.cms.bfd.pipeline.app.DefaultDataSetMonitorListener - type=GAUGE, name=RifLoader.loadExecutorService.activeBatches, value=1
2023-01-18T17:09:31.531Z 2277 [metrics-logger-reporter-2-thread-1] INFO  gov.cms.bfd.pipeline.app.DefaultDataSetMonitorListener - type=GAUGE, name=RifLoader.loadExecutorService.queueSize, value=0
2023-01-18T17:09:31.535Z 2277 [metrics-logger-reporter-2-thread-1] INFO  gov.cms.bfd.pipeline.app.DefaultDataSetMonitorListener - type=METER, name=RifLoader.recordBatches.failed, count=1, m1_rate=0.03197594921593881, m5_rate=0.1386081240172883, m15_rate=0.17699033814381568, mean_rate=0.008395164735466103, rate_unit=events/second
2023-01-18T17:09:31.535Z 2277 [metrics-logger-reporter-2-thread-1] INFO  gov.cms.bfd.pipeline.app.DefaultDataSetMonitorListener - type=METER, name=RifLoader.records.INSERTED, count=5, m1_rate=0.15987974607969416, m5_rate=0.6930406200864418, m15_rate=0.8849516907190782, mean_rate=0.041922733456329506, rate_unit=events/second
2023-01-18T17:09:31.539Z 2277 [metrics-logger-reporter-2-thread-1] INFO  gov.cms.bfd.pipeline.app.DefaultDataSetMonitorListener - type=TIMER, name=RifFilesProcessor.recordParsing, count=5, min=0.374905, max=12.533356, mean=2.8194942000000003, stddev=4.856943750791537, p50=0.391516, p75=0.40984, p95=12.533356, p98=12.533356, p99=12.533356, p999=12.533356, m1_rate=0.15987974607969416, m5_rate=0.6930406200864418, m15_rate=0.8849516907190782, mean_rate=0.041911183443334075, rate_unit=events/second, duration_unit=milliseconds
2023-01-18T17:09:31.539Z 2277 [metrics-logger-reporter-2-thread-1] INFO  gov.cms.bfd.pipeline.app.DefaultDataSetMonitorListener - type=TIMER, name=RifLoader.hicnsHashed, count=5, min=0.438201, max=2.022616, mean=0.767088, stddev=0.6278924375454764, p50=0.456694, p75=0.474819, p95=2.022616, p98=2.022616, p99=2.022616, p999=2.022616, m1_rate=0.15987974607969416, m5_rate=0.6930406200864418, m15_rate=0.8849516907190782, mean_rate=0.04191737085194792, rate_unit=events/second, duration_unit=milliseconds
2023-01-18T17:09:31.540Z 2277 [metrics-logger-reporter-2-thread-1] INFO  gov.cms.bfd.pipeline.app.DefaultDataSetMonitorListener - type=TIMER, name=RifLoader.mbisHashed, count=5, min=0.364568, max=0.43745, mean=0.39173260000000004, stddev=0.0285361098932563, p50=0.373047, p75=0.412946, p95=0.43745, p98=0.43745, p99=0.43745, p999=0.43745, m1_rate=0.15987974607969416, m5_rate=0.6930406200864418, m15_rate=0.8849516907190782, mean_rate=0.041917984766438474, rate_unit=events/second, duration_unit=milliseconds
2023-01-18T17:09:31.540Z 2277 [metrics-logger-reporter-2-thread-1] INFO  gov.cms.bfd.pipeline.app.DefaultDataSetMonitorListener - type=TIMER, name=RifLoader.recordBatches.BENEFICIARY, count=0, min=0.0, max=0.0, mean=0.0, stddev=0.0, p50=0.0, p75=0.0, p95=0.0, p98=0.0, p99=0.0, p999=0.0, m1_rate=0.0, m5_rate=0.0, m15_rate=0.0, mean_rate=0.0, rate_unit=events/second, duration_unit=milliseconds
```

</details></summary>




### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [X] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [X] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [X] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [X] No

### What Needs to Be Merged and Deployed Before this PR?

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A

### Submitter Checklist>

I have gone through and verified that...:

* [X] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [X] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [X] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [X] The data dictionary has been updated with any field mapping changes, if any were made.
* [X] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [X] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [X] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [X] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    