### PR TITLE
BFD-2476: Execute Partially Adjudicated Smoketest During Deployments

### DIFF
--- a/apps/utils/locust_tests/.vscode/settings.json
+++ b/apps/utils/locust_tests/.vscode/settings.json
@@ -17,5 +17,7 @@
   // https://github.com/Microsoft/python-language-server/issues/887.
   // None of the proposed solutions seemed to work, other than disabling this
   // linting error
-  "python.linting.pylintArgs": ["--disable=import-error"]
+  "python.linting.pylintArgs": ["--disable=import-error"],
+  "python.languageServer": "Pylance",
+  "python.analysis.typeCheckingMode": "strict"
 }

--- a/apps/utils/locust_tests/common/bfd_user_base.py
+++ b/apps/utils/locust_tests/common/bfd_user_base.py
@@ -89,7 +89,7 @@ def _(environment: Environment, **kwargs) -> None:
                 )
         except Exception as exc:
             compare_result = FinalCompareResult.FAILED
-            logger.error("Stat comparsion was not able to complete; err: %s", str(exc))
+            logger.error("Stat comparison was not able to complete; err: %s", str(exc))
 
         stats.metadata.compare_result = compare_result
         stats.metadata.validation_result = validation_result

--- a/apps/utils/locust_tests/common/stats/aggregated_stats.py
+++ b/apps/utils/locust_tests/common/stats/aggregated_stats.py
@@ -26,7 +26,7 @@ class StatsCollector(object):
         self,
         locust_env: Environment,
         stats_tags: List[str],
-        running_env: StatsEnvironment = StatsEnvironment.TEST,
+        running_env: StatsEnvironment,
     ) -> None:
         """Creates a new instance of StatsCollector given the current Locust environment and a list
         of percentiles to report.
@@ -35,12 +35,12 @@ class StatsCollector(object):
             locust_env (Environment): Current Locust environment
             stats_tag (str): A string which tags the output JSON; used to distinguish between
             separate test runs
-            running_env (StatsEnvironment, optional): A StatsEnvironment enum which represents the
-            current testing environment; either TEST or PROD. Defaults to TEST.
+            running_env (StatsEnvironment): A StatsEnvironment enum which represents the
+            current testing environment; either TEST, PROD or PROD_SBX
         """
         super().__init__()
-        self.locust_env = locust_env
 
+        self.locust_env = locust_env
         self.stats_tags = stats_tags
         self.running_env = running_env
 

--- a/apps/utils/locust_tests/common/stats/stats_compare.py
+++ b/apps/utils/locust_tests/common/stats/stats_compare.py
@@ -86,9 +86,8 @@ class StatComparison:
 
 
 def do_stats_comparison(
-    environment: Environment,
     stats_config: StatsConfiguration,
-    stats_metadata_path: Optional[str],
+    stats_metadata_path: str,
     stats: AggregatedStats,
 ) -> FinalCompareResult:
     """Compares the current run's stats (totals and all tasks) against a user-configured baseline,
@@ -109,10 +108,6 @@ def do_stats_comparison(
         return FinalCompareResult.NOT_APPLICABLE
 
     logger = logging.getLogger()
-
-    if not stats_metadata_path:
-        logger.error("No comparison metadata file found -- stats cannot be compared.")
-        return FinalCompareResult.NOT_APPLICABLE
 
     stats_loader = StatsLoader.create(stats_config, stats.metadata)  # type: ignore
     try:
@@ -202,7 +197,6 @@ def do_stats_comparison(
                 str(stats_config.stats_compare.value),
                 stats_config.stats_compare_tag,
             )
-            environment.process_exit_code = 1
 
             return FinalCompareResult.FAILED
     else:

--- a/apps/utils/locust_tests/common/stats/stats_config.py
+++ b/apps/utils/locust_tests/common/stats/stats_config.py
@@ -1,7 +1,7 @@
 import dataclasses
 import re
 from argparse import Namespace
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
@@ -48,12 +48,10 @@ class StatsConfiguration:
     """Dataclass that holds data about where and how aggregated performance statistics are stored
     and compared"""
 
-    stats_store: StatsStorageType
+    stats_store: Optional[StatsStorageType]
     """The storage type that the stats will be written to"""
-    stats_env: StatsEnvironment
+    stats_env: Optional[StatsEnvironment]
     """The test running environment from which the statistics will be collected"""
-    stats_store_tags: List[str]
-    """A simple List of string tags that are used to partition collected statistics when stored"""
     stats_store_file_path: Optional[str]
     """The local parent directory where JSON files will be written to.
     Used only if type is file, ignored if type is s3"""
@@ -70,12 +68,14 @@ class StatsConfiguration:
     """Indicates the type of performance stats comparison that will be done"""
     stats_compare_tag: Optional[str]
     """Indicates the tag from which comparison statistics will be loaded"""
-    stats_compare_load_limit: int
-    """Indicates the limit of previous AggregatedStats loaded for comparison; used only for average
-    comparisons"""
     stats_compare_meta_file: Optional[str]
     """Indicates the path to a JSON file containing metadata about how stats should be compared for
     the running test suite. Overrides the default specified by the test suite, if any"""
+    stats_store_tags: List[str] = field(default_factory=list)
+    """A simple List of string tags that are used to partition collected statistics when stored"""
+    stats_compare_load_limit: int = 5
+    """Indicates the limit of previous AggregatedStats loaded for comparison; used only for average
+    comparisons"""
 
     @classmethod
     def register_custom_args(cls, parser: LocustArgumentParser) -> None:
@@ -125,6 +125,7 @@ class StatsConfiguration:
             dest="stats_store_tags",
             env_var="LOCUS_STATS_STORE_TAG",
             action="append",
+            default=[]
         )
         stats_group.add_argument(
             "--stats-store-file-path",

--- a/apps/utils/locust_tests/lambda/server-regression/.dockerignore
+++ b/apps/utils/locust_tests/lambda/server-regression/.dockerignore
@@ -1,7 +1,0 @@
-*
-!common/
-!config/
-!v1
-!v2
-!requirements.txt
-!app.py

--- a/apps/utils/locust_tests/lambda/server-regression/Dockerfile
+++ b/apps/utils/locust_tests/lambda/server-regression/Dockerfile
@@ -11,7 +11,8 @@ ENV  PATH="/var/lang/lib/python3.9/site-packages:${PATH}"
 FROM python as app
 # Copy function code
 COPY . ${LAMBDA_TASK_ROOT}
-RUN cp "${LAMBDA_TASK_ROOT}/lambda/server-regression/app.py" "${LAMBDA_TASK_ROOT}"
+RUN mv "${LAMBDA_TASK_ROOT}/lambda/server-regression/app.py" "${LAMBDA_TASK_ROOT}"
+RUN rm -rf "${LAMBDA_TASK_ROOT}/lambda"
 
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
 CMD [ "app.handler" ]

--- a/apps/utils/locust_tests/lambda/server-regression/Dockerfile.dockerignore
+++ b/apps/utils/locust_tests/lambda/server-regression/Dockerfile.dockerignore
@@ -1,0 +1,8 @@
+*
+!common/*.py
+!config/
+!v1/*.py
+!v2/*.py
+!requirements.txt
+!app.py
+!lambda/server-regression/app.py

--- a/apps/utils/locust_tests/lambda/server-regression/Dockerfile.dockerignore
+++ b/apps/utils/locust_tests/lambda/server-regression/Dockerfile.dockerignore
@@ -1,8 +1,8 @@
 *
 !common/*.py
+!common/stats/*.py
 !config/
 !v1/*.py
 !v2/*.py
 !requirements.txt
-!app.py
 !lambda/server-regression/app.py

--- a/apps/utils/locust_tests/lambda/server-regression/README.md
+++ b/apps/utils/locust_tests/lambda/server-regression/README.md
@@ -2,22 +2,11 @@
 
 ## Building the Image Locally
 
-As the `Dockerfile` for this image is not at the root of this `locust_tests` project, we need to ensure the [Docker build context](https://docs.docker.com/engine/reference/commandline/build/#description) is properly set to the root. This can be achieved in two ways:
-
-### Option 1 -- Specifying the `lambda/server-regression/Dockerfile` from the Root
-
-This option is _preferred_ to option 2, as it is generally better form to run `docker build` from the directory of the build context itslef.
-
-Ensure you current working directory is `/apps/utils/locust_tests` and run:
+Simply call the `build-push.sh` script from your terminal with a valid AWS session:
 
 ```
-docker build -f lambda/bfd-server-regression/Dockerfile -t "<your-tag>" --platform linux/amd64 .
+./lambda/server-regression/build-push.sh
 ```
 
-### Option 2 -- Specifying the Context Relative to This Directory
-
-This option simply tells Docker that the build context is the grandparent directory, via `../../`. Ensure your current working directory is `lambda/server-regression` and run:
-
-```
-docker build -t "<your-tag>" --platform linux/amd64 ../../.
-```
+The `build-push.sh` script can be invoked from any location provided that it has not been moved
+from the `./lambda/server-regression` directory.

--- a/apps/utils/locust_tests/lambda/server-regression/app.py
+++ b/apps/utils/locust_tests/lambda/server-regression/app.py
@@ -180,7 +180,7 @@ def handler(event, context):
     db_dsn = f"postgres://{username}:{password}@{db_uri}:5432/fhirdb"
 
     store_tag_args = [f"--stats-store-tag={tag}" for tag in invoke_event.store_tags]
-    process = subprocess.run(
+    regression_process = subprocess.run(
         [
             "locust",
             f"--locustfile=/var/task/{invoke_event.suite_version}/regression_suite.py",
@@ -204,13 +204,40 @@ def handler(event, context):
         text=True,
         check=False,
     )
+    regression_suite_succeeded = regression_process.returncode == 0
+
+    # This is a temporary addition to the regression suite lambda in order to easily smoketest PACA
+    # endpoints. No performance statistics are collected as the data this smoketest test suite
+    # operates on is not synthetic nor is it consistent across environments. Because it's just a
+    # smoketest the number of users, spawn rate, and runtime are not entirely important and so have
+    # been made static.
+    # TODO: Replace this in favor of merging PACA endpoint tests into the full regression suite in BFD-2490
+    paca_smoketest_process = subprocess.run(
+        [
+            "locust",
+            "--locustfile=/var/task/v2/partially_adjudicated_smoketest.py",
+            f"--host={invoke_event.host}",
+            "--users=10",
+            "--spawn-rate=10",
+            "--spawned-runtime=10s",
+            f"--database-connection-string={db_dsn}",
+            f"--client-cert-path={cert_path}",
+            "--headless",
+            "--only-summary",
+        ],
+        text=True,
+        check=False,
+    )
+    paca_smoketest_succeeded = paca_smoketest_process.returncode == 0
 
     # Signal the outcome of the locust test run
     send_pipeline_signal(
         signal_queue_url=signal_queue_url,
-        result=TestResult.SUCCESS if process.returncode == 0 else TestResult.FAILURE,
+        result=TestResult.SUCCESS
+        if regression_suite_succeeded and paca_smoketest_succeeded
+        else TestResult.FAILURE,
         message="Pipeline run finished, check the CloudWatch logs for more information",
         context=context,
     )
 
-    return process.stdout
+    return regression_process.stdout

--- a/apps/utils/locust_tests/lambda/server-regression/build-push.sh
+++ b/apps/utils/locust_tests/lambda/server-regression/build-push.sh
@@ -12,14 +12,17 @@ SSM_IMAGE_TAG_PARAMETER="/bfd/mgmt/server/nonsensitive/server_regression_latest_
 DOCKER_TAG="${DOCKER_TAG_OVERRIDE:-"${GIT_SHORT_HASH}"}"
 DOCKER_TAG_LATEST="${DOCKER_TAG_LATEST_OVERRIDE:-"latest"}"
 
+aws ecr-public get-login-password --region "$AWS_REGION" | docker login --username AWS --password-stdin "public.ecr.aws"
+aws ecr get-login-password --region "$AWS_REGION" | docker login --username AWS --password-stdin "$PRIVATE_REGISTRY_URI"
+
+DOCKER_BUILDKIT=1 # Specified to enable Dockerfile local Dockerignore, see https://stackoverflow.com/a/57774684
 docker build . \
   --file "./lambda/server-regression/Dockerfile" \
   --tag "$IMAGE_NAME:${DOCKER_TAG}" \
   --tag "$IMAGE_NAME:${DOCKER_TAG_LATEST}" \
   --platform "linux/amd64"
 
-aws ecr get-login-password --region "$AWS_REGION" | docker login --username AWS --password-stdin "$PRIVATE_REGISTRY_URI"
-docker push "$IMAGE_NAME" --all-tags
+docker image push --all-tags "$IMAGE_NAME"
 
 aws ssm put-parameter \
   --name "$SSM_IMAGE_TAG_PARAMETER" \

--- a/apps/utils/locust_tests/lambda/server-regression/build-push.sh
+++ b/apps/utils/locust_tests/lambda/server-regression/build-push.sh
@@ -12,17 +12,21 @@ SSM_IMAGE_TAG_PARAMETER="/bfd/mgmt/server/nonsensitive/server_regression_latest_
 DOCKER_TAG="${DOCKER_TAG_OVERRIDE:-"${GIT_SHORT_HASH}"}"
 DOCKER_TAG_LATEST="${DOCKER_TAG_LATEST_OVERRIDE:-"latest"}"
 
+IMAGE_TAGGED_HASH="$IMAGE_NAME:$DOCKER_TAG"
+IMAGE_TAGGED_LATEST="$IMAGE_NAME:$DOCKER_TAG_LATEST"
+
 aws ecr-public get-login-password --region "$AWS_REGION" | docker login --username AWS --password-stdin "public.ecr.aws"
 aws ecr get-login-password --region "$AWS_REGION" | docker login --username AWS --password-stdin "$PRIVATE_REGISTRY_URI"
 
 DOCKER_BUILDKIT=1 # Specified to enable Dockerfile local Dockerignore, see https://stackoverflow.com/a/57774684
 docker build . \
   --file "./lambda/server-regression/Dockerfile" \
-  --tag "$IMAGE_NAME:${DOCKER_TAG}" \
-  --tag "$IMAGE_NAME:${DOCKER_TAG_LATEST}" \
+  --tag "$IMAGE_TAGGED_HASH" \
+  --tag "$IMAGE_TAGGED_LATEST" \
   --platform "linux/amd64"
 
-docker image push --all-tags "$IMAGE_NAME"
+docker image push "$IMAGE_TAGGED_HASH"
+docker image push "$IMAGE_TAGGED_LATEST"
 
 aws ssm put-parameter \
   --name "$SSM_IMAGE_TAG_PARAMETER" \

--- a/apps/utils/locust_tests/lambda/server-regression/build-push.sh
+++ b/apps/utils/locust_tests/lambda/server-regression/build-push.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 set -eou pipefail
 
-# Constants
-GIT_SHORT_HASH="$(git rev-parse --short HEAD)"
+# SCRIPT_DIR will return the directory where this script is located, and CONTEXT_DIR will be the
+# directory of the Docker build context (locust_tests). This way, this script can be called from
+# _any_ directory and there will be no issues
+SCRIPT_DIR="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")"
+CONTEXT_DIR="$(cd "$SCRIPT_DIR"; cd ../../; pwd)"
+GIT_SHORT_HASH="$(cd "$SCRIPT_DIR"; git rev-parse --short HEAD)"
 AWS_REGION="us-east-1"
 PRIVATE_REGISTRY_URI="$(aws ecr describe-registry --region "$AWS_REGION" | jq -r '.registryId').dkr.ecr.$AWS_REGION.amazonaws.com"
 IMAGE_NAME="$PRIVATE_REGISTRY_URI/bfd-mgmt-server-regression"
@@ -19,8 +23,8 @@ aws ecr-public get-login-password --region "$AWS_REGION" | docker login --userna
 aws ecr get-login-password --region "$AWS_REGION" | docker login --username AWS --password-stdin "$PRIVATE_REGISTRY_URI"
 
 DOCKER_BUILDKIT=1 # Specified to enable Dockerfile local Dockerignore, see https://stackoverflow.com/a/57774684
-docker build . \
-  --file "./lambda/server-regression/Dockerfile" \
+docker build "$CONTEXT_DIR" \
+  --file "$CONTEXT_DIR/lambda/server-regression/Dockerfile" \
   --tag "$IMAGE_TAGGED_HASH" \
   --tag "$IMAGE_TAGGED_LATEST" \
   --platform "linux/amd64"

--- a/apps/utils/locust_tests/pyproject.toml
+++ b/apps/utils/locust_tests/pyproject.toml
@@ -8,6 +8,11 @@ line-length = 100
 profile = "isort"
 
 [tool.pyright]
+typeCheckingMode = "strict"
+# Compromising between practicality and strictness here by enabling strict type checking and 
+# selectively disabling rules that are, realistically, not possible to fully resolve in a project
+# using boto3 and Locust
+# TODO: In the future, consider enabling some of these where possible to take full advantage of Pyright
 reportUnknownMemberType = false
 reportUnknownVariableType = false
 reportUnknownArgumentType = false

--- a/apps/utils/locust_tests/pyproject.toml
+++ b/apps/utils/locust_tests/pyproject.toml
@@ -15,3 +15,4 @@ reportUnknownParameterType = false
 reportMissingTypeArgument = false
 reportMissingParameterType = false
 reportConstantRedefinition = false
+reportMissingTypeStubs = false

--- a/apps/utils/locust_tests/pyproject.toml
+++ b/apps/utils/locust_tests/pyproject.toml
@@ -6,3 +6,12 @@ line-length = 100
 
 [tool.isort]
 profile = "isort"
+
+[tool.pyright]
+reportUnknownMemberType = false
+reportUnknownVariableType = false
+reportUnknownArgumentType = false
+reportUnknownParameterType = false
+reportMissingTypeArgument = false
+reportMissingParameterType = false
+reportConstantRedefinition = false


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BFD-2746](https://jira.cms.gov/browse/BFD-2746)

**User Story or Bug Summary:**

<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->

As a BFD Engineer I want the Regression Suite to exercise the BFD Server as fully as possible in order to test for regressions in both performance and behavior

---

### What Does This PR Do?

<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

This PR adds the PACA smoke tests to the existing Regression Suite Lambda such that they will run immediately after the existing Regression Suite during deployment and so the outcome of the smoketest will influence the result of the corresponding deployment stage.

These smoke tests differ from the existing Regression Suite in that they use random, non-synthetic data and thus do not have consistent performance characteristics from environment-to-environment or run-to-run; thus, statistics from these smoke tests are _not_ collected as part of our existing Regression Suite performance baseleine. Only the final validation result is considered with respect to the PACA smoketests, and validation fails if there are _any_ failing test cases. These tests will _always_ run with the same static configuration of 10 synthetic users for 10 seconds.

It is expected that a more comprehensive set of PACA endpoint tests will be _merged_ with the existing Regression Suite when BFD-2490 is complete. This is currently blocked until a consistent set of synthetic data is available to test against, as _performance_ regression testing requires such data.

In addition to adding the smoke tests to the Regression Suite Lambda, several code improvements have been made:

1. The entrypoint for stats-related operations, in `bfd_user_base.py`, has been refactored such that the code's behavior is more obvious with respect to failure cases and conditional logic
2. The cases where the Locust process exits with error code `1` have been made much more obvious and have been centralized to `bfd_user_base.py`
3. Multiple type hinting errors and linting errors have been corrected
4. Pylance/Pyright's `strict` type-checking mode has been enabled with some rules explicitly disabled to compromise between safety and practicality (as several of the libraries used do not export proper types, or encourage "best practices" that trigger some rules)
5. Multiple errors with respect to the Regression Suite Lambda Docker image's build process have been corrected:
   1. The `Dockerfile.dockerignore` is now actually respected
   2. Authentication errors with Amazon's Public ECR have been corrected when using `build-push.sh`
   3. Unnecessary image tag pushes have been minimized

This PR has been tested by building a new image and applying it to `test`'s Regression Suite Lambda and verifying that, when run, the Lambda runs both the Regression Suite and PACA smoketests.

### What Should Reviewers Watch For?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:

<!-- Add some items to the following list here -->

- Verify all PR security questions and checklists have been completed and addressed.

### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

- If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

  - Does this PR add any new software dependencies?
    - [ ] Yes
    - [x] No
  - Does this PR modify or invalidate any of our security controls?
    - [ ] Yes
    - [x] No
  - Does this PR store or transmit data that was not stored or transmitted before?
    - [ ] Yes
    - [x] No

- If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
  - Do you think this PR requires additional review of its security implications for other reasons?
    - [ ] Yes
    - [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

- N/A

### Submitter Checklist

<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

- [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
- [x] This PR is reasonably limited in scope, to help ensure that:
  1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
  2. There isn't too much of a burden on reviewers.
  3. Any problems it causes have a small "blast radius".
  4. It'll be easier to rollback if that becomes necessary.
- [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
- [x] The data dictionary has been updated with any field mapping changes, if any were made.
- [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
- [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
- [x] Reviews are requested from both:
  - At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
  - Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
- [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
  - Please review the standards every few months to ensure you're familiar with them.
