### PR TITLE
PACA-1000: message errors cleanup feature

### DIFF
--- a/apps/bfd-model/bfd-model-rda/src/main/java/gov/cms/bfd/model/rda/MessageError.java
+++ b/apps/bfd-model/bfd-model-rda/src/main/java/gov/cms/bfd/model/rda/MessageError.java
@@ -8,8 +8,6 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.Id;
 import javax.persistence.IdClass;
-import javax.persistence.PrePersist;
-import javax.persistence.PreUpdate;
 import javax.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -78,32 +76,36 @@ public class MessageError {
   @Column(name = "message", nullable = false, columnDefinition = "jsonb")
   private String message;
 
+  /** The status of this record. */
   @Enumerated(EnumType.STRING)
   @Column(name = "status", length = 20, nullable = false)
   private Status status;
 
-  /** Hibernate used method to set certain values only on insert */
-  @PrePersist
-  protected void onCreate() {
-    createdDate = Instant.now();
-    updatedDate = Instant.now();
-  }
-
-  /** Hibernate used method to update certain values only on updates */
-  @PreUpdate
-  protected void onUpdate() {
-    updatedDate = Instant.now();
-  }
-
+  /** Possible values for {@link #claimType}. */
   public enum ClaimType {
+    /** A FISS claim. * */
     FISS,
+    /** A MCS claim. * */
     MCS
   }
 
+  /** Possible values for {@link #status}. */
   public enum Status {
+    /** Starting state for new errors. */
     UNRESOLVED,
+    /** The error has been corrected. */
     RESOLVED,
+    /** This sequence number is no longer available in RDA API. */
     OBSOLETE
+  }
+
+  /**
+   * Gets a primary key object for this record.
+   *
+   * @return the {@link PK}
+   */
+  public PK getPK() {
+    return new PK(sequenceNumber, claimType);
   }
 
   /** PK class for the MessageError table */

--- a/apps/bfd-model/bfd-model-rda/src/main/java/gov/cms/bfd/model/rda/MessageError.java
+++ b/apps/bfd-model/bfd-model-rda/src/main/java/gov/cms/bfd/model/rda/MessageError.java
@@ -22,7 +22,7 @@ import lombok.experimental.FieldNameConstants;
 @Entity
 @Getter
 @Setter
-@Builder
+@Builder(toBuilder = true)
 @AllArgsConstructor
 @NoArgsConstructor
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)

--- a/apps/bfd-pipeline/bfd-pipeline-app/src/main/java/gov/cms/bfd/pipeline/app/AppConfiguration.java
+++ b/apps/bfd-pipeline/bfd-pipeline-app/src/main/java/gov/cms/bfd/pipeline/app/AppConfiguration.java
@@ -4,6 +4,7 @@ import com.amazonaws.AmazonClientException;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.regions.Regions;
 import com.google.common.annotations.VisibleForTesting;
+import gov.cms.bfd.model.rda.MessageError;
 import gov.cms.bfd.model.rif.RifFileType;
 import gov.cms.bfd.model.rif.RifRecordEvent;
 import gov.cms.bfd.pipeline.ccw.rif.CcwRifLoadOptions;
@@ -221,6 +222,12 @@ public final class AppConfiguration extends BaseAppConfiguration implements Seri
    * error without causing the job to stop processing prematurely.
    */
   public static final String ENV_VAR_KEY_RDA_JOB_ERROR_LIMIT = "RDA_JOB_ERROR_LIMIT";
+
+  /**
+   * The name of the environment variable that should be used to indicate the maximum number of days
+   * that processed records can remain in the {@link MessageError} table.
+   */
+  public static final String ENV_VAR_KEY_RDA_JOB_ERROR_EXPIRE_DAYS = "RDA_JOB_ERROR_EXPIRE_DAYS";
 
   /**
    * The name of the environment variable that should be used to provide the {@link
@@ -624,6 +631,8 @@ public final class AppConfiguration extends BaseAppConfiguration implements Seri
             .authenticationToken(
                 readEnvStringOptional(ENV_VAR_KEY_RDA_GRPC_AUTH_TOKEN)
                     .orElse(DEFAULT_RDA_GRPC_AUTH_TOKEN))
+            .messageErrorExpirationDays(
+                readEnvIntOptional(ENV_VAR_KEY_RDA_JOB_ERROR_EXPIRE_DAYS).orElse(null))
             .build();
     final RdaServerJob.Config.ConfigBuilder mockServerConfig = RdaServerJob.Config.builder();
     mockServerConfig.serverMode(

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/RdaLoadOptions.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/RdaLoadOptions.java
@@ -16,6 +16,7 @@ import gov.cms.bfd.pipeline.rda.grpc.source.RdaSourceConfig;
 import gov.cms.bfd.pipeline.rda.grpc.source.StandardGrpcRdaSource;
 import gov.cms.bfd.pipeline.sharedutils.IdHasher;
 import gov.cms.bfd.pipeline.sharedutils.PipelineApplicationState;
+import gov.cms.bfd.pipeline.sharedutils.TransactionManager;
 import gov.cms.bfd.sharedutils.interfaces.ThrowingFunction;
 import gov.cms.mpsm.rda.v1.FissClaimChange;
 import gov.cms.mpsm.rda.v1.McsClaimChange;
@@ -128,7 +129,7 @@ public class RdaLoadOptions implements Serializable {
       preJobTaskFactory =
           () ->
               new DLQGrpcRdaSource<>(
-                  appState.getEntityManagerFactory().createEntityManager(),
+                  new TransactionManager(appState.getEntityManagerFactory()),
                   (seqNumber, fissClaimChange) -> seqNumber == fissClaimChange.getSeq(),
                   rdaSourceConfig,
                   new FissClaimStreamCaller(),
@@ -203,7 +204,7 @@ public class RdaLoadOptions implements Serializable {
       preJobTaskFactory =
           () ->
               new DLQGrpcRdaSource<>(
-                  appState.getEntityManagerFactory().createEntityManager(),
+                  new TransactionManager(appState.getEntityManagerFactory()),
                   (seqNumber, mcsClaimChange) -> seqNumber == mcsClaimChange.getSeq(),
                   rdaSourceConfig,
                   new McsClaimStreamCaller(),

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/sink/direct/FissClaimRdaSink.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/sink/direct/FissClaimRdaSink.java
@@ -122,6 +122,8 @@ public class FissClaimRdaSink extends AbstractClaimRdaSink<FissClaimChange, RdaF
         .errors(AbstractJsonConverter.convertObjectToJsonString(errors))
         .message(protobufObjectWriter.print(change))
         .status(MessageError.Status.UNRESOLVED)
+        .createdDate(clock.instant())
+        .updatedDate(clock.instant())
         .build();
   }
 }

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/sink/direct/McsClaimRdaSink.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/sink/direct/McsClaimRdaSink.java
@@ -109,6 +109,8 @@ public class McsClaimRdaSink extends AbstractClaimRdaSink<McsClaimChange, RdaMcs
         .errors(AbstractJsonConverter.convertObjectToJsonString(errors))
         .message(protobufObjectWriter.print(change))
         .status(MessageError.Status.UNRESOLVED)
+        .createdDate(clock.instant())
+        .updatedDate(clock.instant())
         .build();
   }
 }

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/source/DLQDao.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/source/DLQDao.java
@@ -1,0 +1,160 @@
+package gov.cms.bfd.pipeline.rda.grpc.source;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import gov.cms.bfd.model.rda.MessageError;
+import gov.cms.bfd.pipeline.sharedutils.TransactionManager;
+import java.time.Clock;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+/** Utility Data Access Object (DAO) class for the {@link MessageError} entity. */
+@VisibleForTesting
+@RequiredArgsConstructor
+class DLQDao implements AutoCloseable {
+
+  /** Used for time calculation. */
+  private final Clock clock;
+
+  /** Used to execute transactions. */
+  private final TransactionManager transactionManager;
+
+  /**
+   * Finds all message errors with the matching claim type and status.
+   *
+   * @param claimType the claim type to match
+   * @param status the status to match
+   * @return the list of errors that match the conditions
+   */
+  public List<MessageError> findAllMessageErrorsByClaimTypeAndStatus(
+      MessageError.ClaimType claimType, MessageError.Status status) {
+    return transactionManager.executeFunction(
+        entityManager ->
+            entityManager
+                .createQuery(
+                    "select error from MessageError error"
+                        + " where error.claimType = :claimType"
+                        + " and error.status = :status",
+                    MessageError.class)
+                .setParameter("claimType", claimType)
+                .setParameter("status", status)
+                .getResultList());
+  }
+
+  /**
+   * Updates the message error status for the entry with the specified sequence number and type.
+   *
+   * @param sequenceNumber the sequence number to check for
+   * @param type the type to check for
+   * @param status the status to update with
+   * @return the number of entities affected by the update
+   */
+  public long updateState(
+      Long sequenceNumber, MessageError.ClaimType type, MessageError.Status status) {
+    return transactionManager.executeFunction(
+        entityManager -> {
+          long entitiesAffected = 0L;
+
+          MessageError messageError =
+              entityManager.find(MessageError.class, new MessageError.PK(sequenceNumber, type));
+
+          if (messageError != null) {
+            messageError.setStatus(status);
+            messageError.setUpdatedDate(clock.instant());
+            entityManager.merge(messageError);
+            entitiesAffected = 1L;
+          }
+
+          return entitiesAffected;
+        });
+  }
+
+  /**
+   * Deletes any unprocessed message errors with the given type that have not been updated within
+   * the given number of days. Unprocessed means having a status other than {@link
+   * MessageError.Status#UNRESOLVED}.
+   *
+   * @param maxAgeDays max days since last update to retain in database
+   * @param claimType type of claims to delete
+   * @return number of records deleted
+   */
+  public int deleteExpiredMessageErrors(int maxAgeDays, MessageError.ClaimType claimType) {
+    return transactionManager.executeFunction(
+        entityManager ->
+            entityManager
+                .createQuery(
+                    "delete from MessageError error"
+                        + " where error.claimType = :claimType"
+                        + " and error.status <> :keepStatus"
+                        + " and error.updatedDate < :minKeepDate")
+                .setParameter("claimType", claimType)
+                .setParameter("keepStatus", MessageError.Status.UNRESOLVED)
+                .setParameter("minKeepDate", clock.instant().minus(maxAgeDays, ChronoUnit.DAYS))
+                .executeUpdate());
+  }
+
+  /**
+   * Helper method to find a particular record in a test.
+   *
+   * @param sequenceNumber desired sequence number
+   * @param claimType desired claim type
+   * @return {@link Optional} holding matching record if present
+   */
+  @VisibleForTesting
+  Optional<MessageError> readRecord(long sequenceNumber, MessageError.ClaimType claimType) {
+    return transactionManager.executeFunction(
+        entityManager ->
+            Optional.ofNullable(
+                entityManager.find(
+                    MessageError.class, new MessageError.PK(sequenceNumber, claimType))));
+  }
+
+  /**
+   * Helper method to insert records during a test.
+   *
+   * @param records the records to insert
+   */
+  @VisibleForTesting
+  void insertMessageErrors(List<MessageError> records) {
+    transactionManager.executeProcedure(em -> records.forEach(em::persist));
+  }
+
+  /**
+   * Helper method to read all records during a test.
+   *
+   * @return the records
+   */
+  @VisibleForTesting
+  List<MessageError> readAllMessageErrors() {
+    return transactionManager.executeFunction(
+        em ->
+            em.createQuery("select error from MessageError error", MessageError.class)
+                .getResultList());
+  }
+
+  /**
+   * Helper method to clear the table at end of a test.
+   *
+   * @return number of records deleted
+   */
+  @VisibleForTesting
+  @CanIgnoreReturnValue
+  int deleteAllMessageErrors() {
+    return transactionManager.executeFunction(
+        em -> em.createQuery("delete from MessageError error").executeUpdate());
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Closes our transaction manager.
+   *
+   * @throws Exception pass through
+   */
+  @Override
+  public void close() throws Exception {
+    transactionManager.close();
+  }
+}

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/source/RdaSourceConfig.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/source/RdaSourceConfig.java
@@ -179,6 +179,15 @@ public class RdaSourceConfig implements Serializable {
   }
 
   /**
+   * The maximum number of days to retain records in the DLQ after they have been processed.
+   *
+   * @return max age for processed records
+   */
+  public int getMessageErrorExpirationDays() {
+    return 100;
+  }
+
+  /**
    * Creates a remove channel builder.
    *
    * @return the channel builder

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/DLQDaoIT.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/DLQDaoIT.java
@@ -74,8 +74,9 @@ public class DLQDaoIT {
                   allRecords, dao.readAllMessageErrors(), ComparatorForSorting);
             } finally {
               // clean up database and ensure we deleted everything
-              dao.deleteAllMessageErrors();
+              var deletedCount = dao.deleteMessageErrors(allRecords);
               assertTrue(dao.readAllMessageErrors().isEmpty());
+              assertEquals(allRecords.size(), deletedCount);
             }
           }
         });
@@ -116,7 +117,7 @@ public class DLQDaoIT {
               noMatches = dao.findAllMessageErrorsByClaimTypeAndStatus(ignoredClaimType, OBSOLETE);
               assertTrue(noMatches.isEmpty());
             } finally {
-              dao.deleteAllMessageErrors();
+              dao.deleteMessageErrors(allRecordsBefore);
             }
           }
         });
@@ -172,7 +173,7 @@ public class DLQDaoIT {
               assertContentsHaveSamePropertyValues(
                   allRecordsAfter, remainingRecords, ComparatorForSorting);
             } finally {
-              dao.deleteAllMessageErrors();
+              dao.deleteMessageErrors(allRecordsBefore);
             }
           }
         });
@@ -231,7 +232,7 @@ public class DLQDaoIT {
               assertContentsHaveSamePropertyValues(
                   allRecordsAfter, remainingRecords, ComparatorForSorting);
             } finally {
-              dao.deleteAllMessageErrors();
+              dao.deleteMessageErrors(allRecordsBefore);
             }
           }
         });

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/DLQDaoIT.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/DLQDaoIT.java
@@ -1,0 +1,223 @@
+package gov.cms.bfd.pipeline.rda.grpc.source;
+
+import static gov.cms.bfd.model.rda.MessageError.Status.OBSOLETE;
+import static gov.cms.bfd.model.rda.MessageError.Status.RESOLVED;
+import static gov.cms.bfd.model.rda.MessageError.Status.UNRESOLVED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import gov.cms.bfd.model.rda.MessageError;
+import gov.cms.bfd.pipeline.rda.grpc.RdaPipelineTestUtils;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+/** Integration tests for {@link DLQDaoIT}. */
+public class DLQDaoIT {
+  /** Fixed clock for predictable times. */
+  private final Clock clock = Clock.fixed(Instant.now(), ZoneId.systemDefault());
+  /** Expected type for all tests. */
+  private final MessageError.ClaimType claimType = MessageError.ClaimType.FISS;
+  /** Non-expected type for all tests. */
+  private final MessageError.ClaimType ignoredClaimType = MessageError.ClaimType.MCS;
+  /** Expiration age in days for deleting expired records. */
+  private final int maxAgeDays = 100;
+  /** Precomputed value for threshold of record expiration. */
+  private final Instant oldestUpdateDateToKeep = clock.instant().minus(maxAgeDays, ChronoUnit.DAYS);
+
+  /** Verifies that records are correctly found by type and status. */
+  @Test
+  void testFindAllMessageErrorsByClaimTypeAndStatus() throws Exception {
+    long seqNo = 0;
+    final var match1 = createRecord(++seqNo, claimType, UNRESOLVED, -1);
+    final var match2 = createRecord(++seqNo, claimType, UNRESOLVED, -1);
+    final var typeMismatch = createRecord(++seqNo, ignoredClaimType, UNRESOLVED, -1);
+    final var statusMismatch = createRecord(++seqNo, claimType, OBSOLETE, -1);
+
+    final var allRecordsBefore = List.of(match1, typeMismatch, statusMismatch, match2);
+    final var expectedMatches = List.of(match1, match2);
+
+    RdaPipelineTestUtils.runTestWithTemporaryDb(
+        DLQDaoIT.class,
+        clock,
+        (appState, transactionManager) -> {
+          try (var dao = new DLQDao(clock, transactionManager)) {
+            try {
+              dao.insertMessageErrors(allRecordsBefore);
+
+              // we know there should be some matching records
+              final var actualMatches =
+                  dao.findAllMessageErrorsByClaimTypeAndStatus(claimType, UNRESOLVED);
+              assertEquals(createKeysSet(expectedMatches), createKeysSet(actualMatches));
+
+              // we did not insert anything matching this combination
+              var noMatches = dao.findAllMessageErrorsByClaimTypeAndStatus(claimType, RESOLVED);
+              assertTrue(noMatches.isEmpty());
+
+              // we did not insert anything matching this combination
+              noMatches = dao.findAllMessageErrorsByClaimTypeAndStatus(ignoredClaimType, OBSOLETE);
+              assertTrue(noMatches.isEmpty());
+            } finally {
+              dao.deleteAllMessageErrors();
+            }
+          }
+        });
+  }
+
+  /**
+   * Verifies that only the intended record is updated.
+   *
+   * @throws Exception pass through
+   */
+  @Test
+  void testUpdateState() throws Exception {
+    final var recordToUpdate = createRecord(1, claimType, UNRESOLVED, 1);
+    final var sameSeqNoWrongTypeRecord = createRecord(1, ignoredClaimType, UNRESOLVED, 1);
+    final var wrongSeqSameTypeRecord = createRecord(2, claimType, UNRESOLVED, 1);
+    final var allRecordsBefore =
+        List.of(recordToUpdate, sameSeqNoWrongTypeRecord, wrongSeqSameTypeRecord);
+
+    RdaPipelineTestUtils.runTestWithTemporaryDb(
+        DLQDaoIT.class,
+        clock,
+        (appState, transactionManager) -> {
+          try (var dao = new DLQDao(clock, transactionManager)) {
+            try {
+              dao.insertMessageErrors(allRecordsBefore);
+
+              // verify it's safe to call when there are no matching records
+              final var notFoundCount = dao.updateState(42L, claimType, OBSOLETE);
+              assertEquals(0, notFoundCount);
+
+              // correctly updates the intended record when it exists inthe database
+              final var updatedCount = dao.updateState(1L, claimType, RESOLVED);
+              final var modifiedRecord = dao.readRecord(1L, claimType);
+              final var remainingRecords = dao.readAllMessageErrors();
+              assertEquals(1, updatedCount);
+              assertTrue(modifiedRecord.isPresent());
+              modifiedRecord.ifPresent(
+                  rec -> {
+                    // sanity check, it is the right record right?
+                    assertEquals(1L, rec.getSequenceNumber());
+                    // status should be changed as expected
+                    assertEquals(RESOLVED, rec.getStatus());
+                    // the created date should be unchanged
+                    assertEquals(recordToUpdate.getCreatedDate(), rec.getCreatedDate());
+                    // the update date should have been updated
+                    assertEquals(clock.instant(), rec.getUpdatedDate());
+                  });
+              assertTrue(remainingRecords.contains(wrongSeqSameTypeRecord));
+              assertTrue(remainingRecords.contains(sameSeqNoWrongTypeRecord));
+            } finally {
+              dao.deleteAllMessageErrors();
+            }
+          }
+        });
+  }
+
+  /**
+   * Verifies that only expired records of the correct type and status are deleted.
+   *
+   * @throws Exception pass through
+   */
+  @Test
+  void testDeleteExpiredMessageErrors() throws Exception {
+    long seqNo = 0;
+    // should be deleted because of age and status
+    final var expiredObsolete = createRecord(++seqNo, claimType, OBSOLETE, -1);
+    final var expiredResolved = createRecord(++seqNo, claimType, RESOLVED, -1);
+    // should not be deleted because of status
+    final var expiredUnresolved = createRecord(++seqNo, claimType, UNRESOLVED, -1);
+    // should not be deleted because of claim type
+    final var expiredWrongClaimType = createRecord(++seqNo, ignoredClaimType, OBSOLETE, -100);
+    // should not be deleted because of age
+    final var validObsolete = createRecord(++seqNo, claimType, OBSOLETE, 1);
+    final var validResolved = createRecord(++seqNo, claimType, RESOLVED, 1);
+    final var validUnresolved = createRecord(++seqNo, claimType, UNRESOLVED, 1);
+
+    final var allRecordsBefore =
+        List.of(
+            expiredObsolete,
+            expiredResolved,
+            expiredUnresolved,
+            expiredWrongClaimType,
+            validObsolete,
+            validResolved,
+            validUnresolved);
+
+    final var allRecordsAfter =
+        List.of(
+            expiredUnresolved,
+            expiredWrongClaimType,
+            validObsolete,
+            validResolved,
+            validUnresolved);
+
+    RdaPipelineTestUtils.runTestWithTemporaryDb(
+        DLQDaoIT.class,
+        clock,
+        (appState, transactionManager) -> {
+          try (var dao = new DLQDao(clock, transactionManager)) {
+            try {
+              dao.insertMessageErrors(allRecordsBefore);
+              final var deletedCount = dao.deleteExpiredMessageErrors(maxAgeDays, claimType);
+              final var remainingRecords = dao.readAllMessageErrors();
+              // verify we deleted as many records as expected
+              assertEquals(2, deletedCount);
+              // verify only the expected records remain in the database
+              assertEquals(createKeysSet(allRecordsAfter), createKeysSet(remainingRecords));
+            } finally {
+              dao.deleteAllMessageErrors();
+            }
+          }
+        });
+  }
+
+  /**
+   * Creates a suitable record for testing expired record deletion.
+   *
+   * @param sequenceNumber the sequence number
+   * @param claimType the claim type
+   * @param status the claim status
+   * @param ageDeltaSeconds used to compute update date
+   * @return the record
+   */
+  private MessageError createRecord(
+      long sequenceNumber,
+      MessageError.ClaimType claimType,
+      MessageError.Status status,
+      long ageDeltaSeconds) {
+    final var claimId = status.name().toLowerCase() + "-" + sequenceNumber;
+    // All dates are relative to the expiration date threshold.
+    final var updatedDate = oldestUpdateDateToKeep.plusSeconds(ageDeltaSeconds);
+    // Using an older createdDate ensures only the updatedDate is being used for queries.
+    final var createdDate = updatedDate.minus(1, ChronoUnit.DAYS);
+    return MessageError.builder()
+        .apiSource("test")
+        .claimType(claimType)
+        .updatedDate(updatedDate)
+        .createdDate(createdDate)
+        .sequenceNumber(sequenceNumber)
+        .claimId(claimId)
+        .status(status)
+        .errors("")
+        .message("")
+        .build();
+  }
+
+  /**
+   * Turn a list of {@link MessageError} objects into a {@link Set} containing just their primary
+   * keys. Used for existence checks to ensure database contains an exact set of records.
+   *
+   * @param records records to convert to keys
+   * @return the converted keys
+   */
+  private Set<MessageError.PK> createKeysSet(List<MessageError> records) {
+    return records.stream().map(MessageError::getPK).collect(Collectors.toUnmodifiableSet());
+  }
+}

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/DLQGrpcRdaSourceTest.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/DLQGrpcRdaSourceTest.java
@@ -20,6 +20,7 @@ import com.codahale.metrics.MetricRegistry;
 import gov.cms.bfd.model.rda.MessageError;
 import gov.cms.bfd.pipeline.rda.grpc.ProcessingException;
 import gov.cms.bfd.pipeline.rda.grpc.RdaSink;
+import gov.cms.bfd.pipeline.sharedutils.TransactionManager;
 import io.grpc.CallOptions;
 import io.grpc.ManagedChannel;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -29,7 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import javax.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -47,8 +47,8 @@ public class DLQGrpcRdaSourceTest {
   /** Mock {@link RdaSink} to use in testing. */
   @Mock private RdaSink<Long, Long> mockSink;
 
-  /** Mock {@link EntityManager} to use in testing. */
-  @Mock private EntityManager mockManager;
+  /** Mock {@link TransactionManager} to use in testing. */
+  @Mock private TransactionManager mockManager;
 
   /** Mock {@link ManagedChannel} to use in testing. */
   @Mock private ManagedChannel mockChannel;

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/DLQGrpcRdaSourceTest.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/DLQGrpcRdaSourceTest.java
@@ -29,6 +29,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -77,7 +78,10 @@ public class DLQGrpcRdaSourceTest {
     meters = new SimpleMeterRegistry();
     lenient().doReturn(false).when(rdaVersion).allows(anyString());
     lenient().doReturn(true).when(rdaVersion).allows(TEST_RDA_VERSION);
-    lenient().doReturn(MAX_DQL_AGE_DAYS).when(mockConfig).getMessageErrorExpirationDays();
+    lenient()
+        .doReturn(Optional.of(MAX_DQL_AGE_DAYS))
+        .when(mockConfig)
+        .getMessageErrorExpirationDays();
     lenient().doReturn(mockChannel).when(mockConfig).createChannel();
   }
 
@@ -177,12 +181,12 @@ public class DLQGrpcRdaSourceTest {
             meters,
             claimType,
             rdaVersion,
-            MAX_DQL_AGE_DAYS,
+            Optional.of(MAX_DQL_AGE_DAYS),
             mockDao);
     doReturn(18)
         .when(mockDao)
         .deleteExpiredMessageErrors(MAX_DQL_AGE_DAYS, MessageError.ClaimType.FISS);
-    assertEquals(18, source.deleteExpiredDlqRecords(MessageError.ClaimType.FISS));
+    assertEquals(18, source.deleteExpiredDlqRecords(MAX_DQL_AGE_DAYS, MessageError.ClaimType.FISS));
   }
 
   /**
@@ -202,12 +206,12 @@ public class DLQGrpcRdaSourceTest {
             meters,
             claimType,
             rdaVersion,
-            MAX_DQL_AGE_DAYS,
+            Optional.of(MAX_DQL_AGE_DAYS),
             mockDao);
     doThrow(new RuntimeException("can't stop me!"))
         .when(mockDao)
         .deleteExpiredMessageErrors(MAX_DQL_AGE_DAYS, MessageError.ClaimType.FISS);
-    assertEquals(0, source.deleteExpiredDlqRecords(MessageError.ClaimType.FISS));
+    assertEquals(0, source.deleteExpiredDlqRecords(MAX_DQL_AGE_DAYS, MessageError.ClaimType.FISS));
   }
 
   /** Checks that the logic lambda was successfully and correctly invoked for MCS claims. */

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/DLQGrpcRdaSourceTest.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/DLQGrpcRdaSourceTest.java
@@ -59,8 +59,8 @@ public class DLQGrpcRdaSourceTest {
   /** Mock {@link GrpcStreamCaller} to use in testing. */
   @Mock private GrpcStreamCaller<Long> mockCaller;
 
-  /** Mock {@link DLQGrpcRdaSource.DLQDao} to use in testing. */
-  @Mock private DLQGrpcRdaSource.DLQDao mockDao;
+  /** Mock {@link DLQDao} to use in testing. */
+  @Mock private DLQDao mockDao;
 
   /** Mock {@link RdaVersion} to use in testing. */
   @Mock private RdaVersion rdaVersion;

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/TransformerTestUtils.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/TransformerTestUtils.java
@@ -1,14 +1,14 @@
 package gov.cms.bfd.pipeline.rda.grpc.source;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.samePropertyValuesAs;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Collection;
 import java.util.Comparator;
-import java.util.List;
 import java.util.Set;
 import java.util.function.ToIntFunction;
 import java.util.stream.Collectors;
+import org.hamcrest.beans.SamePropertyValuesAs;
 
 /** Utility class for assertions related to transformations. */
 public class TransformerTestUtils {
@@ -23,13 +23,39 @@ public class TransformerTestUtils {
    */
   public static <T> void assertListContentsHaveSamePropertyValues(
       Set<T> expectedSet, Set<T> actualSet, ToIntFunction<T> priority) {
-    List<T> expected =
-        expectedSet.stream().sorted(Comparator.comparingInt(priority)).collect(Collectors.toList());
-    List<T> actual =
-        actualSet.stream().sorted(Comparator.comparingInt(priority)).collect(Collectors.toList());
+    assertContentsHaveSamePropertyValues(expectedSet, actualSet, Comparator.comparingInt(priority));
+  }
+
+  /**
+   * Compare two collections of objects using reflection and report any mismatched properties. Both
+   * collections must have the same size and be sortable using the comparator. The comparator only
+   * needs to compare enough fields to uniquely identify an object for purposes of comparison (e.g.
+   * using primary key for a database entity).
+   *
+   * @param expected expected values
+   * @param actual values to be compared to expected values
+   * @param comparatorForSort used to sort values prior to comparison
+   * @param <T> type of beans being compared
+   */
+  public static <T> void assertContentsHaveSamePropertyValues(
+      Collection<T> expected, Collection<T> actual, Comparator<T> comparatorForSort) {
     assertEquals(expected.size(), actual.size());
-    for (int i = 0; i < expected.size(); ++i) {
-      assertThat(actual.get(i), samePropertyValuesAs(expected.get(i)));
+    final var expectedList =
+        expected.stream().sorted(comparatorForSort).collect(Collectors.toList());
+    final var actualList = actual.stream().sorted(comparatorForSort).collect(Collectors.toList());
+    for (int i = 0; i < expectedList.size(); ++i) {
+      assertObjectsHaveSamePropertyValues(expectedList.get(i), actualList.get(i));
     }
+  }
+
+  /**
+   * Compare two objects using reflection.
+   *
+   * @param expected expected value
+   * @param actual value to be compared to expected value
+   * @param <T> type of beans being compared
+   */
+  public static <T> void assertObjectsHaveSamePropertyValues(T expected, T actual) {
+    assertThat(actual, SamePropertyValuesAs.samePropertyValuesAs(expected));
   }
 }


### PR DESCRIPTION
**JIRA Ticket:**
[PACA-1000](https://jira.cms.gov/browse/PACA-1000)

**User Story or Bug Summary:**

Manage the growth of the rda.message_errors table by deleting records once they are no longer required.  Allow the parameters used to determine what records should be deleted to be configurable.


---

### What Does This PR Do?

- Moves `DLQDao` class to the top level for cleaner testing.
- Adds integration tests for `DLQDao`
- Adds cleanup method to `DLQDao`
- Adds `RDA_JOB_ERROR_EXPIRE_DAYS` environment variable to configure cleanup.  Defaults to no cleanup being done if env var is not present in environment.
- Adds cleanup logic to `DLQGrpcRdaSource`.  Cleanup takes place before the regular DLQ resolution code is started.

Note: Any exceptions thrown during cleanup are logged but do not halt regular DLQ processing logic.

Some other minor changes:

- `DLQGrpcRdaSource` uses `TransactionManager`
- Removed the magic methods that set the created and update dates from `MessageError` because they made the new feature untestable.
- Enabled Lombok generated `toBuilder()` method in `MessageError` so that modified copies of objects can be easily created for use in testing.
- Added more reflection based assert equals methods to `TransformerTestUtils`.

### What Should Reviewers Watch For?

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items to the following list here -->
* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [x] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [x] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [x] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] The data dictionary has been updated with any field mapping changes, if any were made.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    