### PR TITLE
BFD-2508: Improved Pipeline performance config

### DIFF
--- a/ops/ansible/roles/bfd-pipeline/defaults/main.yml
+++ b/ops/ansible/roles/bfd-pipeline/defaults/main.yml
@@ -11,9 +11,9 @@ data_pipeline_new_relic_metric_host: 'https://gov-metric-api.newrelic.com'
 data_pipeline_new_relic_metric_path: '/metric/v1'
 data_pipeline_ccw_rif_job_enabled: true
 
-data_pipeline_loader_threads: 200
-rif_job_batch_size: 25
-rif_job_queue_size_multiple: 2
+rif_thread_multiple: 3
+rif_job_batch_size: 7
+rif_job_queue_size_multiple: 5
 
 ## RDA API Pipeline
 # Used to download FISS/MCS partially adjudicated claims data.

--- a/ops/ansible/roles/bfd-pipeline/defaults/main.yml
+++ b/ops/ansible/roles/bfd-pipeline/defaults/main.yml
@@ -3,7 +3,6 @@ env_name_std: 'unknown-environment'
 
 data_pipeline_dir: /usr/local/bluebutton-data-pipeline
 data_pipeline_user: bb-etl
-data_pipeline_loader_threads: 200
 data_pipeline_jvm_args: -Xmx64g
 data_pipeline_tmp_dir: /tmp
 data_pipeline_idempotency_required: true
@@ -11,6 +10,10 @@ data_pipeline_filtering_non_null_and_non_2023_benes: true
 data_pipeline_new_relic_metric_host: 'https://gov-metric-api.newrelic.com'
 data_pipeline_new_relic_metric_path: '/metric/v1'
 data_pipeline_ccw_rif_job_enabled: true
+
+data_pipeline_loader_threads: 200
+rif_job_batch_size: 25
+rif_job_queue_size_multiple: 2
 
 ## RDA API Pipeline
 # Used to download FISS/MCS partially adjudicated claims data.

--- a/ops/ansible/roles/bfd-pipeline/templates/bfd-pipeline-service.sh.j2
+++ b/ops/ansible/roles/bfd-pipeline/templates/bfd-pipeline-service.sh.j2
@@ -8,7 +8,7 @@ export DATABASE_URL='{{ data_pipeline_db_url }}'
 export DATABASE_USERNAME='{{ data_pipeline_db_username }}'
 export DATABASE_PASSWORD='{{ data_pipeline_db_password }}'
 # NOTE: RIF Loader Threads are generally some multiple of available cpus/core, e.g. `$((3 * $(nproc)))`
-export LOADER_THREADS='{{ ansible_processor_vcpus * rif_thread_multiple }}'
+export LOADER_THREADS='{{ ansible_processor_vcpus * (rif_thread_multiple | int) }}'
 export RIF_JOB_BATCH_SIZE='{{ rif_job_batch_size }}'
 export RIF_JOB_QUEUE_SIZE_MULTIPLE='{{ rif_job_queue_size_multiple }}'
 

--- a/ops/ansible/roles/bfd-pipeline/templates/bfd-pipeline-service.sh.j2
+++ b/ops/ansible/roles/bfd-pipeline/templates/bfd-pipeline-service.sh.j2
@@ -7,8 +7,8 @@ export HICN_HASH_PEPPER='{{ data_pipeline_hicn_hash_pepper }}'
 export DATABASE_URL='{{ data_pipeline_db_url }}'
 export DATABASE_USERNAME='{{ data_pipeline_db_username }}'
 export DATABASE_PASSWORD='{{ data_pipeline_db_password }}'
-
-export LOADER_THREADS='{{ data_pipeline_loader_threads }}'
+# NOTE: RIF Loader Threads are generally some multiple of available cpus/core, e.g. `$((3 * $(nproc)))`
+export LOADER_THREADS='{{ ansible_processor_vcpus * rif_thread_multiple }}'
 export RIF_JOB_BATCH_SIZE='{{ rif_job_batch_size }}'
 export RIF_JOB_QUEUE_SIZE_MULTIPLE='{{ rif_job_queue_size_multiple }}'
 

--- a/ops/ansible/roles/bfd-pipeline/templates/bfd-pipeline-service.sh.j2
+++ b/ops/ansible/roles/bfd-pipeline/templates/bfd-pipeline-service.sh.j2
@@ -7,7 +7,11 @@ export HICN_HASH_PEPPER='{{ data_pipeline_hicn_hash_pepper }}'
 export DATABASE_URL='{{ data_pipeline_db_url }}'
 export DATABASE_USERNAME='{{ data_pipeline_db_username }}'
 export DATABASE_PASSWORD='{{ data_pipeline_db_password }}'
+
 export LOADER_THREADS='{{ data_pipeline_loader_threads }}'
+export RIF_JOB_BATCH_SIZE='{{ rif_job_batch_size }}'
+export RIF_JOB_QUEUE_SIZE_MULTIPLE='{{ rif_job_queue_size_multiple }}'
+
 export IDEMPOTENCY_REQUIRED='{{ data_pipeline_idempotency_required }}'
 export FILTERING_NON_NULL_AND_NON_2023_BENES='{{ data_pipeline_filtering_non_null_and_non_2023_benes }}'
 

--- a/ops/terraform/services/base/values/ephemeral.yaml
+++ b/ops/terraform/services/base/values/ephemeral.yaml
@@ -41,9 +41,10 @@
 /bfd/${env}/pipeline/ccw/nonsensitive/data_pipeline_ccw_rif_job_enabled: false
 /bfd/${env}/pipeline/ccw/nonsensitive/data_pipeline_filtering_non_null_and_non_2023_benes: true
 /bfd/${env}/pipeline/ccw/nonsensitive/data_pipeline_idempotency_required: false
-/bfd/${env}/pipeline/ccw/nonsensitive/rif_job_batch_size: 10
-/bfd/${env}/pipeline/ccw/nonsensitive/rif_job_queue_size_multiple: 3
 /bfd/${env}/pipeline/ccw/nonsensitive/instance_type: m6i.large
+/bfd/${env}/pipeline/ccw/nonsensitive/rif_job_batch_size: 7
+/bfd/${env}/pipeline/ccw/nonsensitive/rif_job_queue_size_multiple: 5
+/bfd/${env}/pipeline/ccw/nonsensitive/rif_thread_multiple: 3
 ## PIPELINE RDA
 /bfd/${env}/pipeline/rda/nonsensitive/data_pipeline_ccw_rif_job_enabled: false # CCW Jobs are disabled by default on RDA Pipelines
 /bfd/${env}/pipeline/rda/nonsensitive/data_pipeline_rda_job_enabled: false

--- a/ops/terraform/services/base/values/ephemeral.yaml
+++ b/ops/terraform/services/base/values/ephemeral.yaml
@@ -41,6 +41,8 @@
 /bfd/${env}/pipeline/ccw/nonsensitive/data_pipeline_ccw_rif_job_enabled: false
 /bfd/${env}/pipeline/ccw/nonsensitive/data_pipeline_filtering_non_null_and_non_2023_benes: true
 /bfd/${env}/pipeline/ccw/nonsensitive/data_pipeline_idempotency_required: false
+/bfd/${env}/pipeline/ccw/nonsensitive/rif_job_batch_size: 10
+/bfd/${env}/pipeline/ccw/nonsensitive/rif_job_queue_size_multiple: 3
 /bfd/${env}/pipeline/ccw/nonsensitive/instance_type: m6i.large
 ## PIPELINE RDA
 /bfd/${env}/pipeline/rda/nonsensitive/data_pipeline_ccw_rif_job_enabled: false # CCW Jobs are disabled by default on RDA Pipelines

--- a/ops/terraform/services/base/values/prod-sbx.yaml
+++ b/ops/terraform/services/base/values/prod-sbx.yaml
@@ -40,6 +40,8 @@
 /bfd/${env}/pipeline/ccw/nonsensitive/data_pipeline_ccw_rif_job_enabled: true
 /bfd/${env}/pipeline/ccw/nonsensitive/data_pipeline_filtering_non_null_and_non_2023_benes: true
 /bfd/${env}/pipeline/ccw/nonsensitive/data_pipeline_idempotency_required: false
+/bfd/${env}/pipeline/ccw/nonsensitive/rif_job_batch_size: 10
+/bfd/${env}/pipeline/ccw/nonsensitive/rif_job_queue_size_multiple: 3
 /bfd/${env}/pipeline/ccw/nonsensitive/instance_type: m6i.large
 ## PIPELINE+RDA
 /bfd/${env}/pipeline/rda/nonsensitive/data_pipeline_ccw_rif_job_enabled: false # CCW Jobs are disabled by default on RDA Pipelines

--- a/ops/terraform/services/base/values/prod-sbx.yaml
+++ b/ops/terraform/services/base/values/prod-sbx.yaml
@@ -40,9 +40,10 @@
 /bfd/${env}/pipeline/ccw/nonsensitive/data_pipeline_ccw_rif_job_enabled: true
 /bfd/${env}/pipeline/ccw/nonsensitive/data_pipeline_filtering_non_null_and_non_2023_benes: true
 /bfd/${env}/pipeline/ccw/nonsensitive/data_pipeline_idempotency_required: false
-/bfd/${env}/pipeline/ccw/nonsensitive/rif_job_batch_size: 10
-/bfd/${env}/pipeline/ccw/nonsensitive/rif_job_queue_size_multiple: 3
 /bfd/${env}/pipeline/ccw/nonsensitive/instance_type: m6i.large
+/bfd/${env}/pipeline/ccw/nonsensitive/rif_job_batch_size: 7
+/bfd/${env}/pipeline/ccw/nonsensitive/rif_job_queue_size_multiple: 5
+/bfd/${env}/pipeline/ccw/nonsensitive/rif_thread_multiple: 3
 ## PIPELINE+RDA
 /bfd/${env}/pipeline/rda/nonsensitive/data_pipeline_ccw_rif_job_enabled: false # CCW Jobs are disabled by default on RDA Pipelines
 /bfd/${env}/pipeline/rda/nonsensitive/data_pipeline_rda_grpc_inproc_server_mode: 'S3'

--- a/ops/terraform/services/base/values/prod.yaml
+++ b/ops/terraform/services/base/values/prod.yaml
@@ -40,6 +40,8 @@
 /bfd/${env}/pipeline/ccw/nonsensitive/data_pipeline_ccw_rif_job_enabled: true
 /bfd/${env}/pipeline/ccw/nonsensitive/data_pipeline_filtering_non_null_and_non_2023_benes: true
 /bfd/${env}/pipeline/ccw/nonsensitive/data_pipeline_idempotency_required: false
+/bfd/${env}/pipeline/ccw/nonsensitive/rif_job_batch_size: 10
+/bfd/${env}/pipeline/ccw/nonsensitive/rif_job_queue_size_multiple: 3
 /bfd/${env}/pipeline/ccw/nonsensitive/instance_type: c6i.4xlarge
 ## PIPELINE+RDA
 /bfd/${env}/pipeline/rda/nonsensitive/data_pipeline_ccw_rif_job_enabled: false # CCW Jobs are disabled by default on RDA Pipelines

--- a/ops/terraform/services/base/values/prod.yaml
+++ b/ops/terraform/services/base/values/prod.yaml
@@ -40,9 +40,10 @@
 /bfd/${env}/pipeline/ccw/nonsensitive/data_pipeline_ccw_rif_job_enabled: true
 /bfd/${env}/pipeline/ccw/nonsensitive/data_pipeline_filtering_non_null_and_non_2023_benes: true
 /bfd/${env}/pipeline/ccw/nonsensitive/data_pipeline_idempotency_required: false
-/bfd/${env}/pipeline/ccw/nonsensitive/rif_job_batch_size: 10
-/bfd/${env}/pipeline/ccw/nonsensitive/rif_job_queue_size_multiple: 3
 /bfd/${env}/pipeline/ccw/nonsensitive/instance_type: c6i.4xlarge
+/bfd/${env}/pipeline/ccw/nonsensitive/rif_job_batch_size: 7
+/bfd/${env}/pipeline/ccw/nonsensitive/rif_job_queue_size_multiple: 5
+/bfd/${env}/pipeline/ccw/nonsensitive/rif_thread_multiple: 3
 ## PIPELINE+RDA
 /bfd/${env}/pipeline/rda/nonsensitive/data_pipeline_ccw_rif_job_enabled: false # CCW Jobs are disabled by default on RDA Pipelines
 /bfd/${env}/pipeline/rda/nonsensitive/data_pipeline_rda_job_enabled: true

--- a/ops/terraform/services/base/values/test.yaml
+++ b/ops/terraform/services/base/values/test.yaml
@@ -40,9 +40,10 @@
 /bfd/${env}/pipeline/ccw/nonsensitive/data_pipeline_ccw_rif_job_enabled: true
 /bfd/${env}/pipeline/ccw/nonsensitive/data_pipeline_filtering_non_null_and_non_2023_benes: true
 /bfd/${env}/pipeline/ccw/nonsensitive/data_pipeline_idempotency_required: false
-/bfd/${env}/pipeline/ccw/nonsensitive/rif_job_batch_size: 10
-/bfd/${env}/pipeline/ccw/nonsensitive/rif_job_queue_size_multiple: 3
 /bfd/${env}/pipeline/ccw/nonsensitive/instance_type: m6i.large
+/bfd/${env}/pipeline/ccw/nonsensitive/rif_job_batch_size: 7
+/bfd/${env}/pipeline/ccw/nonsensitive/rif_job_queue_size_multiple: 5
+/bfd/${env}/pipeline/ccw/nonsensitive/rif_thread_multiple: 3
 ## PIPELINE+RDA
 /bfd/${env}/pipeline/rda/nonsensitive/data_pipeline_ccw_rif_job_enabled: false # CCW Jobs are disabled by default on RDA Pipelines
 /bfd/${env}/pipeline/rda/nonsensitive/data_pipeline_rda_job_enabled: true

--- a/ops/terraform/services/base/values/test.yaml
+++ b/ops/terraform/services/base/values/test.yaml
@@ -40,6 +40,8 @@
 /bfd/${env}/pipeline/ccw/nonsensitive/data_pipeline_ccw_rif_job_enabled: true
 /bfd/${env}/pipeline/ccw/nonsensitive/data_pipeline_filtering_non_null_and_non_2023_benes: true
 /bfd/${env}/pipeline/ccw/nonsensitive/data_pipeline_idempotency_required: false
+/bfd/${env}/pipeline/ccw/nonsensitive/rif_job_batch_size: 10
+/bfd/${env}/pipeline/ccw/nonsensitive/rif_job_queue_size_multiple: 3
 /bfd/${env}/pipeline/ccw/nonsensitive/instance_type: m6i.large
 ## PIPELINE+RDA
 /bfd/${env}/pipeline/rda/nonsensitive/data_pipeline_ccw_rif_job_enabled: false # CCW Jobs are disabled by default on RDA Pipelines

--- a/ops/terraform/services/pipeline/user-data.sh.tftpl
+++ b/ops/terraform/services/pipeline/user-data.sh.tftpl
@@ -38,7 +38,6 @@ cat <<EOF > extra_vars.json
 {
   "data_pipeline_db_url": "${writer_endpoint}",
   "data_pipeline_jvm_args": "-Xms{{ ((ansible_memtotal_mb * 0.80) | int) - 2048 }}m -Xmx{{ ((ansible_memtotal_mb * 0.80) | int) - 2048 }}m -XX:+PreserveFramePointer",
-  "data_pipeline_loader_threads": "{{ ansible_processor_vcpus * 25 }}",
   "data_pipeline_new_relic_app_name": "BFD Pipeline %{ if pipeline_instance == "rda" ~} %{ else ~} ${pipeline_instance} %{ endif ~} ({{ env_name_std }})",
   "data_pipeline_s3_bucket": "${pipeline_bucket}",
   "data_pipeline_tmp_dir": "{{ data_pipeline_dir }}/tmp",


### PR DESCRIPTION
**JIRA Ticket:**
[BFD-2508](https://jira.cms.gov/browse/BFD-2508)

**User Story or Bug Summary:**

Provide updated configuration supporting changes proposed in BFD-2509 _or_ #1664.

---

### What Does This PR Do?

This PR introduces three new bfd-pipeline ansible role configuration fields to support the changes in #1664:
1. `rif_thread_multiple` replaces the `data_pipeline_loader_threads` and multiplies by the number of cpus available
2. `rif_job_batch_size` represents the size of the batch the rif loader will process
3. `rif_job_queue_size_multiple` represents the multiplier for the queue size


Values for these configuration settings were determined through trial and error. Using the smaller, 1.2GB data set in `2023-03-03T12:00:00Z/bene_upd20230310141228.txt`, we arrived to a batch size/queue size/thread count of 7/5/96 for a c6i.8xlarge instance after running more than 20 different scenarios. This was selected as a balance between the performance on the pipeline instance without causing undue burden to the RDS cluster writer node.

#### Results

<details><summary>See the test results below...</summary>

|#| Note                   | batch size | queue size | threads  | idempotent | Instance    | final mean e/s | duration | rds cpu max |
|-|----------------------- |----------- |----------- |--------- |----------- |------------ |--------------- |--------- |------------ |
|0| original default       | 100        | n/a        | 400      | false      | c6i.4xlarge | 669.2          | 54       | n/a         |
|1| baseline (no cache)    | 25         | 2          | 800      | true       | c6i.8xlarge | 3414           | 11       | 57          |
|2| baseline (built cache) | 25         | 2          | 800      | true       | c6i.8xlarge | 3467           | 11       | 36          |
|3| reduced threads        | 25         | 2          | 96       | true       | c6i.8xlarge | 3513           | 10       | 41          |
|4| smaller batch          | 10         | 2          | 96       | true       | c6i.8xlarge | 5683           | 6.5      | 78          |
|5| increased queue        | 10         | 3          | 96       | true       | c6i.8xlarge | 5752           | 6.5      | 63          |
|6| increased queue        | 10         | 4          | 96       | true       | c6i.8xlarge | 5826           |          | 73          |
|7| increased queue        | 10         | 5          | 96       | true       | c6i.8xlarge | 5863           |          | 72          |
|8| increased queue        | 10         | 6          | 96       | true       | c6i.8xlarge | 5833           | 5         |78             |
|9| increased queue        | 10         | 6    | 96     | true       | c6i.8xlarge | 5915               |  5        | 78            | 
|10| reduced threads and increase queue        | 10         | 3    | 64     | true       | c6i.8xlarge | 5474               | 5         | 70            |
|11|  reduced threads and increase queue        | 10         | 4    | 64     | true       | c6i.8xlarge | 5482               | 5         | 68            |
|12|  reduced threads and increase queue        | 10         | 5   | 64     | true       | c6i.8xlarge |  5519              |  5        |  69           |
|13|  reduced threads and increase queue        | 10         | 6   | 64     | true       | c6i.8xlarge | 5553               |    5      |  66           |
|14| reduced threads and decrease queue        | 5         | 3    | 64     | true       | c6i.8xlarge |   5685             |  4.5        |  67          |
|15|  reduced threads and increase queue        | 5         | 4    | 64     | true       | c6i.8xlarge | 5687              | 4.5        |  68           |
|16|  reduced threads and increase queue        | 5        | 5   | 64     | true       | c6i.8xlarge | 5700               |  4.5        |  68           |
|17|  reduced threads and increase queue        | 5         | 6   | 64     | true       | c6i.8xlarge | 5674               |  5        |67             |
|18|  reduced threads and increase queue        | 10         | 10   | 32     | true       | c6i.8xlarge | 3998               | 9        |  43          |
|19|  reduced threads and reduced batch        | 5         | 10   | 32     | true       | c6i.8xlarge | 4011             |9         |  43         |
|20|  increased threads and reduced batch        | 5         | 5   | 96    | true       | c6i.8xlarge | 6661             | 3.5       | 83         |
|21|  increased threads and reduced batch        | 5         | 4   | 96    | true       | c6i.8xlarge |6671           | 3.5       |83          |
|22|  increased threads and reduced batch        | 5         | 5   | 160   | true       | c6i.8xlarge | 6790        | 3.5    | 89         |
|23|  decrease queue                                            | 5         | 3   | 96   | true       | c6i.8xlarge | 6647        | <4    | 83         |
|24|                                              | 9        | 5   | 96   | true       | c6i.8xlarge | 5931  |  <5  | 70       |
|25|                                              | 7        | 5   | 96   | true       | c6i.8xlarge | 6348  |  <5 | 76       |
|26|                                              | 7        | 5   | 96   | true       | c6i.8xlarge | 6459  |  <5 | 77       |

</details>

### What Should Reviewers Watch For?
<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items to the following list here -->
* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [x] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [x] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [x] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [x] No

### What Needs to Be Merged and Deployed Before this PR?

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] The data dictionary has been updated with any field mapping changes, if any were made.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.