### PR TITLE
BFD-2530: Fix "Pipeline SLIs Lambda submits incorrect time delta samples to CloudWatch Metrics"

### DIFF
--- a/ops/terraform/services/pipeline/modules/bfd_pipeline_slis/lambda_src/update_pipeline_slis.py
+++ b/ops/terraform/services/pipeline/modules/bfd_pipeline_slis/lambda_src/update_pipeline_slis.py
@@ -447,7 +447,7 @@ def handler(event: Any, context: Any):
                         metrics=gen_all_dimensioned_metrics(
                             metric_name=PipelineMetric.TIME_DELTA_DATA_LOAD_TIME.metric_name,
                             dimensions=[rif_type_dimension, group_timestamp_dimension],
-                            value=int(load_time_delta.total_seconds()),
+                            value=round(load_time_delta.total_seconds()),
                             timestamp=event_timestamp,
                             unit=PipelineMetric.TIME_DELTA_DATA_LOAD_TIME.unit,
                         ),
@@ -528,7 +528,7 @@ def handler(event: Any, context: Any):
                             metric_name=PipelineMetric.TIME_DELTA_FULL_DATA_LOAD_TIME.metric_name,
                             dimensions=[group_timestamp_dimension],
                             timestamp=event_timestamp,
-                            value=int(full_load_time_delta.total_seconds()),
+                            value=round(full_load_time_delta.total_seconds()),
                             unit=PipelineMetric.TIME_DELTA_FULL_DATA_LOAD_TIME.unit,
                         ),
                     ),

--- a/ops/terraform/services/pipeline/modules/bfd_pipeline_slis/lambda_src/update_pipeline_slis.py
+++ b/ops/terraform/services/pipeline/modules/bfd_pipeline_slis/lambda_src/update_pipeline_slis.py
@@ -8,10 +8,9 @@ from typing import Any, Type
 from urllib.parse import unquote
 
 import boto3
+from backoff_retry import backoff_retry
 from botocore import exceptions as botocore_exceptions
 from botocore.config import Config
-
-from backoff_retry import backoff_retry
 from cw_metrics import (
     MetricDataQuery,
     gen_all_dimensioned_metrics,
@@ -448,7 +447,7 @@ def handler(event: Any, context: Any):
                         metrics=gen_all_dimensioned_metrics(
                             metric_name=PipelineMetric.TIME_DELTA_DATA_LOAD_TIME.metric_name,
                             dimensions=[rif_type_dimension, group_timestamp_dimension],
-                            value=load_time_delta.seconds,
+                            value=int(load_time_delta.total_seconds()),
                             timestamp=event_timestamp,
                             unit=PipelineMetric.TIME_DELTA_DATA_LOAD_TIME.unit,
                         ),
@@ -529,7 +528,7 @@ def handler(event: Any, context: Any):
                             metric_name=PipelineMetric.TIME_DELTA_FULL_DATA_LOAD_TIME.metric_name,
                             dimensions=[group_timestamp_dimension],
                             timestamp=event_timestamp,
-                            value=full_load_time_delta.seconds,
+                            value=int(full_load_time_delta.total_seconds()),
                             unit=PipelineMetric.TIME_DELTA_FULL_DATA_LOAD_TIME.unit,
                         ),
                     ),


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BFD-2530](https://jira.cms.gov/browse/BFD-2530)

**User Story or Bug Summary:**

<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->

The Pipeline SLIs Lambda submits "time deltas", in seconds, to the following metrics per-environment (with corresponding dimensions):

- `time-delta/data-full-load-time`
- `time-delta/data-load-time`

Unfortunately, due to a misunderstanding when computing time deltas using Python's `timedelta` it was assumed that the `seconds` property was the total seconds of the duration that the `timedelta` represents. However, this is not the case, as the `timedelta`'s `seconds` property instead represents the seconds component of the internal representation of the `timedelta`'s duration. Until now, this seconds component has been submitted to each of the aforementioned metrics whenever a time delta was computed for Pipeline SLIs, and this has caused some samples for each metric to be inaccurate.

---

### What Does This PR Do?

<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

This PR fixes the issue by replacing usages of `timedelta.seconds` with `timedelta.total_seconds()`. This has been verified to work as expected using time data from the case where this was first noticed, ensuring that `timedelta.total_seconds()` is correct.

### What Should Reviewers Watch For?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:

<!-- Add some items to the following list here -->

- Verify all PR security questions and checklists have been completed and addressed.

### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

- If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

  - Does this PR add any new software dependencies?
    - [ ] Yes
    - [x] No
  - Does this PR modify or invalidate any of our security controls?
    - [ ] Yes
    - [x] No
  - Does this PR store or transmit data that was not stored or transmitted before?
    - [ ] Yes
    - [x] No

- If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
  - Do you think this PR requires additional review of its security implications for other reasons?
    - [ ] Yes
    - [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

- N/A

### Submitter Checklist

<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

- [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
- [x] This PR is reasonably limited in scope, to help ensure that:
  1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
  2. There isn't too much of a burden on reviewers.
  3. Any problems it causes have a small "blast radius".
  4. It'll be easier to rollback if that becomes necessary.
- [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
- [x] The data dictionary has been updated with any field mapping changes, if any were made.
- [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
- [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
- [x] Reviews are requested from both:
  - At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
  - Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
- [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
  - Please review the standards every few months to ensure you're familiar with them.
