### PR TITLE
PACA-1028 (DRAFT): Support for RDA DELETE messages.

### DIFF
--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/sink/direct/FissClaimRdaSink.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/sink/direct/FissClaimRdaSink.java
@@ -75,7 +75,9 @@ public class FissClaimRdaSink extends AbstractClaimRdaSink<FissClaimChange, RdaF
   @Override
   RdaChange<RdaFissClaim> transformMessageImpl(String apiVersion, FissClaimChange message) {
     var change = transformer.transformClaim(message);
-    change.getClaim().setApiSource(apiVersion);
+    if (change.getClaim() != null) {
+      change.getClaim().setApiSource(apiVersion);
+    }
     return change;
   }
 

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/sink/direct/McsClaimRdaSink.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/sink/direct/McsClaimRdaSink.java
@@ -57,7 +57,9 @@ public class McsClaimRdaSink extends AbstractClaimRdaSink<McsClaimChange, RdaMcs
   @Override
   RdaChange<RdaMcsClaim> transformMessageImpl(String apiVersion, McsClaimChange message) {
     var change = transformer.transformClaim(message);
-    change.getClaim().setApiSource(apiVersion);
+    if (change != null) {
+      change.getClaim().setApiSource(apiVersion);
+    }
     return change;
   }
 

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/sink/direct/McsClaimRdaSinkTest.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/sink/direct/McsClaimRdaSinkTest.java
@@ -118,6 +118,7 @@ public class McsClaimRdaSinkTest {
             "McsClaimRdaSink.transform.failures",
             "McsClaimRdaSink.transform.successes",
             "McsClaimRdaSink.writes.batchSize",
+            "McsClaimRdaSink.writes.deletes",
             "McsClaimRdaSink.writes.elapsed",
             "McsClaimRdaSink.writes.merged",
             "McsClaimRdaSink.writes.persisted",
@@ -195,7 +196,7 @@ public class McsClaimRdaSinkTest {
     final AbstractClaimRdaSink.Metrics metrics = sink.getMetrics();
     assertMeterReading(1, "calls", metrics.getCalls());
     assertMeterReading(0, "persists", metrics.getObjectsPersisted());
-    assertMeterReading(0, "merges", metrics.getObjectsMerged());
+    assertMeterReading(1, "merges", metrics.getObjectsMerged());
     assertMeterReading(0, "writes", metrics.getObjectsWritten());
     assertMeterReading(3, "transform successes", metrics.getTransformSuccesses());
     assertMeterReading(0, "transform failures", metrics.getTransformFailures());

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/FissClaimTransformerTest.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/FissClaimTransformerTest.java
@@ -4,8 +4,11 @@ import static gov.cms.bfd.pipeline.rda.grpc.RdaChange.MIN_SEQUENCE_NUM;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.samePropertyValuesAs;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import com.google.protobuf.Timestamp;
 import gov.cms.bfd.model.rda.Mbi;
 import gov.cms.bfd.model.rda.RdaFissAuditTrail;
 import gov.cms.bfd.model.rda.RdaFissClaim;
@@ -107,6 +110,31 @@ public class FissClaimTransformerTest {
     claimBuilder = FissClaim.newBuilder();
     claim = new RdaFissClaim();
     claim.setSequenceNumber(0L);
+  }
+
+  /**
+   * Verifies that claim is not transformed when the change message is a {@link
+   * ChangeType#CHANGE_TYPE_DELETE} but that other values of the {@link RdaChange} are populated.
+   */
+  @Test
+  public void deleteShouldSkipClaimTransformation() {
+    Instant now = clock.instant();
+    changeBuilder
+        .setSeq(MIN_SEQUENCE_NUM)
+        .setChangeType(ChangeType.CHANGE_TYPE_DELETE)
+        .setDcn("dcn")
+        .setRdaClaimKey("key")
+        .setTimestamp(
+            Timestamp.newBuilder()
+                .setSeconds(now.getEpochSecond())
+                .setNanos(now.getNano())
+                .build());
+    RdaChange<RdaFissClaim> changed = transformer.transformClaim(changeBuilder.build());
+    assertEquals(RdaChange.Type.DELETE, changed.getType());
+    assertEquals(MIN_SEQUENCE_NUM, changed.getSequenceNumber());
+    assertNull(changed.getClaim());
+    assertNotNull(changed.getSource());
+    assertEquals(now, changed.getTimestamp());
   }
 
   /**


### PR DESCRIPTION
**JIRA Ticket:**
[BFD-123456](https://jira.cms.gov/browse/BFD-123456)

**User Story or Bug Summary:**

We need to add support for DELETE message directives from RDA.
Such a request is highly unlikely but if received we need to swallow it and log that we have received it...for now.

---

### What Does This PR Do?

- Adds code to track the number of `DELETE` messages received as well as logging their sequence numbers.
- Handles the fact that `claim` is actually optional in `FissClaimChange` and `McsClaimChange` and will not be provided for deleted claims.

### What Should Reviewers Watch For?

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items to the following list here -->
* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [x] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [x] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [x] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] The data dictionary has been updated with any field mapping changes, if any were made.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    