### PR TITLE
PACA-1032: random claims start at seq 1

### DIFF
--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/server/AbstractRandomClaimGenerator.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/main/java/gov/cms/bfd/pipeline/rda/grpc/server/AbstractRandomClaimGenerator.java
@@ -66,7 +66,7 @@ abstract class AbstractRandomClaimGenerator<T> {
   AbstractRandomClaimGenerator(RandomClaimGeneratorConfig config) {
     this.config = config;
     errorGenerationRandom = new Random(config.getRandomErrorSeed());
-    sequence = 0;
+    sequence = 1;
     path = new Stack<>();
   }
 

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/RdaServerJobIT.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/RdaServerJobIT.java
@@ -75,7 +75,7 @@ public class RdaServerJobIT extends MinioTestContainer {
             .serverMode(RdaServerJob.Config.ServerMode.Random)
             .serverName(SERVER_NAME)
             .randomSeed(1L)
-            .randomMaxClaims(5)
+            .randomMaxClaims(4)
             .build();
     final RdaServerJob job = new RdaServerJob(config);
     final ExecutorService exec = Executors.newCachedThreadPool();

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/server/RandomFissClaimGeneratorTest.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/server/RandomFissClaimGeneratorTest.java
@@ -38,448 +38,476 @@ public class RandomFissClaimGeneratorTest {
                 .build());
     final FissClaim claim = generator.randomClaim();
     final String json = JsonFormat.printer().print(claim);
+    assertEquals(1, generator.getPreviousSequenceNumber());
     assertEquals(
-        "{\n"
-            + "  \"dcn\": \"79347185903055953987254\",\n"
-            + "  \"hicNo\": \"618367226005\",\n"
-            + "  \"currStatusEnum\": \"CLAIM_STATUS_ROUTING\",\n"
-            + "  \"currLoc1Enum\": \"PROCESSING_TYPE_OFFLINE\",\n"
-            + "  \"currLoc2Enum\": \"CURRENT_LOCATION_2_POST_PAY_7573\",\n"
-            + "  \"provStateCd\": \"k8\",\n"
-            + "  \"provTypFacilCd\": \"w\",\n"
-            + "  \"provEmerInd\": \"m\",\n"
-            + "  \"provDeptId\": \"mkm\",\n"
-            + "  \"totalChargeAmount\": \"4879.67\",\n"
-            + "  \"recdDtCymd\": \"2021-02-07\",\n"
-            + "  \"currTranDtCymd\": \"2021-01-20\",\n"
-            + "  \"admDiagCode\": \"hrp\",\n"
-            + "  \"principleDiag\": \"rkfdh\",\n"
-            + "  \"npiNumber\": \"2581678565\",\n"
-            + "  \"mbi\": \"bd1n31sbbrq\",\n"
-            + "  \"fedTaxNb\": \"4725636111\",\n"
-            + "  \"fissProcCodes\": [{\n"
-            + "    \"procCd\": \"rkfdh\",\n"
-            + "    \"rdaPosition\": 1,\n"
-            + "    \"procFlag\": \"hn\",\n"
-            + "    \"procDt\": \"2021-02-15\"\n"
-            + "  }, {\n"
-            + "    \"procCd\": \"b\",\n"
-            + "    \"rdaPosition\": 2,\n"
-            + "    \"procFlag\": \"p\",\n"
-            + "    \"procDt\": \"2021-04-11\"\n"
-            + "  }, {\n"
-            + "    \"procCd\": \"xstrzvw\",\n"
-            + "    \"rdaPosition\": 3,\n"
-            + "    \"procFlag\": \"pxxs\",\n"
-            + "    \"procDt\": \"2021-02-06\"\n"
-            + "  }, {\n"
-            + "    \"procCd\": \"rdvbd\",\n"
-            + "    \"rdaPosition\": 4,\n"
-            + "    \"procFlag\": \"jh\",\n"
-            + "    \"procDt\": \"2021-04-22\"\n"
-            + "  }, {\n"
-            + "    \"procCd\": \"h\",\n"
-            + "    \"rdaPosition\": 5,\n"
-            + "    \"procFlag\": \"qx\",\n"
-            + "    \"procDt\": \"2021-04-02\"\n"
-            + "  }, {\n"
-            + "    \"procCd\": \"jvd\",\n"
-            + "    \"rdaPosition\": 6,\n"
-            + "    \"procFlag\": \"x\",\n"
-            + "    \"procDt\": \"2021-04-06\"\n"
-            + "  }],\n"
-            + "  \"medaProvId\": \"3gt5j5ckm3v24\",\n"
-            + "  \"pracLocAddr1\": \"5q20q9db0z4gv7\",\n"
-            + "  \"pracLocAddr2\": \"k3m4d6t1g9hj7wpg10sr3m4xsfdkvb69h7tvx0nt7px8c2c9hkg0fn646b44jmskpwd2g7xc522w6xzmdsp26rds8gpd8rrd5p6p\",\n"
-            + "  \"pracLocCity\": \"x2x6cqbh59f762hrnfdjq2ntqq\",\n"
-            + "  \"pracLocState\": \"kj\",\n"
-            + "  \"pracLocZip\": \"14735937\",\n"
-            + "  \"fissDiagCodes\": [{\n"
-            + "    \"diagCd2\": \"zq\",\n"
-            + "    \"bitFlags\": \"vfjk\",\n"
-            + "    \"diagPoaIndUnrecognized\": \"x\",\n"
-            + "    \"rdaPosition\": 1\n"
-            + "  }, {\n"
-            + "    \"diagCd2\": \"ghnhhzj\",\n"
-            + "    \"diagPoaIndEnum\": \"DIAGNOSIS_PRESENT_ON_ADMISSION_INDICATOR_YES\",\n"
-            + "    \"bitFlags\": \"cjsn\",\n"
-            + "    \"rdaPosition\": 2\n"
-            + "  }, {\n"
-            + "    \"diagCd2\": \"bvcqwpr\",\n"
-            + "    \"diagPoaIndEnum\": \"DIAGNOSIS_PRESENT_ON_ADMISSION_INDICATOR_UNREPORTED\",\n"
-            + "    \"bitFlags\": \"kpmd\",\n"
-            + "    \"rdaPosition\": 3\n"
-            + "  }, {\n"
-            + "    \"diagCd2\": \"xkvkf\",\n"
-            + "    \"diagPoaIndEnum\": \"DIAGNOSIS_PRESENT_ON_ADMISSION_INDICATOR_CLINICALLY_UNDETERMINED\",\n"
-            + "    \"bitFlags\": \"svf\",\n"
-            + "    \"rdaPosition\": 4\n"
-            + "  }, {\n"
-            + "    \"diagCd2\": \"jkns\",\n"
-            + "    \"diagPoaIndEnum\": \"DIAGNOSIS_PRESENT_ON_ADMISSION_INDICATOR_CLINICALLY_UNDETERMINED\",\n"
-            + "    \"bitFlags\": \"hgnz\",\n"
-            + "    \"rdaPosition\": 5\n"
-            + "  }, {\n"
-            + "    \"diagCd2\": \"ccpfxmk\",\n"
-            + "    \"diagPoaIndEnum\": \"DIAGNOSIS_PRESENT_ON_ADMISSION_INDICATOR_CLINICALLY_UNDETERMINED\",\n"
-            + "    \"bitFlags\": \"gp\",\n"
-            + "    \"rdaPosition\": 6\n"
-            + "  }],\n"
-            + "  \"stmtCovFromCymd\": \"2021-03-17\",\n"
-            + "  \"stmtCovToCymd\": \"2021-04-23\",\n"
-            + "  \"medaProv6\": \"3gt5j5\",\n"
-            + "  \"lobCdEnum\": \"BILL_FACILITY_TYPE_INTERMEDIATE_CASE\",\n"
-            + "  \"servTypeCdForClinicsEnum\": \"BILL_CLASSIFICATION_FOR_CLINICS_OPIOID_TREATMENT_PROGRAM\",\n"
-            + "  \"freqCdUnrecognized\": \"b\",\n"
-            + "  \"billTypCd\": \"q88\",\n"
-            + "  \"fissPayers\": [{\n"
-            + "    \"insuredPayer\": {\n"
-            + "      \"rdaPosition\": 1,\n"
-            + "      \"payersIdEnum\": \"PAYERS_CODE_BLACK_LUNG\",\n"
-            + "      \"payersName\": \"ksfvnjfdqmvdfqm\",\n"
-            + "      \"relIndEnum\": \"RELEASE_OF_INFORMATION_SIGNED_STATEMENT_WAS_OBTAINED\",\n"
-            + "      \"assignIndEnum\": \"ASSIGNMENT_OF_BENEFITS_INDICATOR_BENEFITS_ASSIGNED\",\n"
-            + "      \"providerNumber\": \"tzggwdnbbxr\",\n"
-            + "      \"adjDcnIcn\": \"xfpcdgtbtkfmxcxnqxwbhtg\",\n"
-            + "      \"priorPmt\": \"48.50\",\n"
-            + "      \"estAmtDue\": \"27684.64\",\n"
-            + "      \"insuredRelUnrecognized\": \"23\",\n"
-            + "      \"insuredName\": \"ngzpjnzfzpnxqtxkm\",\n"
-            + "      \"insuredSsnHic\": \"k\",\n"
-            + "      \"insuredGroupName\": \"rvwvnzwcpxjmm\",\n"
-            + "      \"insuredGroupNbr\": \"tmbcfxsrnxb\",\n"
-            + "      \"treatAuthCd\": \"s7g279ntxbwk\",\n"
-            + "      \"insuredSexUnrecognized\": \"r\",\n"
-            + "      \"insuredRelX12Unrecognized\": \"21\",\n"
-            + "      \"insuredDob\": \"2021-06-22\",\n"
-            + "      \"insuredDobText\": \"06222021\"\n"
-            + "    }\n"
-            + "  }, {\n"
-            + "    \"insuredPayer\": {\n"
-            + "      \"rdaPosition\": 2,\n"
-            + "      \"payersIdUnrecognized\": \"h\",\n"
-            + "      \"payersName\": \"kjpxrjgk\",\n"
-            + "      \"relIndEnum\": \"RELEASE_OF_INFORMATION_SIGNED_STATEMENT_WAS_OBTAINED\",\n"
-            + "      \"assignIndUnrecognized\": \"t\",\n"
-            + "      \"providerNumber\": \"xrqjqxrbxr\",\n"
-            + "      \"adjDcnIcn\": \"rtfqfsdxvbnqfgkzgfmbjnj\",\n"
-            + "      \"priorPmt\": \"9740.67\",\n"
-            + "      \"estAmtDue\": \"597.06\",\n"
-            + "      \"insuredRelUnrecognized\": \"88\",\n"
-            + "      \"insuredName\": \"r\",\n"
-            + "      \"insuredSsnHic\": \"rcctzcwwjrscrqkn\",\n"
-            + "      \"insuredGroupName\": \"qmtnmxbxfngh\",\n"
-            + "      \"insuredGroupNbr\": \"tthftwdwxjprvrsphcr\",\n"
-            + "      \"treatAuthCd\": \"851b1zr47jz7p585d\",\n"
-            + "      \"insuredSexEnum\": \"BENEFICIARY_SEX_FEMALE\",\n"
-            + "      \"insuredRelX12Unrecognized\": \"14\",\n"
-            + "      \"insuredDob\": \"2021-01-18\",\n"
-            + "      \"insuredDobText\": \"01182021\"\n"
-            + "    }\n"
-            + "  }, {\n"
-            + "    \"insuredPayer\": {\n"
-            + "      \"rdaPosition\": 3,\n"
-            + "      \"payersIdEnum\": \"PAYERS_CODE_BLACK_LUNG\",\n"
-            + "      \"payersName\": \"sxgvjhbqdvkzcbbrrzjnbfsdvthbdtx\",\n"
-            + "      \"relIndEnum\": \"RELEASE_OF_INFORMATION_NO_RELEASE_ON_FILE\",\n"
-            + "      \"assignIndEnum\": \"ASSIGNMENT_OF_BENEFITS_INDICATOR_BENEFITS_ASSIGNED\",\n"
-            + "      \"providerNumber\": \"wxwcbghwpcfr\",\n"
-            + "      \"adjDcnIcn\": \"kmxjvqbwvfpggrbphwxgdvc\",\n"
-            + "      \"priorPmt\": \"5.94\",\n"
-            + "      \"estAmtDue\": \"1594.06\",\n"
-            + "      \"insuredRelUnrecognized\": \"82\",\n"
-            + "      \"insuredName\": \"tnpcvrvwmjmfhchmjffssf\",\n"
-            + "      \"insuredSsnHic\": \"qvh\",\n"
-            + "      \"insuredGroupName\": \"vc\",\n"
-            + "      \"insuredGroupNbr\": \"bbnbqpjvxq\",\n"
-            + "      \"treatAuthCd\": \"1gk4hm82t7c\",\n"
-            + "      \"insuredSexUnrecognized\": \"w\",\n"
-            + "      \"insuredRelX12Unrecognized\": \"83\",\n"
-            + "      \"insuredDob\": \"2021-06-25\",\n"
-            + "      \"insuredDobText\": \"06252021\"\n"
-            + "    }\n"
-            + "  }, {\n"
-            + "    \"beneZPayer\": {\n"
-            + "      \"rdaPosition\": 4,\n"
-            + "      \"payersIdUnrecognized\": \"t\",\n"
-            + "      \"payersName\": \"hj8x\",\n"
-            + "      \"relIndEnum\": \"RELEASE_OF_INFORMATION_NO_RELEASE_ON_FILE\",\n"
-            + "      \"assignIndUnrecognized\": \"d\",\n"
-            + "      \"providerNumber\": \"2bz9p9gckd\",\n"
-            + "      \"adjDcnIcn\": \"80h3d1\",\n"
-            + "      \"priorPmt\": \"1.06\",\n"
-            + "      \"estAmtDue\": \"978.17\",\n"
-            + "      \"beneRelUnrecognized\": \"68\",\n"
-            + "      \"beneLastName\": \"thjdmtwcbzn\",\n"
-            + "      \"beneFirstName\": \"zsnsdt\",\n"
-            + "      \"beneMidInit\": \"p\",\n"
-            + "      \"beneSsnHic\": \"9b22bfr\",\n"
-            + "      \"insuredGroupName\": \"gkwkxbvbgc\",\n"
-            + "      \"beneDob\": \"2021-02-23\",\n"
-            + "      \"beneSexUnrecognized\": \"p\",\n"
-            + "      \"treatAuthCd\": \"d\",\n"
-            + "      \"insuredSexUnrecognized\": \"g\",\n"
-            + "      \"insuredRelX12Enum\": \"PATIENT_RELATIONSHIP_CODE_RESERVED_FOR_NATIONAL_ASSIGNMENT_65\"\n"
-            + "    }\n"
-            + "  }, {\n"
-            + "    \"beneZPayer\": {\n"
-            + "      \"rdaPosition\": 5,\n"
-            + "      \"payersIdEnum\": \"PAYERS_CODE_PUBLIC_HEALTH_SERVICE_OR_OTHER_FEDERAL_AGENCY\",\n"
-            + "      \"payersName\": \"vr\",\n"
-            + "      \"relIndUnrecognized\": \"x\",\n"
-            + "      \"assignIndEnum\": \"ASSIGNMENT_OF_BENEFITS_INDICATOR_BENEFITS_ASSIGNED\",\n"
-            + "      \"providerNumber\": \"npnmc3m\",\n"
-            + "      \"adjDcnIcn\": \"b29mm021b68w7dtbww\",\n"
-            + "      \"priorPmt\": \"106.82\",\n"
-            + "      \"estAmtDue\": \"804.14\",\n"
-            + "      \"beneRelEnum\": \"PATIENT_RELATIONSHIP_CODE_RESERVED_FOR_NATIONAL_ASSIGNMENT_81\",\n"
-            + "      \"beneLastName\": \"qrwx\",\n"
-            + "      \"beneFirstName\": \"mgwptv\",\n"
-            + "      \"beneMidInit\": \"f\",\n"
-            + "      \"beneSsnHic\": \"q5hb34\",\n"
-            + "      \"insuredGroupName\": \"gxhsczcspsvc\",\n"
-            + "      \"beneDob\": \"2021-01-27\",\n"
-            + "      \"beneSexEnum\": \"BENEFICIARY_SEX_MALE\",\n"
-            + "      \"treatAuthCd\": \"d\",\n"
-            + "      \"insuredSexUnrecognized\": \"n\",\n"
-            + "      \"insuredRelX12Unrecognized\": \"55\"\n"
-            + "    }\n"
-            + "  }],\n"
-            + "  \"fissAuditTrail\": [{\n"
-            + "    \"badtStatusUnrecognized\": \"h\",\n"
-            + "    \"badtLoc\": \"t\",\n"
-            + "    \"badtOperId\": \"w32kw1\",\n"
-            + "    \"badtReas\": \"6kthk\",\n"
-            + "    \"badtCurrDateCymd\": \"2021-04-14\",\n"
-            + "    \"rdaPosition\": 1\n"
-            + "  }, {\n"
-            + "    \"badtStatusEnum\": \"CLAIM_STATUS_SUSPEND\",\n"
-            + "    \"badtLoc\": \"m59kj\",\n"
-            + "    \"badtOperId\": \"d0\",\n"
-            + "    \"badtReas\": \"94\",\n"
-            + "    \"badtCurrDateCymd\": \"2021-06-26\",\n"
-            + "    \"rdaPosition\": 2\n"
-            + "  }, {\n"
-            + "    \"badtStatusUnrecognized\": \"w\",\n"
-            + "    \"badtLoc\": \"ng\",\n"
-            + "    \"badtOperId\": \"s7\",\n"
-            + "    \"badtReas\": \"5c623\",\n"
-            + "    \"badtCurrDateCymd\": \"2021-01-27\",\n"
-            + "    \"rdaPosition\": 3\n"
-            + "  }, {\n"
-            + "    \"badtStatusEnum\": \"CLAIM_STATUS_RETURN_TO_PRO\",\n"
-            + "    \"badtLoc\": \"hfg9\",\n"
-            + "    \"badtOperId\": \"pj306\",\n"
-            + "    \"badtReas\": \"08b8g\",\n"
-            + "    \"badtCurrDateCymd\": \"2021-02-22\",\n"
-            + "    \"rdaPosition\": 4\n"
-            + "  }, {\n"
-            + "    \"badtStatusUnrecognized\": \"x\",\n"
-            + "    \"badtLoc\": \"7sdb4\",\n"
-            + "    \"badtOperId\": \"ppv\",\n"
-            + "    \"badtReas\": \"h\",\n"
-            + "    \"badtCurrDateCymd\": \"2021-03-12\",\n"
-            + "    \"rdaPosition\": 5\n"
-            + "  }, {\n"
-            + "    \"badtStatusEnum\": \"CLAIM_STATUS_ROUTING\",\n"
-            + "    \"badtLoc\": \"wq8q\",\n"
-            + "    \"badtOperId\": \"43sdchx\",\n"
-            + "    \"badtReas\": \"mkh\",\n"
-            + "    \"badtCurrDateCymd\": \"2021-04-26\",\n"
-            + "    \"rdaPosition\": 6\n"
-            + "  }, {\n"
-            + "    \"badtStatusUnrecognized\": \"j\",\n"
-            + "    \"badtLoc\": \"4ff\",\n"
-            + "    \"badtOperId\": \"fqj6gm656\",\n"
-            + "    \"badtReas\": \"t\",\n"
-            + "    \"badtCurrDateCymd\": \"2021-05-04\",\n"
-            + "    \"rdaPosition\": 7\n"
-            + "  }, {\n"
-            + "    \"badtStatusUnrecognized\": \"3\",\n"
-            + "    \"badtLoc\": \"08\",\n"
-            + "    \"badtOperId\": \"pdrxm\",\n"
-            + "    \"badtReas\": \"2m\",\n"
-            + "    \"badtCurrDateCymd\": \"2021-02-05\",\n"
-            + "    \"rdaPosition\": 8\n"
-            + "  }, {\n"
-            + "    \"badtStatusEnum\": \"CLAIM_STATUS_INACTIVE\",\n"
-            + "    \"badtLoc\": \"dkd\",\n"
-            + "    \"badtOperId\": \"btz7dk4pn\",\n"
-            + "    \"badtReas\": \"4\",\n"
-            + "    \"badtCurrDateCymd\": \"2021-02-09\",\n"
-            + "    \"rdaPosition\": 9\n"
-            + "  }, {\n"
-            + "    \"badtStatusUnrecognized\": \"3\",\n"
-            + "    \"badtLoc\": \"rf33f\",\n"
-            + "    \"badtOperId\": \"03\",\n"
-            + "    \"badtReas\": \"9n\",\n"
-            + "    \"badtCurrDateCymd\": \"2021-06-03\",\n"
-            + "    \"rdaPosition\": 10\n"
-            + "  }, {\n"
-            + "    \"badtStatusUnrecognized\": \"g\",\n"
-            + "    \"badtLoc\": \"hk\",\n"
-            + "    \"badtOperId\": \"56g7nz6\",\n"
-            + "    \"badtReas\": \"n5\",\n"
-            + "    \"badtCurrDateCymd\": \"2021-03-04\",\n"
-            + "    \"rdaPosition\": 11\n"
-            + "  }, {\n"
-            + "    \"badtStatusUnrecognized\": \"t\",\n"
-            + "    \"badtLoc\": \"j\",\n"
-            + "    \"badtOperId\": \"rkrr71z5\",\n"
-            + "    \"badtReas\": \"mk\",\n"
-            + "    \"badtCurrDateCymd\": \"2021-02-19\",\n"
-            + "    \"rdaPosition\": 12\n"
-            + "  }, {\n"
-            + "    \"badtStatusUnrecognized\": \"r\",\n"
-            + "    \"badtLoc\": \"7\",\n"
-            + "    \"badtOperId\": \"23\",\n"
-            + "    \"badtReas\": \"33\",\n"
-            + "    \"badtCurrDateCymd\": \"2021-04-04\",\n"
-            + "    \"rdaPosition\": 13\n"
-            + "  }, {\n"
-            + "    \"badtStatusUnrecognized\": \"9\",\n"
-            + "    \"badtLoc\": \"d\",\n"
-            + "    \"badtOperId\": \"qxcnp\",\n"
-            + "    \"badtReas\": \"3n\",\n"
-            + "    \"badtCurrDateCymd\": \"2021-02-20\",\n"
-            + "    \"rdaPosition\": 14\n"
-            + "  }, {\n"
-            + "    \"badtStatusEnum\": \"CLAIM_STATUS_ROUTING\",\n"
-            + "    \"badtLoc\": \"qswqx\",\n"
-            + "    \"badtOperId\": \"t104bjgc\",\n"
-            + "    \"badtReas\": \"n\",\n"
-            + "    \"badtCurrDateCymd\": \"2021-04-17\",\n"
-            + "    \"rdaPosition\": 15\n"
-            + "  }, {\n"
-            + "    \"badtStatusEnum\": \"CLAIM_STATUS_MOVE\",\n"
-            + "    \"badtLoc\": \"p\",\n"
-            + "    \"badtOperId\": \"bcr66s8hv\",\n"
-            + "    \"badtReas\": \"kn4q8\",\n"
-            + "    \"badtCurrDateCymd\": \"2021-06-28\",\n"
-            + "    \"rdaPosition\": 16\n"
-            + "  }],\n"
-            + "  \"rejectCd\": \"9fk6f\",\n"
-            + "  \"fullPartDenInd\": \"k\",\n"
-            + "  \"nonPayInd\": \"7\",\n"
-            + "  \"xrefDcnNbr\": \"9g6cdt7\",\n"
-            + "  \"adjReqCdUnrecognized\": \"q\",\n"
-            + "  \"adjReasCd\": \"d\",\n"
-            + "  \"cancelXrefDcn\": \"6s1f7xf9mghjr\",\n"
-            + "  \"cancelDateCymd\": \"2021-03-21\",\n"
-            + "  \"cancAdjCdUnrecognized\": \"k\",\n"
-            + "  \"originalXrefDcn\": \"69khdgd6x0c4mb\",\n"
-            + "  \"paidDtCymd\": \"2021-06-05\",\n"
-            + "  \"admDateCymd\": \"2021-04-18\",\n"
-            + "  \"admSourceUnrecognized\": \"p\",\n"
-            + "  \"primaryPayerCodeUnrecognized\": \"2\",\n"
-            + "  \"attendPhysId\": \"n\",\n"
-            + "  \"attendPhysLname\": \"91bk27x96z8g\",\n"
-            + "  \"attendPhysFname\": \"vvrw\",\n"
-            + "  \"attendPhysMint\": \"v\",\n"
-            + "  \"attendPhysFlagEnum\": \"PHYSICIAN_FLAG_NO\",\n"
-            + "  \"operatingPhysId\": \"n13\",\n"
-            + "  \"operPhysLname\": \"9qrpp2d\",\n"
-            + "  \"operPhysFname\": \"330vttqqqmbmcbf\",\n"
-            + "  \"operPhysMint\": \"s\",\n"
-            + "  \"operPhysFlagEnum\": \"PHYSICIAN_FLAG_NO\",\n"
-            + "  \"othPhysId\": \"58b\",\n"
-            + "  \"othPhysLname\": \"x3rnt1f8c246td6h3\",\n"
-            + "  \"othPhysFname\": \"pwg5\",\n"
-            + "  \"othPhysMint\": \"8\",\n"
-            + "  \"othPhysFlagEnum\": \"PHYSICIAN_FLAG_NO\",\n"
-            + "  \"xrefHicNbr\": \"bhc8xt3\",\n"
-            + "  \"procNewHicIndUnrecognized\": \"0\",\n"
-            + "  \"newHic\": \"jdnbrt9\",\n"
-            + "  \"reposIndEnum\": \"REPOSITORY_INDICATOR_NOT_APPLICABLE\",\n"
-            + "  \"reposHic\": \"w5m3wx\",\n"
-            + "  \"mbiSubmBeneIndEnum\": \"FISS_HIC_OR_MBI_IS_HIC\",\n"
-            + "  \"adjMbiIndEnum\": \"ADJUSTMENT_MBI_INDICATOR_MBI_SUBMITTED_ON_ADJUSTMENT_OR_CANCEL_CLAIM\",\n"
-            + "  \"adjMbi\": \"m532pp5pxkf\",\n"
-            + "  \"medicalRecordNo\": \"x08jk412t\",\n"
-            + "  \"stmtCovFromCymdText\": \"2021-03-17\",\n"
-            + "  \"stmtCovToCymdText\": \"2021-04-23\",\n"
-            + "  \"admDateCymdText\": \"2021-04-18\",\n"
-            + "  \"fissRevenueLines\": [{\n"
-            + "    \"rdaPosition\": 1,\n"
-            + "    \"nonBillRevCodeEnum\": \"NON_BILL_S\",\n"
-            + "    \"revCd\": \"dvd\",\n"
-            + "    \"revUnitsBilled\": 19,\n"
-            + "    \"revServUnitCnt\": 23,\n"
-            + "    \"servDtCymd\": \"2021-04-24\",\n"
-            + "    \"servDtCymdText\": \"2021-04-24\",\n"
-            + "    \"hcpcCd\": \"w\",\n"
-            + "    \"hcpcInd\": \"d\",\n"
-            + "    \"hcpcModifier\": \"h\",\n"
-            + "    \"hcpcModifier2\": \"f\",\n"
-            + "    \"hcpcModifier3\": \"5\",\n"
-            + "    \"hcpcModifier4\": \"1\",\n"
-            + "    \"hcpcModifier5\": \"2\",\n"
-            + "    \"acoRedRarc\": \"z\",\n"
-            + "    \"acoRedCarc\": \"q\",\n"
-            + "    \"acoRedCagc\": \"3x\"\n"
-            + "  }, {\n"
-            + "    \"rdaPosition\": 2,\n"
-            + "    \"nonBillRevCodeUnrecognized\": \"7\",\n"
-            + "    \"revCd\": \"2h\",\n"
-            + "    \"revUnitsBilled\": 21,\n"
-            + "    \"revServUnitCnt\": 28,\n"
-            + "    \"servDtCymd\": \"2021-04-09\",\n"
-            + "    \"servDtCymdText\": \"2021-04-09\",\n"
-            + "    \"hcpcCd\": \"s0h3\",\n"
-            + "    \"hcpcInd\": \"b\",\n"
-            + "    \"hcpcModifier\": \"z9\",\n"
-            + "    \"hcpcModifier2\": \"j\",\n"
-            + "    \"hcpcModifier3\": \"5\",\n"
-            + "    \"hcpcModifier4\": \"t\",\n"
-            + "    \"hcpcModifier5\": \"p\",\n"
-            + "    \"acoRedRarc\": \"vp3\",\n"
-            + "    \"acoRedCarc\": \"hb\",\n"
-            + "    \"acoRedCagc\": \"pt\"\n"
-            + "  }, {\n"
-            + "    \"rdaPosition\": 3,\n"
-            + "    \"nonBillRevCodeEnum\": \"NON_BILL_R\",\n"
-            + "    \"revCd\": \"b6g\",\n"
-            + "    \"revUnitsBilled\": 21,\n"
-            + "    \"revServUnitCnt\": 8,\n"
-            + "    \"servDtCymd\": \"2021-03-09\",\n"
-            + "    \"servDtCymdText\": \"2021-03-09\",\n"
-            + "    \"hcpcCd\": \"96\",\n"
-            + "    \"hcpcInd\": \"s\",\n"
-            + "    \"hcpcModifier\": \"9\",\n"
-            + "    \"hcpcModifier2\": \"s\",\n"
-            + "    \"hcpcModifier3\": \"r\",\n"
-            + "    \"hcpcModifier4\": \"b\",\n"
-            + "    \"hcpcModifier5\": \"2\",\n"
-            + "    \"acoRedRarc\": \"knp\",\n"
-            + "    \"acoRedCarc\": \"x0j\",\n"
-            + "    \"acoRedCagc\": \"6d\"\n"
-            + "  }, {\n"
-            + "    \"rdaPosition\": 4,\n"
-            + "    \"nonBillRevCodeEnum\": \"NON_BILL_S\",\n"
-            + "    \"revCd\": \"8\",\n"
-            + "    \"revUnitsBilled\": 11,\n"
-            + "    \"revServUnitCnt\": 32,\n"
-            + "    \"servDtCymd\": \"2021-01-10\",\n"
-            + "    \"servDtCymdText\": \"2021-01-10\",\n"
-            + "    \"hcpcCd\": \"4jh\",\n"
-            + "    \"hcpcInd\": \"5\",\n"
-            + "    \"hcpcModifier\": \"r3\",\n"
-            + "    \"hcpcModifier2\": \"sn\",\n"
-            + "    \"hcpcModifier3\": \"nw\",\n"
-            + "    \"hcpcModifier4\": \"b6\",\n"
-            + "    \"hcpcModifier5\": \"76\",\n"
-            + "    \"acoRedRarc\": \"g3f\",\n"
-            + "    \"acoRedCarc\": \"43\",\n"
-            + "    \"acoRedCagc\": \"hx\"\n"
-            + "  }],\n"
-            + "  \"drgCd\": \"t\",\n"
-            + "  \"groupCode\": \"n\",\n"
-            + "  \"clmTypIndUnrecognized\": \"w\",\n"
-            + "  \"recdDtCymdText\": \"2021-02-07\",\n"
-            + "  \"currTranDtCymdText\": \"2021-01-20\",\n"
-            + "  \"rdaClaimKey\": \"19669840573147667643640083677381\",\n"
-            + "  \"intermediaryNb\": \"09142\"\n"
-            + "}",
+        """
+{
+  "dcn": "65686447345742655016681",
+  "hicNo": "897538270399",
+  "currStatusEnum": "CLAIM_STATUS_BLANK",
+  "provStateCd": "m4",
+  "provTypFacilCd": "n",
+  "provEmerInd": "j",
+  "provDeptId": "c01",
+  "totalChargeAmount": "8878.88",
+  "recdDtCymd": "2021-01-15",
+  "currTranDtCymd": "2021-05-07",
+  "admDiagCode": "sbzzv",
+  "principleDiag": "pkvrk",
+  "npiNumber": "3207789530",
+  "mbi": "wkh52g7nbkf",
+  "fedTaxNb": "9738554920",
+  "fissProcCodes": [{
+    "procCd": "pkvrk",
+    "rdaPosition": 1,
+    "procFlag": "htx",
+    "procDt": "2021-04-02"
+  }, {
+    "procCd": "cmhfc",
+    "rdaPosition": 2,
+    "procFlag": "k",
+    "procDt": "2021-06-26"
+  }, {
+    "procCd": "frq",
+    "rdaPosition": 3,
+    "procFlag": "f",
+    "procDt": "2021-03-12"
+  }],
+  "medaProvId": "wkhcjxjwqp8bq",
+  "pracLocAddr1": "vvv1m6fpjbn33zzp75s2wc9dnqvpcscm7458n7t7hjndfh2v843q3sm",
+  "pracLocAddr2": "194hz2pmknchmbs45zzz",
+  "pracLocCity": "6wvgbtc3mcghzjz0kzcwxm9scfsq9xpwnx490p0twzrzxc",
+  "pracLocState": "fc",
+  "pracLocZip": "062130",
+  "currLoc1Unrecognized": "r",
+  "currLoc2Unrecognized": "jzsq",
+  "stmtCovFromCymd": "2021-03-24",
+  "stmtCovToCymd": "2021-03-18",
+  "medaProv6": "wkhcjx",
+  "lobCdEnum": "BILL_FACILITY_TYPE_RELIGIOUS_NON_MEDICAL_EXTENDED_CARE",
+  "servTypeCdForClinicsEnum": "BILL_CLASSIFICATION_FOR_CLINICS_COMPREHENSIVE_OUTPATIENT_REHABILITATION_FACILITY",
+  "freqCdUnrecognized": "d",
+  "billTypCd": "rnh",
+  "fissPayers": [{
+    "beneZPayer": {
+      "rdaPosition": 1,
+      "payersIdEnum": "PAYERS_CODE_WORKERS_COMPENSATION",
+      "payersName": "db4dq8",
+      "relIndEnum": "RELEASE_OF_INFORMATION_SIGNED_STATEMENT_WAS_OBTAINED",
+      "assignIndEnum": "ASSIGNMENT_OF_BENEFITS_INDICATOR_BENEFITS_ASSIGNED",
+      "providerNumber": "4p",
+      "adjDcnIcn": "s6m075",
+      "priorPmt": "89196.37",
+      "estAmtDue": "152.69",
+      "beneRelUnrecognized": "71",
+      "beneLastName": "mfjp",
+      "beneFirstName": "qdbpbhfkfm",
+      "beneMidInit": "z",
+      "beneSsnHic": "dkkgpn36g0dg7xnk1w3",
+      "insuredGroupName": "zfwnnzvxgw",
+      "beneDob": "2021-02-08",
+      "beneSexEnum": "BENEFICIARY_SEX_UNKNOWN",
+      "treatAuthCd": "x",
+      "insuredSexEnum": "BENEFICIARY_SEX_FEMALE",
+      "insuredRelX12Unrecognized": "74"
+    }
+  }, {
+    "beneZPayer": {
+      "rdaPosition": 2,
+      "payersIdEnum": "PAYERS_CODE_CONDITIONAL_PAYMENT",
+      "payersName": "80gcv323nqt5trhn89b",
+      "relIndUnrecognized": "z",
+      "assignIndEnum": "ASSIGNMENT_OF_BENEFITS_INDICATOR_BENEFITS_ASSIGNED",
+      "providerNumber": "zt398xkjmk5g6",
+      "adjDcnIcn": "b7dz5rbmtb0045p95tq",
+      "priorPmt": "20666.98",
+      "estAmtDue": "12.23",
+      "beneRelEnum": "PATIENT_RELATIONSHIP_CODE_RESERVED_FOR_NATIONAL_ASSIGNMENT_77",
+      "beneLastName": "b",
+      "beneFirstName": "xnmzvkbwh",
+      "beneMidInit": "r",
+      "beneSsnHic": "vf2zg8gpj91jv4jrcjx",
+      "insuredGroupName": "sftr",
+      "beneDob": "2021-01-13",
+      "beneSexUnrecognized": "d",
+      "treatAuthCd": "x",
+      "insuredSexEnum": "BENEFICIARY_SEX_UNKNOWN",
+      "insuredRelX12Enum": "PATIENT_RELATIONSHIP_CODE_LIFE_PARTNER"
+    }
+  }, {
+    "beneZPayer": {
+      "rdaPosition": 3,
+      "payersIdEnum": "PAYERS_CODE_WORKERS_COMPENSATION",
+      "payersName": "f4gmk4w72bkjz3smccstmpsg80s8",
+      "relIndEnum": "RELEASE_OF_INFORMATION_NO_RELEASE_ON_FILE",
+      "assignIndEnum": "ASSIGNMENT_OF_BENEFITS_INDICATOR_NO_BENEFITS_ASSIGNED",
+      "providerNumber": "r9d3c54fgwhd9",
+      "adjDcnIcn": "d0jmmb7n",
+      "priorPmt": "48704.98",
+      "estAmtDue": "61751.08",
+      "beneRelEnum": "PATIENT_RELATIONSHIP_CODE_RESERVED_FOR_NATIONAL_ASSIGNMENT_74",
+      "beneLastName": "sgxkjmtxmmnm",
+      "beneFirstName": "svbkg",
+      "beneMidInit": "b",
+      "beneSsnHic": "k842jj",
+      "insuredGroupName": "fzhtjjrwtznbqb",
+      "beneDob": "2021-06-02",
+      "beneSexEnum": "BENEFICIARY_SEX_UNKNOWN",
+      "treatAuthCd": "q",
+      "insuredSexEnum": "BENEFICIARY_SEX_UNKNOWN",
+      "insuredRelX12Unrecognized": "95"
+    }
+  }, {
+    "beneZPayer": {
+      "rdaPosition": 4,
+      "payersIdUnrecognized": "p",
+      "payersName": "ktz52n4qdbjchsm50crttb78gg",
+      "relIndUnrecognized": "p",
+      "assignIndUnrecognized": "h",
+      "providerNumber": "fqr2mtz5",
+      "adjDcnIcn": "3t46kt",
+      "priorPmt": "2642.52",
+      "estAmtDue": "9823.82",
+      "beneRelUnrecognized": "13",
+      "beneLastName": "mtc",
+      "beneFirstName": "kmgr",
+      "beneMidInit": "r",
+      "beneSsnHic": "fpgb1k2",
+      "insuredGroupName": "zczrfwnvj",
+      "beneDob": "2021-01-26",
+      "beneSexUnrecognized": "p",
+      "treatAuthCd": "d",
+      "insuredSexEnum": "BENEFICIARY_SEX_MALE",
+      "insuredRelX12Unrecognized": "18"
+    }
+  }, {
+    "beneZPayer": {
+      "rdaPosition": 5,
+      "payersIdUnrecognized": "q",
+      "payersName": "gkzg426s4qh5tc296xmdx3spzt9",
+      "relIndUnrecognized": "f",
+      "assignIndUnrecognized": "n",
+      "providerNumber": "gdxv543gdk",
+      "adjDcnIcn": "535680wxr8",
+      "priorPmt": "516.92",
+      "estAmtDue": "4.00",
+      "beneRelUnrecognized": "77",
+      "beneLastName": "qsfvjn",
+      "beneFirstName": "ggrj",
+      "beneMidInit": "q",
+      "beneSsnHic": "wgtf2xxhj0mqh",
+      "insuredGroupName": "wtdxqpvfxxhvptz",
+      "beneDob": "2021-03-11",
+      "beneSexEnum": "BENEFICIARY_SEX_UNKNOWN",
+      "treatAuthCd": "f",
+      "insuredSexUnrecognized": "p",
+      "insuredRelX12Unrecognized": "03"
+    }
+  }],
+  "fissAuditTrail": [{
+    "badtStatusEnum": "CLAIM_STATUS_MOVE",
+    "badtLoc": "f0b",
+    "badtOperId": "dk3qkj8",
+    "badtReas": "c1rg",
+    "badtCurrDateCymd": "2021-01-25",
+    "rdaPosition": 1
+  }, {
+    "badtStatusUnrecognized": "c",
+    "badtLoc": "f461",
+    "badtOperId": "pz9kx",
+    "badtReas": "5n",
+    "badtCurrDateCymd": "2021-06-14",
+    "rdaPosition": 2
+  }, {
+    "badtStatusEnum": "CLAIM_STATUS_SUSPEND",
+    "badtLoc": "f",
+    "badtOperId": "g4348xj",
+    "badtReas": "21t",
+    "badtCurrDateCymd": "2021-06-05",
+    "rdaPosition": 3
+  }, {
+    "badtStatusUnrecognized": "s",
+    "badtLoc": "f80d",
+    "badtOperId": "f",
+    "badtReas": "t",
+    "badtCurrDateCymd": "2021-01-31",
+    "rdaPosition": 4
+  }, {
+    "badtStatusUnrecognized": "m",
+    "badtLoc": "d0m13",
+    "badtOperId": "vhjc5",
+    "badtReas": "jwf2",
+    "badtCurrDateCymd": "2021-06-07",
+    "rdaPosition": 5
+  }, {
+    "badtStatusEnum": "CLAIM_STATUS_ROUTING",
+    "badtLoc": "pfhhf",
+    "badtOperId": "3vqx4q0",
+    "badtReas": "h6hb",
+    "badtCurrDateCymd": "2021-03-12",
+    "rdaPosition": 6
+  }, {
+    "badtStatusEnum": "CLAIM_STATUS_RTP",
+    "badtLoc": "3",
+    "badtOperId": "gsxvnqj",
+    "badtReas": "cf",
+    "badtCurrDateCymd": "2021-05-14",
+    "rdaPosition": 7
+  }, {
+    "badtStatusUnrecognized": "8",
+    "badtLoc": "ww",
+    "badtOperId": "fcgmpskq",
+    "badtReas": "k7th8",
+    "badtCurrDateCymd": "2021-03-11",
+    "rdaPosition": 8
+  }, {
+    "badtStatusUnrecognized": "0",
+    "badtLoc": "d",
+    "badtOperId": "r616",
+    "badtReas": "5f2dm",
+    "badtCurrDateCymd": "2021-03-22",
+    "rdaPosition": 9
+  }, {
+    "badtStatusEnum": "CLAIM_STATUS_FORCE",
+    "badtLoc": "99hj",
+    "badtOperId": "j843h15ms",
+    "badtReas": "s",
+    "badtCurrDateCymd": "2021-01-16",
+    "rdaPosition": 10
+  }, {
+    "badtStatusEnum": "CLAIM_STATUS_MOVE",
+    "badtLoc": "1cv05",
+    "badtOperId": "g",
+    "badtReas": "1v",
+    "badtCurrDateCymd": "2021-03-17",
+    "rdaPosition": 11
+  }, {
+    "badtStatusUnrecognized": "2",
+    "badtLoc": "jg9",
+    "badtOperId": "dpnk1pf",
+    "badtReas": "z8",
+    "badtCurrDateCymd": "2021-04-17",
+    "rdaPosition": 12
+  }, {
+    "badtStatusEnum": "CLAIM_STATUS_RETURN_TO_PRO",
+    "badtLoc": "8j",
+    "badtOperId": "f0q5tnw",
+    "badtReas": "9v",
+    "badtCurrDateCymd": "2021-01-13",
+    "rdaPosition": 13
+  }],
+  "rejectCd": "87",
+  "fullPartDenInd": "f",
+  "nonPayInd": "zq",
+  "xrefDcnNbr": "0jn2sgcvmdwz",
+  "adjReqCdUnrecognized": "m",
+  "adjReasCd": "tv",
+  "cancelXrefDcn": "92141675m",
+  "cancelDateCymd": "2021-02-03",
+  "cancAdjCdEnum": "CANCEL_ADJUSTMENT_CODE_PROVIDER_CANCELLED_EPISODE",
+  "originalXrefDcn": "v8xh",
+  "paidDtCymd": "2021-06-03",
+  "admDateCymd": "2021-06-17",
+  "admSourceUnrecognized": "7",
+  "primaryPayerCodeEnum": "PAYERS_CODE_WORKING_AGE",
+  "attendPhysId": "tq3hcd1",
+  "attendPhysLname": "0v4b0n",
+  "attendPhysFname": "g4k4kbjfgrhgrs5",
+  "attendPhysMint": "t",
+  "attendPhysFlagEnum": "PHYSICIAN_FLAG_NO",
+  "operatingPhysId": "dqkq4t7kz7r",
+  "operPhysLname": "h9pps",
+  "operPhysFname": "thqzvzsm014jsdk",
+  "operPhysMint": "d",
+  "operPhysFlagEnum": "PHYSICIAN_FLAG_NO",
+  "othPhysId": "9r79nmd598",
+  "othPhysLname": "q94s0r",
+  "othPhysFname": "8dt9w",
+  "othPhysMint": "0",
+  "othPhysFlagUnrecognized": "r",
+  "xrefHicNbr": "3xbtpc",
+  "procNewHicIndEnum": "PROCESS_NEW_HIC_INDICATOR_Y",
+  "newHic": "d",
+  "reposIndUnrecognized": "c",
+  "reposHic": "qnv80",
+  "mbiSubmBeneIndUnrecognized": "7",
+  "adjMbiIndEnum": "ADJUSTMENT_MBI_INDICATOR_HIC_SUBMITTED_ON_ADJUSTMENT_OR_CANCEL_CLAIM",
+  "adjMbi": "wnkf643w5",
+  "medicalRecordNo": "z3t566hsc3s17",
+  "stmtCovFromCymdText": "2021-03-24",
+  "stmtCovToCymdText": "2021-03-18",
+  "admDateCymdText": "2021-06-17",
+  "fissRevenueLines": [{
+    "rdaPosition": 1,
+    "nonBillRevCodeEnum": "NON_BILL_S",
+    "revCd": "26kn",
+    "revUnitsBilled": 21,
+    "revServUnitCnt": 7,
+    "servDtCymd": "2021-01-19",
+    "servDtCymdText": "2021-01-19",
+    "hcpcCd": "9d",
+    "hcpcInd": "w",
+    "hcpcModifier": "6w",
+    "hcpcModifier2": "5",
+    "hcpcModifier3": "6",
+    "hcpcModifier4": "r",
+    "hcpcModifier5": "f",
+    "acoRedRarc": "1x4",
+    "acoRedCarc": "g",
+    "acoRedCagc": "nz"
+  }, {
+    "rdaPosition": 2,
+    "nonBillRevCodeUnrecognized": "m",
+    "revCd": "t",
+    "revUnitsBilled": 39,
+    "revServUnitCnt": 15,
+    "servDtCymd": "2021-01-15",
+    "servDtCymdText": "2021-01-15",
+    "hcpcCd": "jqq",
+    "hcpcInd": "v",
+    "hcpcModifier": "22",
+    "hcpcModifier2": "zw",
+    "hcpcModifier3": "t6",
+    "hcpcModifier4": "j7",
+    "hcpcModifier5": "df",
+    "acoRedRarc": "p",
+    "acoRedCarc": "t0",
+    "acoRedCagc": "tm"
+  }, {
+    "rdaPosition": 3,
+    "nonBillRevCodeEnum": "NON_BILL_INVALID_REV_CODE",
+    "revCd": "mrjt",
+    "revUnitsBilled": 12,
+    "revServUnitCnt": 19,
+    "servDtCymd": "2021-01-20",
+    "servDtCymdText": "2021-01-20",
+    "hcpcCd": "0",
+    "hcpcInd": "0",
+    "hcpcModifier": "b",
+    "hcpcModifier2": "n",
+    "hcpcModifier3": "b",
+    "hcpcModifier4": "7",
+    "hcpcModifier5": "8",
+    "acoRedRarc": "c1c7",
+    "acoRedCarc": "67",
+    "acoRedCagc": "tv"
+  }, {
+    "rdaPosition": 4,
+    "nonBillRevCodeEnum": "NON_BILL_INVALID_HCPCS_HC",
+    "revCd": "cfb",
+    "revUnitsBilled": 45,
+    "revServUnitCnt": 48,
+    "servDtCymd": "2021-06-27",
+    "servDtCymdText": "2021-06-27",
+    "hcpcCd": "d",
+    "hcpcInd": "d",
+    "hcpcModifier": "s",
+    "hcpcModifier2": "mr",
+    "hcpcModifier3": "g1",
+    "hcpcModifier4": "68",
+    "hcpcModifier5": "rg",
+    "acoRedRarc": "ntq",
+    "acoRedCarc": "z7",
+    "acoRedCagc": "3x"
+  }, {
+    "rdaPosition": 5,
+    "nonBillRevCodeEnum": "NON_BILL_S",
+    "revCd": "2zb",
+    "revUnitsBilled": 17,
+    "revServUnitCnt": 23,
+    "servDtCymd": "2021-05-27",
+    "servDtCymdText": "2021-05-27",
+    "hcpcCd": "tnr5",
+    "hcpcInd": "j",
+    "hcpcModifier": "48",
+    "hcpcModifier2": "7",
+    "hcpcModifier3": "w",
+    "hcpcModifier4": "r",
+    "hcpcModifier5": "f",
+    "acoRedRarc": "x",
+    "acoRedCarc": "s95",
+    "acoRedCagc": "k2"
+  }, {
+    "rdaPosition": 6,
+    "nonBillRevCodeEnum": "NON_BILL_ESRD",
+    "revCd": "vmtw",
+    "revUnitsBilled": 9,
+    "revServUnitCnt": 23,
+    "servDtCymd": "2021-02-17",
+    "servDtCymdText": "2021-02-17",
+    "hcpcCd": "s",
+    "hcpcInd": "8",
+    "hcpcModifier": "6p",
+    "hcpcModifier2": "s",
+    "hcpcModifier3": "c",
+    "hcpcModifier4": "b",
+    "hcpcModifier5": "x",
+    "acoRedRarc": "svf7",
+    "acoRedCarc": "5",
+    "acoRedCagc": "xv"
+  }, {
+    "rdaPosition": 7,
+    "nonBillRevCodeEnum": "NON_BILL_T",
+    "revCd": "nzjd",
+    "revUnitsBilled": 38,
+    "revServUnitCnt": 9,
+    "servDtCymd": "2021-03-06",
+    "servDtCymdText": "2021-03-06",
+    "hcpcCd": "866",
+    "hcpcInd": "s",
+    "hcpcModifier": "p",
+    "hcpcModifier2": "1v",
+    "hcpcModifier3": "p3",
+    "hcpcModifier4": "j0",
+    "hcpcModifier5": "8m",
+    "acoRedRarc": "sh1zj",
+    "acoRedCarc": "054",
+    "acoRedCagc": "93"
+  }, {
+    "rdaPosition": 8,
+    "nonBillRevCodeEnum": "NON_BILL_INVALID_HCPCS_EMC",
+    "revCd": "42v4",
+    "revUnitsBilled": 12,
+    "revServUnitCnt": 33,
+    "servDtCymd": "2021-05-21",
+    "servDtCymdText": "2021-05-21",
+    "hcpcCd": "r7p",
+    "hcpcInd": "3",
+    "hcpcModifier": "6",
+    "hcpcModifier2": "r",
+    "hcpcModifier3": "m",
+    "hcpcModifier4": "0",
+    "hcpcModifier5": "6",
+    "acoRedRarc": "df57b",
+    "acoRedCarc": "rt",
+    "acoRedCagc": "q"
+  }, {
+    "rdaPosition": 9,
+    "nonBillRevCodeEnum": "NON_BILL_INVALID_REV_CODE",
+    "revCd": "ck7",
+    "revUnitsBilled": 1,
+    "revServUnitCnt": 9,
+    "servDtCymd": "2021-03-30",
+    "servDtCymdText": "2021-03-30",
+    "hcpcCd": "kmzjs",
+    "hcpcInd": "t",
+    "hcpcModifier": "hc",
+    "hcpcModifier2": "z",
+    "hcpcModifier3": "q",
+    "hcpcModifier4": "k",
+    "hcpcModifier5": "9",
+    "acoRedRarc": "rjfgw",
+    "acoRedCarc": "2xb",
+    "acoRedCagc": "1"
+  }],
+  "drgCd": "0",
+  "groupCode": "1",
+  "clmTypIndEnum": "CLAIM_TYPE_TOB_X20_X28",
+  "recdDtCymdText": "2021-01-15",
+  "currTranDtCymdText": "2021-05-07",
+  "rdaClaimKey": "79173353508803659401417553844541",
+  "intermediaryNb": "82320"
+}""",
         json);
   }
 

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/server/RandomFissClaimSourceTest.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/server/RandomFissClaimSourceTest.java
@@ -83,16 +83,19 @@ public class RandomFissClaimSourceTest {
   }
 
   /**
-   * Validates that the sequence numbers generated for claims is sequential.
+   * Validates that the sequence numbers generated for claims are sequential and start at 1.
    *
    * @throws Exception indicates test failure
    */
   @Test
   public void sequenceNumbers() throws Exception {
-    MessageSource<FissClaimChange> source = new RandomFissClaimSource(0, 7).skipTo(4);
+    MessageSource<FissClaimChange> source = new RandomFissClaimSource(0, 7);
+    assertEquals(1L, source.next().getSeq());
+    source.skipTo(4);
     assertEquals(4L, source.next().getSeq());
     assertEquals(5L, source.next().getSeq());
     assertEquals(6L, source.next().getSeq());
+    assertEquals(7L, source.next().getSeq());
     assertFalse(source.hasNext());
   }
 

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/server/RandomMcsClaimGeneratorTest.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/server/RandomMcsClaimGeneratorTest.java
@@ -38,350 +38,339 @@ public class RandomMcsClaimGeneratorTest {
                 .build());
     final McsClaim claim = generator.randomClaim();
     final String json = JsonFormat.printer().print(claim);
+    assertEquals(1, generator.getPreviousSequenceNumber());
     assertEquals(claim.getIdrDtlCnt(), claim.getMcsDetailsList().size());
     for (McsDiagnosisCode diagnosisCode : claim.getMcsDiagnosisCodesList()) {
       assertEquals(claim.getIdrClmHdIcn(), diagnosisCode.getIdrClmHdIcn());
     }
     assertEquals(
-        "{\n"
-            + "  \"idrClmHdIcn\": \"212941673334303\",\n"
-            + "  \"idrContrId\": \"2\",\n"
-            + "  \"idrHic\": \"922470\",\n"
-            + "  \"idrDtlCnt\": 3,\n"
-            + "  \"idrBeneLast16\": \"xm\",\n"
-            + "  \"idrBeneFirstInit\": \"g\",\n"
-            + "  \"idrBeneMidInit\": \"c\",\n"
-            + "  \"idrStatusCodeEnum\": \"STATUS_CODE_APPROVED_AND_PAID_D\",\n"
-            + "  \"idrStatusDate\": \"2021-06-16\",\n"
-            + "  \"idrBillProvNpi\": \"d6fdchd69\",\n"
-            + "  \"idrBillProvNum\": \"6285\",\n"
-            + "  \"idrBillProvEin\": \"zvzf\",\n"
-            + "  \"idrBillProvType\": \"rx\",\n"
-            + "  \"idrBillProvSpec\": \"q7\",\n"
-            + "  \"idrBillProvPriceSpec\": \"0\",\n"
-            + "  \"idrBillProvCounty\": \"n\",\n"
-            + "  \"idrBillProvLoc\": \"39\",\n"
-            + "  \"idrTotAllowed\": \"326.33\",\n"
-            + "  \"idrCoinsurance\": \"1709.09\",\n"
-            + "  \"idrDeductible\": \"72395.23\",\n"
-            + "  \"idrTotBilledAmt\": \"65.06\",\n"
-            + "  \"idrClaimReceiptDate\": \"2021-03-31\",\n"
-            + "  \"idrClaimMbi\": \"978t9bxjj24\",\n"
-            + "  \"mcsDiagnosisCodes\": [{\n"
-            + "    \"idrClmHdIcn\": \"212941673334303\",\n"
-            + "    \"idrDiagIcdTypeEnum\": \"DIAGNOSIS_ICD_TYPE_ICD10\",\n"
-            + "    \"idrDiagCode\": \"v4j\",\n"
-            + "    \"rdaPosition\": 1\n"
-            + "  }, {\n"
-            + "    \"idrClmHdIcn\": \"212941673334303\",\n"
-            + "    \"idrDiagIcdTypeEnum\": \"DIAGNOSIS_ICD_TYPE_ICD9\",\n"
-            + "    \"idrDiagCode\": \"bsr\",\n"
-            + "    \"rdaPosition\": 2\n"
-            + "  }, {\n"
-            + "    \"idrClmHdIcn\": \"212941673334303\",\n"
-            + "    \"idrDiagCode\": \"kn\",\n"
-            + "    \"idrDiagIcdTypeUnrecognized\": \"r\",\n"
-            + "    \"rdaPosition\": 3\n"
-            + "  }, {\n"
-            + "    \"idrClmHdIcn\": \"212941673334303\",\n"
-            + "    \"idrDiagCode\": \"1p34\",\n"
-            + "    \"idrDiagIcdTypeUnrecognized\": \"j\",\n"
-            + "    \"rdaPosition\": 4\n"
-            + "  }, {\n"
-            + "    \"idrClmHdIcn\": \"212941673334303\",\n"
-            + "    \"idrDiagIcdTypeEnum\": \"DIAGNOSIS_ICD_TYPE_ICD10\",\n"
-            + "    \"idrDiagCode\": \"jb0m2\",\n"
-            + "    \"rdaPosition\": 5\n"
-            + "  }, {\n"
-            + "    \"idrClmHdIcn\": \"212941673334303\",\n"
-            + "    \"idrDiagCode\": \"k\",\n"
-            + "    \"idrDiagIcdTypeUnrecognized\": \"s\",\n"
-            + "    \"rdaPosition\": 6\n"
-            + "  }],\n"
-            + "  \"mcsDetails\": [{\n"
-            + "    \"idrDtlFromDate\": \"2021-04-22\",\n"
-            + "    \"idrDtlToDate\": \"2021-04-22\",\n"
-            + "    \"idrProcCode\": \"q2\",\n"
-            + "    \"idrModOne\": \"dt\",\n"
-            + "    \"idrModTwo\": \"xq\",\n"
-            + "    \"idrModThree\": \"t\",\n"
-            + "    \"idrModFour\": \"tm\",\n"
-            + "    \"idrDtlPrimaryDiagCode\": \"8x4k854\",\n"
-            + "    \"idrKPosLnameOrg\": \"jgnvgswfffxcpqqqhjwfhftprhxnwtmvcdkkzz\",\n"
-            + "    \"idrKPosFname\": \"svsctnnkjjqnqr\",\n"
-            + "    \"idrKPosMname\": \"fvfrbj\",\n"
-            + "    \"idrKPosAddr1\": \"48sscv0475m4pbj5x2p0k1qbtnnb\",\n"
-            + "    \"idrKPosAddr21st\": \"22hdc64zvgh7qx988jm3zsrc1mh\",\n"
-            + "    \"idrKPosAddr22nd\": \"w44zwdj030xphz87p7p7\",\n"
-            + "    \"idrKPosCity\": \"qncmshzqgcdgfwngzwtvvwtdnjrwrr\",\n"
-            + "    \"idrKPosState\": \"td\",\n"
-            + "    \"idrKPosZip\": \"31974158965575\",\n"
-            + "    \"idrDtlDiagIcdTypeUnrecognized\": \"p\",\n"
-            + "    \"idrDtlStatusUnrecognized\": \"w\",\n"
-            + "    \"idrTosEnum\": \"TYPE_OF_SERVICE_SECOND_OPINION_ON_ELECTIVE_SURGERY\",\n"
-            + "    \"idrTwoDigitPosEnum\": \"TWO_DIGIT_PLAN_OF_SERVICE_INDEPENDENT_CLINIC\",\n"
-            + "    \"idrDtlRendType\": \"9\",\n"
-            + "    \"idrDtlRendSpec\": \"4\",\n"
-            + "    \"idrDtlRendNpi\": \"0dq9g\",\n"
-            + "    \"idrDtlRendProv\": \"8ftzksvsh\",\n"
-            + "    \"idrKDtlFacProvNpi\": \"k9nh13zws\",\n"
-            + "    \"idrDtlAmbPickupAddres1\": \"0vp9qf9\",\n"
-            + "    \"idrDtlAmbPickupAddres2\": \"w5x\",\n"
-            + "    \"idrDtlAmbPickupCity\": \"vtf0px\",\n"
-            + "    \"idrDtlAmbPickupState\": \"c\",\n"
-            + "    \"idrDtlAmbPickupZipcode\": \"w\",\n"
-            + "    \"idrDtlAmbDropoffName\": \"hdbpsrhg8s1frw35dg1mp47\",\n"
-            + "    \"idrDtlAmbDropoffAddrL1\": \"gfzxjm5pq6dmw8bt\",\n"
-            + "    \"idrDtlAmbDropoffAddrL2\": \"3q\",\n"
-            + "    \"idrDtlAmbDropoffCity\": \"874r8sm4m2ppm42\",\n"
-            + "    \"idrDtlAmbDropoffState\": \"8\",\n"
-            + "    \"idrDtlAmbDropoffZipcode\": \"1h5qrgv\",\n"
-            + "    \"idrDtlNumber\": 1\n"
-            + "  }, {\n"
-            + "    \"idrDtlStatusEnum\": \"DETAIL_STATUS_PENDING\",\n"
-            + "    \"idrDtlFromDate\": \"2021-01-12\",\n"
-            + "    \"idrDtlToDate\": \"2021-01-12\",\n"
-            + "    \"idrProcCode\": \"2t7\",\n"
-            + "    \"idrModOne\": \"s6\",\n"
-            + "    \"idrModTwo\": \"mt\",\n"
-            + "    \"idrModThree\": \"hm\",\n"
-            + "    \"idrModFour\": \"6\",\n"
-            + "    \"idrDtlPrimaryDiagCode\": \"bd3jz\",\n"
-            + "    \"idrKPosLnameOrg\": \"cgkpbdpwcschkgfdjnjshsqkhdffrzbkbhtkmjqcbcfcgz\",\n"
-            + "    \"idrKPosFname\": \"jddsbtsbkqnwvzcgnvjdp\",\n"
-            + "    \"idrKPosMname\": \"ctxghttkhdpngbghfpnb\",\n"
-            + "    \"idrKPosAddr1\": \"5g2v7qv6qn3770rh6xpr\",\n"
-            + "    \"idrKPosAddr21st\": \"mggmhsdxm19213cfs\",\n"
-            + "    \"idrKPosAddr22nd\": \"5qt65kbghfg3kwqqczs6vvhkz\",\n"
-            + "    \"idrKPosCity\": \"wwbwdmcpgbxkmjxdqvctwqmz\",\n"
-            + "    \"idrKPosState\": \"gv\",\n"
-            + "    \"idrKPosZip\": \"768036076\",\n"
-            + "    \"idrDtlDiagIcdTypeUnrecognized\": \"c\",\n"
-            + "    \"idrTosUnrecognized\": \"n\",\n"
-            + "    \"idrTwoDigitPosUnrecognized\": \"c0\",\n"
-            + "    \"idrDtlRendType\": \"w\",\n"
-            + "    \"idrDtlRendSpec\": \"t\",\n"
-            + "    \"idrDtlRendNpi\": \"0850gpz2qw\",\n"
-            + "    \"idrDtlRendProv\": \"nn46pf7hw\",\n"
-            + "    \"idrKDtlFacProvNpi\": \"f7\",\n"
-            + "    \"idrDtlAmbPickupAddres1\": \"8x48c935s\",\n"
-            + "    \"idrDtlAmbPickupAddres2\": \"x58hbk9snz32jh8xz\",\n"
-            + "    \"idrDtlAmbPickupCity\": \"32mhgt3ww4wvmgz9m4\",\n"
-            + "    \"idrDtlAmbPickupState\": \"c\",\n"
-            + "    \"idrDtlAmbPickupZipcode\": \"rcjbw9\",\n"
-            + "    \"idrDtlAmbDropoffName\": \"hq307m0jbtpbn0vc5b\",\n"
-            + "    \"idrDtlAmbDropoffAddrL1\": \"zgv4fvmzz7q\",\n"
-            + "    \"idrDtlAmbDropoffAddrL2\": \"np136vsmv7g51z\",\n"
-            + "    \"idrDtlAmbDropoffCity\": \"bw37q1\",\n"
-            + "    \"idrDtlAmbDropoffState\": \"1v\",\n"
-            + "    \"idrDtlAmbDropoffZipcode\": \"z\",\n"
-            + "    \"idrDtlNumber\": 2\n"
-            + "  }, {\n"
-            + "    \"idrDtlFromDate\": \"2021-02-02\",\n"
-            + "    \"idrDtlToDate\": \"2021-02-02\",\n"
-            + "    \"idrProcCode\": \"6w\",\n"
-            + "    \"idrModOne\": \"t\",\n"
-            + "    \"idrModTwo\": \"7\",\n"
-            + "    \"idrModThree\": \"pg\",\n"
-            + "    \"idrModFour\": \"6\",\n"
-            + "    \"idrDtlPrimaryDiagCode\": \"sjjct\",\n"
-            + "    \"idrKPosLnameOrg\": \"bvmspqfpqzqmzkvwhcfzcmwrqzdsqnpbjpfctzfnbdhtttrpdgmbxxmrjq\",\n"
-            + "    \"idrKPosFname\": \"mjvmfthnrnqqnhzndxvhgkccphzsbt\",\n"
-            + "    \"idrKPosMname\": \"qxjmbth\",\n"
-            + "    \"idrKPosAddr1\": \"vx342s\",\n"
-            + "    \"idrKPosAddr21st\": \"wzp0t7gd13\",\n"
-            + "    \"idrKPosAddr22nd\": \"89nc2sp6bqq83f2bb2\",\n"
-            + "    \"idrKPosCity\": \"dqfbrjzvkgjzmc\",\n"
-            + "    \"idrKPosState\": \"k\",\n"
-            + "    \"idrKPosZip\": \"87915092362\",\n"
-            + "    \"idrDtlDiagIcdTypeUnrecognized\": \"t\",\n"
-            + "    \"idrDtlStatusUnrecognized\": \"z\",\n"
-            + "    \"idrTosUnrecognized\": \"t\",\n"
-            + "    \"idrTwoDigitPosUnrecognized\": \"n0\",\n"
-            + "    \"idrDtlRendType\": \"w\",\n"
-            + "    \"idrDtlRendSpec\": \"n\",\n"
-            + "    \"idrDtlRendNpi\": \"pvf7q\",\n"
-            + "    \"idrDtlRendProv\": \"0\",\n"
-            + "    \"idrKDtlFacProvNpi\": \"xsf4\",\n"
-            + "    \"idrDtlAmbPickupAddres1\": \"544gdh59g\",\n"
-            + "    \"idrDtlAmbPickupAddres2\": \"qb3zd1mgj\",\n"
-            + "    \"idrDtlAmbPickupCity\": \"z\",\n"
-            + "    \"idrDtlAmbPickupState\": \"c8\",\n"
-            + "    \"idrDtlAmbPickupZipcode\": \"6w\",\n"
-            + "    \"idrDtlAmbDropoffName\": \"bwph7wkksmfhg814s9x\",\n"
-            + "    \"idrDtlAmbDropoffAddrL1\": \"2j9f9p90pq41118fz97cqh\",\n"
-            + "    \"idrDtlAmbDropoffAddrL2\": \"ms8xjxrhq94xbb00nb\",\n"
-            + "    \"idrDtlAmbDropoffCity\": \"mzf5phf\",\n"
-            + "    \"idrDtlAmbDropoffState\": \"5\",\n"
-            + "    \"idrDtlAmbDropoffZipcode\": \"9dm\",\n"
-            + "    \"idrDtlNumber\": 3\n"
-            + "  }],\n"
-            + "  \"idrClaimTypeUnrecognized\": \"c\",\n"
-            + "  \"idrBeneSexUnrecognized\": \"j\",\n"
-            + "  \"idrBillProvGroupIndUnrecognized\": \"b\",\n"
-            + "  \"idrBillProvStatusCdUnrecognized\": \"v\",\n"
-            + "  \"idrHdrFromDos\": \"2021-01-12\",\n"
-            + "  \"idrHdrToDos\": \"2021-04-22\",\n"
-            + "  \"idrAssignmentEnum\": \"CLAIM_ASSIGNMENT_NON_ASSIGNED_LAB_SERVICES\",\n"
-            + "  \"idrClmLevelIndEnum\": \"CLAIM_LEVEL_INDICATOR_VOID\",\n"
-            + "  \"idrHdrAudit\": 9360,\n"
-            + "  \"idrHdrAuditIndEnum\": \"AUDIT_INDICATOR_AUDIT_NUMBER\",\n"
-            + "  \"idrUSplitReasonEnum\": \"SPLIT_REASON_CODE_2ND_OPINION\",\n"
-            + "  \"idrJReferringProvNpi\": \"jhjfvs9\",\n"
-            + "  \"idrJFacProvNpi\": \"f\",\n"
-            + "  \"idrUDemoProvNpi\": \"j7\",\n"
-            + "  \"idrUSuperNpi\": \"pbdckqr7\",\n"
-            + "  \"idrUFcadjBilNpi\": \"cw0pskjw\",\n"
-            + "  \"idrAmbPickupAddresLine1\": \"jtvnhjmznt60hzcz5w7t\",\n"
-            + "  \"idrAmbPickupAddresLine2\": \"c4tdhr36pp\",\n"
-            + "  \"idrAmbPickupCity\": \"4p\",\n"
-            + "  \"idrAmbPickupState\": \"50\",\n"
-            + "  \"idrAmbPickupZipcode\": \"cpmb3\",\n"
-            + "  \"idrAmbDropoffName\": \"7dghwmqnx3\",\n"
-            + "  \"idrAmbDropoffAddrLine1\": \"njxn8639h559w\",\n"
-            + "  \"idrAmbDropoffAddrLine2\": \"ht6d8d87j\",\n"
-            + "  \"idrAmbDropoffCity\": \"nnnpqb892nks\",\n"
-            + "  \"idrAmbDropoffState\": \"g6\",\n"
-            + "  \"idrAmbDropoffZipcode\": \"bsrrw\",\n"
-            + "  \"mcsAudits\": [{\n"
-            + "    \"idrJAuditNum\": 30026,\n"
-            + "    \"idrJAuditIndUnrecognized\": \"9\",\n"
-            + "    \"idrJAuditDispUnrecognized\": \"4\",\n"
-            + "    \"rdaPosition\": 1\n"
-            + "  }, {\n"
-            + "    \"idrJAuditNum\": 16367,\n"
-            + "    \"idrJAuditIndUnrecognized\": \"n\",\n"
-            + "    \"idrJAuditDispEnum\": \"CUTBACK_AUDIT_DISPOSITION_DENY\",\n"
-            + "    \"rdaPosition\": 2\n"
-            + "  }, {\n"
-            + "    \"idrJAuditNum\": 30113,\n"
-            + "    \"idrJAuditIndUnrecognized\": \"7\",\n"
-            + "    \"idrJAuditDispUnrecognized\": \"4\",\n"
-            + "    \"rdaPosition\": 3\n"
-            + "  }, {\n"
-            + "    \"idrJAuditNum\": 15286,\n"
-            + "    \"idrJAuditIndUnrecognized\": \"s\",\n"
-            + "    \"idrJAuditDispEnum\": \"CUTBACK_AUDIT_DISPOSITION_AUDIT_OVERRIDDEN\",\n"
-            + "    \"rdaPosition\": 4\n"
-            + "  }, {\n"
-            + "    \"idrJAuditNum\": 20021,\n"
-            + "    \"idrJAuditIndUnrecognized\": \"p\",\n"
-            + "    \"idrJAuditDispEnum\": \"CUTBACK_AUDIT_DISPOSITION_EOMB_MESSAGE_ONLY\",\n"
-            + "    \"rdaPosition\": 5\n"
-            + "  }, {\n"
-            + "    \"idrJAuditNum\": 14325,\n"
-            + "    \"idrJAuditIndUnrecognized\": \"j\",\n"
-            + "    \"idrJAuditDispUnrecognized\": \"z\",\n"
-            + "    \"rdaPosition\": 6\n"
-            + "  }],\n"
-            + "  \"mcsLocations\": [{\n"
-            + "    \"idrLocClerk\": \"gh\",\n"
-            + "    \"idrLocCode\": \"8\",\n"
-            + "    \"idrLocDate\": \"2021-01-28\",\n"
-            + "    \"idrLocActvCodeEnum\": \"LOCATION_ACTIVITY_CODE_FINANCIAL_RESPONSE_ACTIVITY\",\n"
-            + "    \"rdaPosition\": 1\n"
-            + "  }, {\n"
-            + "    \"idrLocClerk\": \"m\",\n"
-            + "    \"idrLocCode\": \"b4r\",\n"
-            + "    \"idrLocDate\": \"2021-01-18\",\n"
-            + "    \"idrLocActvCodeEnum\": \"LOCATION_ACTIVITY_CODE_MAINTENANCE_APPLIED_FROM_WORKSHEET_F\",\n"
-            + "    \"rdaPosition\": 2\n"
-            + "  }, {\n"
-            + "    \"idrLocClerk\": \"378k\",\n"
-            + "    \"idrLocCode\": \"k74\",\n"
-            + "    \"idrLocDate\": \"2021-03-30\",\n"
-            + "    \"idrLocActvCodeUnrecognized\": \"0\",\n"
-            + "    \"rdaPosition\": 3\n"
-            + "  }, {\n"
-            + "    \"idrLocClerk\": \"t\",\n"
-            + "    \"idrLocCode\": \"4\",\n"
-            + "    \"idrLocDate\": \"2021-06-21\",\n"
-            + "    \"idrLocActvCodeEnum\": \"LOCATION_ACTIVITY_CODE_ACTIVATION_ACTIVITY\",\n"
-            + "    \"rdaPosition\": 4\n"
-            + "  }],\n"
-            + "  \"mcsAdjustments\": [{\n"
-            + "    \"idrAdjDate\": \"2021-03-11\",\n"
-            + "    \"idrXrefIcn\": \"xmxj\",\n"
-            + "    \"idrAdjClerk\": \"320\",\n"
-            + "    \"idrInitCcn\": \"t96h\",\n"
-            + "    \"idrAdjChkWrtDt\": \"2021-06-16\",\n"
-            + "    \"idrAdjBEombAmt\": \"10.13\",\n"
-            + "    \"idrAdjPEombAmt\": \"194.27\",\n"
-            + "    \"rdaPosition\": 1\n"
-            + "  }, {\n"
-            + "    \"idrAdjDate\": \"2021-01-21\",\n"
-            + "    \"idrXrefIcn\": \"z270m\",\n"
-            + "    \"idrAdjClerk\": \"qb\",\n"
-            + "    \"idrInitCcn\": \"f0g03sj\",\n"
-            + "    \"idrAdjChkWrtDt\": \"2021-04-21\",\n"
-            + "    \"idrAdjBEombAmt\": \"2185.24\",\n"
-            + "    \"idrAdjPEombAmt\": \"48855.78\",\n"
-            + "    \"rdaPosition\": 2\n"
-            + "  }, {\n"
-            + "    \"idrAdjDate\": \"2021-06-28\",\n"
-            + "    \"idrXrefIcn\": \"kq4rbc3\",\n"
-            + "    \"idrAdjClerk\": \"dz6\",\n"
-            + "    \"idrInitCcn\": \"sq2kh\",\n"
-            + "    \"idrAdjChkWrtDt\": \"2021-06-02\",\n"
-            + "    \"idrAdjBEombAmt\": \"16.13\",\n"
-            + "    \"idrAdjPEombAmt\": \"8943.66\",\n"
-            + "    \"rdaPosition\": 3\n"
-            + "  }, {\n"
-            + "    \"idrAdjDate\": \"2021-03-28\",\n"
-            + "    \"idrXrefIcn\": \"qt3z\",\n"
-            + "    \"idrAdjClerk\": \"k5\",\n"
-            + "    \"idrInitCcn\": \"zs6q6q8g158\",\n"
-            + "    \"idrAdjChkWrtDt\": \"2021-01-17\",\n"
-            + "    \"idrAdjBEombAmt\": \"713.08\",\n"
-            + "    \"idrAdjPEombAmt\": \"7.06\",\n"
-            + "    \"rdaPosition\": 4\n"
-            + "  }, {\n"
-            + "    \"idrAdjDate\": \"2021-01-03\",\n"
-            + "    \"idrXrefIcn\": \"15ctbq7rb9fwhzt\",\n"
-            + "    \"idrAdjClerk\": \"z\",\n"
-            + "    \"idrInitCcn\": \"k5mvp3k\",\n"
-            + "    \"idrAdjChkWrtDt\": \"2021-04-09\",\n"
-            + "    \"idrAdjBEombAmt\": \"74.75\",\n"
-            + "    \"idrAdjPEombAmt\": \"4985.31\",\n"
-            + "    \"rdaPosition\": 5\n"
-            + "  }, {\n"
-            + "    \"idrAdjDate\": \"2021-02-05\",\n"
-            + "    \"idrXrefIcn\": \"jvn64s5r4qb6\",\n"
-            + "    \"idrAdjClerk\": \"r995\",\n"
-            + "    \"idrInitCcn\": \"jkrd69\",\n"
-            + "    \"idrAdjChkWrtDt\": \"2021-04-17\",\n"
-            + "    \"idrAdjBEombAmt\": \"913.50\",\n"
-            + "    \"idrAdjPEombAmt\": \"8.87\",\n"
-            + "    \"rdaPosition\": 6\n"
-            + "  }, {\n"
-            + "    \"idrAdjDate\": \"2021-01-25\",\n"
-            + "    \"idrXrefIcn\": \"9bq\",\n"
-            + "    \"idrAdjClerk\": \"hk\",\n"
-            + "    \"idrInitCcn\": \"6180\",\n"
-            + "    \"idrAdjChkWrtDt\": \"2021-01-17\",\n"
-            + "    \"idrAdjBEombAmt\": \"67.97\",\n"
-            + "    \"idrAdjPEombAmt\": \"73.67\",\n"
-            + "    \"rdaPosition\": 7\n"
-            + "  }, {\n"
-            + "    \"idrAdjDate\": \"2021-04-23\",\n"
-            + "    \"idrXrefIcn\": \"s\",\n"
-            + "    \"idrAdjClerk\": \"pj4j\",\n"
-            + "    \"idrInitCcn\": \"wc\",\n"
-            + "    \"idrAdjChkWrtDt\": \"2021-05-18\",\n"
-            + "    \"idrAdjBEombAmt\": \"30262.95\",\n"
-            + "    \"idrAdjPEombAmt\": \"16464.26\",\n"
-            + "    \"rdaPosition\": 8\n"
-            + "  }, {\n"
-            + "    \"idrAdjDate\": \"2021-05-18\",\n"
-            + "    \"idrXrefIcn\": \"5rnjvb7r8tqjnm2\",\n"
-            + "    \"idrAdjClerk\": \"3b\",\n"
-            + "    \"idrInitCcn\": \"f5w98zrjhcjsbw\",\n"
-            + "    \"idrAdjChkWrtDt\": \"2021-03-05\",\n"
-            + "    \"idrAdjBEombAmt\": \"20.31\",\n"
-            + "    \"idrAdjPEombAmt\": \"5676.34\",\n"
-            + "    \"rdaPosition\": 9\n"
-            + "  }]\n"
-            + "}",
+        """
+{
+  "idrClmHdIcn": "543185449367619",
+  "idrContrId": "0546",
+  "idrHic": "935301121",
+  "idrDtlCnt": 3,
+  "idrBeneLast16": "bg",
+  "idrBeneFirstInit": "c",
+  "idrBeneMidInit": "k",
+  "idrBeneSexEnum": "BENEFICIARY_SEX_MALE",
+  "idrStatusCodeEnum": "STATUS_CODE_ADJUSTED",
+  "idrStatusDate": "2021-05-24",
+  "idrBillProvNpi": "db",
+  "idrBillProvNum": "9743",
+  "idrBillProvEin": "zrcfgs7",
+  "idrBillProvType": "h",
+  "idrBillProvSpec": "cm",
+  "idrBillProvGroupIndEnum": "BILLING_PROVIDER_INDICATOR_GROUP",
+  "idrBillProvPriceSpec": "1",
+  "idrBillProvCounty": "1r",
+  "idrBillProvLoc": "84",
+  "idrTotAllowed": "50055.81",
+  "idrCoinsurance": "95.89",
+  "idrDeductible": "9894.24",
+  "idrTotBilledAmt": "866.34",
+  "idrClaimReceiptDate": "2021-06-18",
+  "idrClaimMbi": "k71641b7gm3",
+  "mcsDiagnosisCodes": [{
+    "idrClmHdIcn": "543185449367619",
+    "idrDiagCode": "p",
+    "idrDiagIcdTypeUnrecognized": "s",
+    "rdaPosition": 1
+  }, {
+    "idrClmHdIcn": "543185449367619",
+    "idrDiagIcdTypeEnum": "DIAGNOSIS_ICD_TYPE_ICD10",
+    "idrDiagCode": "c3pz04",
+    "rdaPosition": 2
+  }, {
+    "idrClmHdIcn": "543185449367619",
+    "idrDiagIcdTypeEnum": "DIAGNOSIS_ICD_TYPE_ICD9",
+    "idrDiagCode": "3hm99",
+    "rdaPosition": 3
+  }, {
+    "idrClmHdIcn": "543185449367619",
+    "idrDiagCode": "c",
+    "idrDiagIcdTypeUnrecognized": "s",
+    "rdaPosition": 4
+  }, {
+    "idrClmHdIcn": "543185449367619",
+    "idrDiagCode": "g88",
+    "idrDiagIcdTypeUnrecognized": "d",
+    "rdaPosition": 5
+  }, {
+    "idrClmHdIcn": "543185449367619",
+    "idrDiagCode": "vwmb",
+    "idrDiagIcdTypeUnrecognized": "x",
+    "rdaPosition": 6
+  }],
+  "mcsDetails": [{
+    "idrDtlStatusEnum": "DETAIL_STATUS_REJECTED",
+    "idrDtlFromDate": "2021-03-08",
+    "idrDtlToDate": "2021-03-08",
+    "idrProcCode": "n",
+    "idrModOne": "5",
+    "idrModTwo": "k",
+    "idrModThree": "q",
+    "idrModFour": "v3",
+    "idrDtlPrimaryDiagCode": "k",
+    "idrKPosLnameOrg": "pggtbgjwkmztsfjvjzgtcpbkhfhmzxhpdnqsrzqjvbpgthdsxpsrk",
+    "idrKPosFname": "pcrstwdwfthjxwbbmzgzjthbrfjr",
+    "idrKPosMname": "gqkbtrk",
+    "idrKPosAddr1": "4btxhsqcz68vc",
+    "idrKPosAddr21st": "fgp2f0q408xvhcwv1fs7hz6r9pw",
+    "idrKPosAddr22nd": "tsn",
+    "idrKPosCity": "qbcmjpdsfzzhqwbrvrxdnjqcdzhp",
+    "idrKPosState": "fr",
+    "idrKPosZip": "1061715129",
+    "idrDtlDiagIcdTypeUnrecognized": "p",
+    "idrTosEnum": "TYPE_OF_SERVICE_ASSISTANCE_AT_SURGERY",
+    "idrTwoDigitPosEnum": "TWO_DIGIT_PLAN_OF_SERVICE_COMPREHENSIVE_OUTPATIENT_REHABILITATION_FACILITY",
+    "idrDtlRendType": "5n",
+    "idrDtlRendSpec": "81",
+    "idrDtlRendNpi": "2cjn",
+    "idrDtlRendProv": "cr1bnkb3",
+    "idrKDtlFacProvNpi": "x4wz142gr",
+    "idrDtlAmbPickupAddres1": "0qvnn4rpj93q728c1d7n9x3m7",
+    "idrDtlAmbPickupAddres2": "6z4dxbxvkv3",
+    "idrDtlAmbPickupCity": "qs05mkp3bkm2s5c3ktm",
+    "idrDtlAmbPickupState": "2",
+    "idrDtlAmbPickupZipcode": "t01",
+    "idrDtlAmbDropoffName": "djfj8",
+    "idrDtlAmbDropoffAddrL1": "gwd0hb70d0gpb3px",
+    "idrDtlAmbDropoffAddrL2": "b6cttknhfwg",
+    "idrDtlAmbDropoffCity": "ds",
+    "idrDtlAmbDropoffState": "01",
+    "idrDtlAmbDropoffZipcode": "88jcc14",
+    "idrDtlNumber": 1
+  }, {
+    "idrDtlFromDate": "2021-04-12",
+    "idrDtlToDate": "2021-04-12",
+    "idrProcCode": "k",
+    "idrModOne": "n",
+    "idrModTwo": "9",
+    "idrModThree": "cb",
+    "idrModFour": "0v",
+    "idrDtlDiagIcdTypeEnum": "DIAGNOSIS_ICD_TYPE_ICD9",
+    "idrDtlPrimaryDiagCode": "w",
+    "idrKPosLnameOrg": "wxsdbmvqwhdpgvqkhnzmpqtzkdvczxhwxjmfbwwqshndhbpckrvcmngc",
+    "idrKPosFname": "nmctkmdjkxgnsddnqthbwqbgcbzbjb",
+    "idrKPosMname": "mpmsjjqxdhdrknb",
+    "idrKPosAddr1": "0z4p95cqnq4tg6wg1wd1sdkxschm4nvzwbnwt05dg5tsw8q1xcwfw5",
+    "idrKPosAddr21st": "0",
+    "idrKPosAddr22nd": "6wmnd13g7gj61qs8w4rdxcht",
+    "idrKPosCity": "wcgk",
+    "idrKPosState": "kc",
+    "idrKPosZip": "395749",
+    "idrDtlStatusUnrecognized": "b",
+    "idrTosEnum": "TYPE_OF_SERVICE_DME_PRESCRIPTION",
+    "idrTwoDigitPosUnrecognized": "s",
+    "idrDtlRendType": "x",
+    "idrDtlRendSpec": "m",
+    "idrDtlRendNpi": "dvb",
+    "idrDtlRendProv": "p7bpvdkc",
+    "idrKDtlFacProvNpi": "p061",
+    "idrDtlAmbPickupAddres1": "6zzkc06vrf8qq70961rz2",
+    "idrDtlAmbPickupAddres2": "v6tv",
+    "idrDtlAmbPickupCity": "1d7gvd3gd198pdtk",
+    "idrDtlAmbPickupState": "zz",
+    "idrDtlAmbPickupZipcode": "bw9d",
+    "idrDtlAmbDropoffName": "wfh4p5jgpdg5jszdrcb6j2ns",
+    "idrDtlAmbDropoffAddrL1": "bs954dwjq3m85ndjdgdjwjcq",
+    "idrDtlAmbDropoffAddrL2": "29dd4d3",
+    "idrDtlAmbDropoffCity": "9hrhpnjnw8tq3c0m7jt4",
+    "idrDtlAmbDropoffState": "hj",
+    "idrDtlAmbDropoffZipcode": "r",
+    "idrDtlNumber": 2
+  }, {
+    "idrDtlFromDate": "2021-03-29",
+    "idrDtlToDate": "2021-03-29",
+    "idrProcCode": "kzg4b",
+    "idrModOne": "3j",
+    "idrModTwo": "pj",
+    "idrModThree": "k",
+    "idrModFour": "n",
+    "idrDtlPrimaryDiagCode": "07d",
+    "idrKPosLnameOrg": "gqnrrphtwszfhdqvnbcsvgxsrpfzcdbfcxgstzhcrfbvznspht",
+    "idrKPosFname": "hvr",
+    "idrKPosMname": "tsdwjfsr",
+    "idrKPosAddr1": "vd0c6mvws5hzmvmvtmbjcx7p9m1f1dvg0n03whcnb078f6m2wkjq",
+    "idrKPosAddr21st": "xsg6qhr8f4n34c77gqzz7",
+    "idrKPosAddr22nd": "sv3fzr7tzn3hw",
+    "idrKPosCity": "cjmbrcs",
+    "idrKPosState": "r",
+    "idrKPosZip": "97239824074",
+    "idrDtlDiagIcdTypeUnrecognized": "h",
+    "idrDtlStatusUnrecognized": "n",
+    "idrTosUnrecognized": "v",
+    "idrTwoDigitPosEnum": "TWO_DIGIT_PLAN_OF_SERVICE_INDEPENDENT_CLINIC",
+    "idrDtlRendType": "f",
+    "idrDtlRendSpec": "z",
+    "idrDtlRendNpi": "918q",
+    "idrDtlRendProv": "kr23h9k4f6",
+    "idrKDtlFacProvNpi": "tf9ncj",
+    "idrDtlAmbPickupAddres1": "z",
+    "idrDtlAmbPickupAddres2": "tzvvnxcst5zcc8pvb",
+    "idrDtlAmbPickupCity": "zj2p94m3hjct",
+    "idrDtlAmbPickupState": "d",
+    "idrDtlAmbPickupZipcode": "2hx",
+    "idrDtlAmbDropoffName": "rn93",
+    "idrDtlAmbDropoffAddrL1": "g379h9z14qpwj",
+    "idrDtlAmbDropoffAddrL2": "b36rjh56",
+    "idrDtlAmbDropoffCity": "k435qcfd53whjf5txf",
+    "idrDtlAmbDropoffState": "gs",
+    "idrDtlAmbDropoffZipcode": "qqwq",
+    "idrDtlNumber": 3
+  }],
+  "idrClaimTypeUnrecognized": "h",
+  "idrBillProvStatusCdUnrecognized": "s",
+  "idrHdrFromDos": "2021-03-08",
+  "idrHdrToDos": "2021-04-12",
+  "idrAssignmentEnum": "CLAIM_ASSIGNMENT_NON_ASSIGNED_LAB_SERVICES",
+  "idrClmLevelIndUnrecognized": "9",
+  "idrHdrAudit": 28109,
+  "idrHdrAuditIndEnum": "AUDIT_INDICATOR_AUDIT_NUMBER",
+  "idrUSplitReasonEnum": "SPLIT_REASON_CODE_KIDNEY_DONOR",
+  "idrJReferringProvNpi": "h5xbd3",
+  "idrJFacProvNpi": "brpb24",
+  "idrUDemoProvNpi": "qbrsqrw9",
+  "idrUSuperNpi": "8crf7m43j9",
+  "idrUFcadjBilNpi": "g4gj4sf",
+  "idrAmbPickupAddresLine1": "4jvn1w5z5706s3mw",
+  "idrAmbPickupAddresLine2": "pst59d0",
+  "idrAmbPickupCity": "xbn02z37f",
+  "idrAmbPickupState": "37",
+  "idrAmbPickupZipcode": "h1",
+  "idrAmbDropoffName": "rjps29fczvd5f6g0fjppk",
+  "idrAmbDropoffAddrLine1": "84m013kgpfxcbbpszzh977hzc",
+  "idrAmbDropoffAddrLine2": "4ck32",
+  "idrAmbDropoffCity": "f0qw",
+  "idrAmbDropoffState": "x",
+  "idrAmbDropoffZipcode": "ggtmg3wp",
+  "mcsAudits": [{
+    "idrJAuditNum": 32488,
+    "idrJAuditIndEnum": "CUTBACK_AUDIT_INDICATOR_HEADER_EDIT_NUMBER",
+    "idrJAuditDispUnrecognized": "x",
+    "rdaPosition": 1
+  }, {
+    "idrJAuditNum": 6771,
+    "idrJAuditIndEnum": "CUTBACK_AUDIT_INDICATOR__AUDIT_NUM_IS_ZEROES",
+    "idrJAuditDispUnrecognized": "t",
+    "rdaPosition": 2
+  }, {
+    "idrJAuditNum": 15930,
+    "idrJAuditIndUnrecognized": "k",
+    "idrJAuditDispEnum": "CUTBACK_AUDIT_DISPOSITION_MODIFIER_51",
+    "rdaPosition": 3
+  }, {
+    "idrJAuditNum": 25878,
+    "idrJAuditIndUnrecognized": "b",
+    "idrJAuditDispEnum": "CUTBACK_AUDIT_DISPOSITION_REDUCE_BY_SUM_OF_PRIOR_PAYMENTS",
+    "rdaPosition": 4
+  }, {
+    "idrJAuditNum": 1044,
+    "idrJAuditIndUnrecognized": "t",
+    "idrJAuditDispEnum": "CUTBACK_AUDIT_DISPOSITION_REDUCE_BY_SUM_OF_MATCHING_DATES",
+    "rdaPosition": 5
+  }, {
+    "idrJAuditNum": 17441,
+    "idrJAuditIndUnrecognized": "3",
+    "idrJAuditDispEnum": "CUTBACK_AUDIT_DISPOSITION_EOMB_MESSAGE_ONLY",
+    "rdaPosition": 6
+  }, {
+    "idrJAuditNum": 16211,
+    "idrJAuditIndEnum": "CUTBACK_AUDIT_INDICATOR_HEADER_EDIT_NUMBER",
+    "idrJAuditDispEnum": "CUTBACK_AUDIT_DISPOSITION_TRANSFER",
+    "rdaPosition": 7
+  }],
+  "mcsLocations": [{
+    "idrLocClerk": "t",
+    "idrLocCode": "d",
+    "idrLocDate": "2021-04-17",
+    "idrLocActvCodeUnrecognized": "x",
+    "rdaPosition": 1
+  }, {
+    "idrLocClerk": "9j",
+    "idrLocCode": "6kc",
+    "idrLocDate": "2021-03-04",
+    "idrLocActvCodeUnrecognized": "f",
+    "rdaPosition": 2
+  }, {
+    "idrLocClerk": "579",
+    "idrLocCode": "3jb",
+    "idrLocDate": "2021-05-21",
+    "idrLocActvCodeUnrecognized": "3",
+    "rdaPosition": 3
+  }, {
+    "idrLocClerk": "gzx",
+    "idrLocCode": "z",
+    "idrLocDate": "2021-05-22",
+    "idrLocActvCodeUnrecognized": "w",
+    "rdaPosition": 4
+  }, {
+    "idrLocClerk": "p5",
+    "idrLocCode": "kd2",
+    "idrLocDate": "2021-03-11",
+    "idrLocActvCodeEnum": "LOCATION_ACTIVITY_CODE_MAINTENANCE_APPLIED_FROM_WORKSHEET_F",
+    "rdaPosition": 5
+  }, {
+    "idrLocClerk": "5g7",
+    "idrLocCode": "cg",
+    "idrLocDate": "2021-05-11",
+    "idrLocActvCodeEnum": "LOCATION_ACTIVITY_CODE_CORRECTION_DOCUMENT_REPRINT",
+    "rdaPosition": 6
+  }, {
+    "idrLocClerk": "q6g3",
+    "idrLocCode": "ttf",
+    "idrLocDate": "2021-02-01",
+    "idrLocActvCodeEnum": "LOCATION_ACTIVITY_CODE_CLAIM_IS_MISSING",
+    "rdaPosition": 7
+  }],
+  "mcsAdjustments": [{
+    "idrAdjDate": "2021-04-02",
+    "idrXrefIcn": "j1ct",
+    "idrAdjClerk": "gz",
+    "idrInitCcn": "11hc3kgkv",
+    "idrAdjChkWrtDt": "2021-01-03",
+    "idrAdjBEombAmt": "380.38",
+    "idrAdjPEombAmt": "685.12",
+    "rdaPosition": 1
+  }, {
+    "idrAdjDate": "2021-02-13",
+    "idrXrefIcn": "jvqb45f5xfvn",
+    "idrAdjClerk": "jnz",
+    "idrInitCcn": "qfrm7fs9ws7",
+    "idrAdjChkWrtDt": "2021-06-26",
+    "idrAdjBEombAmt": "3983.09",
+    "idrAdjPEombAmt": "47308.33",
+    "rdaPosition": 2
+  }, {
+    "idrAdjDate": "2021-02-26",
+    "idrXrefIcn": "j14b9",
+    "idrAdjClerk": "8",
+    "idrInitCcn": "m81p0",
+    "idrAdjChkWrtDt": "2021-06-20",
+    "idrAdjBEombAmt": "8800.96",
+    "idrAdjPEombAmt": "501.81",
+    "rdaPosition": 3
+  }, {
+    "idrAdjDate": "2021-04-26",
+    "idrXrefIcn": "s4kb8c49b34j18",
+    "idrAdjClerk": "vn",
+    "idrInitCcn": "hzf12cg",
+    "idrAdjChkWrtDt": "2021-01-31",
+    "idrAdjBEombAmt": "43.34",
+    "idrAdjPEombAmt": "3.13",
+    "rdaPosition": 4
+  }, {
+    "idrAdjDate": "2021-04-04",
+    "idrXrefIcn": "rc9w3kvc67",
+    "idrAdjClerk": "0dw7",
+    "idrInitCcn": "mpvbt2p5fk7fpzf",
+    "idrAdjChkWrtDt": "2021-05-09",
+    "idrAdjBEombAmt": "166.38",
+    "idrAdjPEombAmt": "714.80",
+    "rdaPosition": 5
+  }]
+}""",
         json);
   }
 

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/server/RandomMcsClaimSourceTest.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/server/RandomMcsClaimSourceTest.java
@@ -74,16 +74,20 @@ public class RandomMcsClaimSourceTest {
   }
 
   /**
-   * Validates that the sequence numbers generated for claims is sequential.
+   * Validates that the sequence numbers generated for claims are sequential and start at 1.
    *
    * @throws Exception indicates test failure
    */
   @Test
   public void sequenceNumbers() throws Exception {
-    MessageSource<McsClaimChange> source = new RandomMcsClaimSource(0, 6).skipTo(3);
-    assertEquals(3L, source.next().getSeq());
-    assertEquals(4L, source.next().getSeq());
+    MessageSource<McsClaimChange> source = new RandomMcsClaimSource(0, 8);
+    assertEquals(1L, source.next().getSeq());
+    assertEquals(2L, source.next().getSeq());
+    source.skipTo(5);
     assertEquals(5L, source.next().getSeq());
+    assertEquals(6L, source.next().getSeq());
+    assertEquals(7L, source.next().getSeq());
+    assertEquals(8L, source.next().getSeq());
     assertFalse(source.hasNext());
   }
 

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/FissClaimStreamCallerIT.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/FissClaimStreamCallerIT.java
@@ -139,7 +139,7 @@ public class FissClaimStreamCallerIT {
     RdaServer.InProcessConfig.builder()
         .serverName(getClass().getSimpleName())
         .fissSourceFactory(
-            sequenceNumber -> new RandomFissClaimSource(1000L, 15).skipTo(sequenceNumber))
+            sequenceNumber -> new RandomFissClaimSource(1000L, 14).skipTo(sequenceNumber))
         .build()
         .runWithChannelParam(
             channel -> {

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/McsClaimStreamCallerIT.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/McsClaimStreamCallerIT.java
@@ -33,7 +33,7 @@ public class McsClaimStreamCallerIT {
     RdaServer.InProcessConfig.builder()
         .serverName(getClass().getSimpleName())
         .mcsSourceFactory(
-            sequenceNumber -> new RandomMcsClaimSource(1000L, 3).skipTo(sequenceNumber))
+            sequenceNumber -> new RandomMcsClaimSource(1000L, 2).skipTo(sequenceNumber))
         .build()
         .runWithChannelParam(
             channel -> {
@@ -64,7 +64,7 @@ public class McsClaimStreamCallerIT {
     RdaServer.InProcessConfig.builder()
         .serverName(getClass().getSimpleName())
         .mcsSourceFactory(
-            sequenceNumber -> new RandomMcsClaimSource(1000L, 15).skipTo(sequenceNumber))
+            sequenceNumber -> new RandomMcsClaimSource(1000L, 14).skipTo(sequenceNumber))
         .build()
         .runWithChannelParam(
             channel -> {


### PR DESCRIPTION
**JIRA Ticket:**
[PACA-1032](https://jira.cms.gov/browse/PACA-1032)

**User Story or Bug Summary:**

Improve realism of random claim generators compared to real RDA API.

Currently the random claim generators start with sequence number zero but the real RDA API starts with 1.  Change the random claim generators to start at sequence 1 and change any associated tests and/or logic to work properly with this change.
 

---

### What Does This PR Do?

Changes the starting sequence number and adjusts tests to reflect the change.

### What Should Reviewers Watch For?

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items to the following list here -->
* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [x] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [x] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [x] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* [PACA-1031](https://github.com/CMSgov/beneficiary-fhir-data/pull/1686) is the base branch for this change.  Can be MERGED before PACA-1031 is DEPLOYED though.


### Submitter Checklist

I have gone through and verified that...:

* [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] The data dictionary has been updated with any field mapping changes, if any were made.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    