### PR TITLE
BFD-2600: Adjust Coverage transformer to spring-managed class

### DIFF
--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/R4CoverageResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/R4CoverageResourceProvider.java
@@ -68,6 +68,8 @@ public final class R4CoverageResourceProvider implements IResourceProvider {
   private final MetricRegistry metricRegistry;
   /** The Loaded filter manager. */
   private final LoadedFilterManager loadedFilterManager;
+  /** The coverage transformer. */
+  private final CoverageTransformerV2 coverageTransformer;
 
   /**
    * Instantiates a new {@link R4CoverageResourceProvider}.
@@ -77,13 +79,18 @@ public final class R4CoverageResourceProvider implements IResourceProvider {
    *
    * @param metricRegistry the metric registry
    * @param loadedFilterManager the loaded filter manager
+   * @param coverageTransformer the coverage transformer
    */
   public R4CoverageResourceProvider(
-      MetricRegistry metricRegistry, LoadedFilterManager loadedFilterManager) {
+      MetricRegistry metricRegistry,
+      LoadedFilterManager loadedFilterManager,
+      CoverageTransformerV2 coverageTransformer) {
     requireNonNull(metricRegistry);
     requireNonNull(loadedFilterManager);
+    requireNonNull(coverageTransformer);
     this.metricRegistry = metricRegistry;
     this.loadedFilterManager = loadedFilterManager;
+    this.coverageTransformer = coverageTransformer;
   }
 
   /**
@@ -164,8 +171,7 @@ public final class R4CoverageResourceProvider implements IResourceProvider {
           new IdDt(Beneficiary.class.getSimpleName(), String.valueOf(beneficiaryId)));
     }
 
-    Coverage coverage =
-        CoverageTransformerV2.transform(metricRegistry, coverageIdSegment.get(), beneficiaryEntity);
+    Coverage coverage = coverageTransformer.transform(coverageIdSegment.get(), beneficiaryEntity);
     return coverage;
   }
 
@@ -205,7 +211,7 @@ public final class R4CoverageResourceProvider implements IResourceProvider {
     Long beneficiaryId = Long.parseLong(beneficiary.getIdPart());
     try {
       Beneficiary beneficiaryEntity = findBeneficiaryById(beneficiaryId, lastUpdated);
-      coverages = CoverageTransformerV2.transform(metricRegistry, beneficiaryEntity);
+      coverages = coverageTransformer.transform(beneficiaryEntity);
     } catch (NoResultException e) {
       coverages = new LinkedList<IBaseResource>();
     }

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/CoverageTransformerV2Test.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/CoverageTransformerV2Test.java
@@ -58,9 +58,13 @@ public final class CoverageTransformerV2Test {
           .appendPattern("dd-MMM-yyyy")
           .toFormatter();
 
+  /** The transformer under test. */
+  private CoverageTransformerV2 coverageTransformer;
+
   /** Sets up the test dependencies shared across each test. */
   @BeforeEach
   public void setup() {
+    coverageTransformer = new CoverageTransformerV2(new MetricRegistry());
     List<Object> parsedRecords =
         ServerTestUtils.parseData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
 
@@ -241,9 +245,7 @@ public final class CoverageTransformerV2Test {
     newBeneficiary.setLastUpdated(calen.getTime().toInstant());
     newBeneficiary.setBeneEnrollmentReferenceYear(Optional.empty());
 
-    Coverage newCoverage =
-        CoverageTransformerV2.transform(
-            new MetricRegistry(), MedicareSegment.PART_A, newBeneficiary);
+    Coverage newCoverage = coverageTransformer.transform(MedicareSegment.PART_A, newBeneficiary);
     checkForNoYearlyDate(newCoverage);
   }
 
@@ -779,10 +781,9 @@ public final class CoverageTransformerV2Test {
    * @param showJson {@code true} if the json should be printed to stdout
    * @throws FHIRException if there is an issue transforming the coverage
    */
-  public static void transformCoverage(MedicareSegment medSeg, boolean showJson)
-      throws FHIRException {
+  public void transformCoverage(MedicareSegment medSeg, boolean showJson) throws FHIRException {
     if (currSegment == null || currSegment != medSeg) {
-      coverage = CoverageTransformerV2.transform(new MetricRegistry(), medSeg, beneficiary);
+      coverage = coverageTransformer.transform(medSeg, beneficiary);
       currSegment = medSeg;
     }
     if (showJson && coverage != null) {

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/R4CoverageResourceProviderTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/R4CoverageResourceProviderTest.java
@@ -1,26 +1,64 @@
 package gov.cms.bfd.server.war.r4.providers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import ca.uhn.fhir.rest.api.Constants;
+import ca.uhn.fhir.rest.param.ReferenceParam;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import gov.cms.bfd.model.rif.Beneficiary;
+import gov.cms.bfd.model.rif.samples.StaticRifResourceGroup;
+import gov.cms.bfd.server.war.ServerTestUtils;
 import gov.cms.bfd.server.war.commons.LoadedFilterManager;
+import java.sql.Date;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.persistence.EntityManager;
+import javax.persistence.NoResultException;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Path;
+import javax.persistence.criteria.Root;
+import javax.persistence.criteria.Subquery;
+import javax.persistence.metamodel.SingularAttribute;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Coverage;
 import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Meta;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 /**
  * Units tests for the {@link R4CoverageResourceProvider} that do not require a full fhir setup to
  * validate. Anything we want to validate from the fhir client level should go in {@link
- * R4CoverageResourceProviderIT}.
+ * R4CoverageResourceProviderE2E}.
  */
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class R4CoverageResourceProviderTest {
 
   /** The class under test. */
@@ -33,17 +71,134 @@ public class R4CoverageResourceProviderTest {
   @Mock private MetricRegistry metricRegistry;
   /** The Loaded filter manager. */
   @Mock private LoadedFilterManager loadedFilterManager;
+  /** The mock coverage transformer. */
+  @Mock private CoverageTransformerV2 coverageTransformer;
+  /** The mock entity manager for mocking database calls. */
+  @Mock private EntityManager entityManager;
+  /** The mock query, for mocking DB returns. */
+  @Mock TypedQuery mockQuery;
+  /** The mock metric timer. */
+  @Mock Timer mockTimer;
+  /** The mock metric timer context (used to stop the metric). */
+  @Mock Timer.Context mockTimerContext;
+  /** Used to mock bene data for a bene search. */
+  @Mock ReferenceParam beneficiary;
+  /** The mocked request details. */
+  @Mock ServletRequestDetails requestDetails;
+
+  /** The test data bene. */
+  private Beneficiary testBene;
+
+  /** The mock coverage item. * */
+  @Mock private Coverage testCoverage;
+
+  /** A valid coverage id number. Abides by the coverage id pattern in the resource provider. */
+  private static final String VALID_PART_A_COVERAGE_ID = "part-a-1234";
 
   /** Sets up the test class. */
   @BeforeEach
   public void setup() {
-    coverageProvider = new R4CoverageResourceProvider(metricRegistry, loadedFilterManager);
+    coverageProvider =
+        new R4CoverageResourceProvider(metricRegistry, loadedFilterManager, coverageTransformer);
+    coverageProvider.setEntityManager(entityManager);
     lenient().when(coverageId.getVersionIdPartAsLong()).thenReturn(null);
+    when(beneficiary.getIdPart()).thenReturn("111199991111");
+
+    List<Object> parsedRecords =
+        ServerTestUtils.parseData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
+    testBene =
+        parsedRecords.stream()
+            .filter(r -> r instanceof Beneficiary)
+            .map(r -> (Beneficiary) r)
+            .findFirst()
+            .get();
+
+    // entity manager mocking
+    mockEntityManager();
+
+    // metrics mocking
+    when(metricRegistry.timer(any())).thenReturn(mockTimer);
+    when(mockTimer.time()).thenReturn(mockTimerContext);
+
+    // loaded filter mocking
+    when(loadedFilterManager.isResultSetEmpty(any(), any())).thenReturn(false);
+
+    // transformer mocking
+    when(coverageTransformer.transform(any())).thenReturn(List.of(testCoverage));
+    when(coverageTransformer.transform(any(), any())).thenReturn(testCoverage);
+
+    // Mock coverage id
+    when(coverageId.getIdPart()).thenReturn(VALID_PART_A_COVERAGE_ID);
+
+    // Mock headers
+    when(requestDetails.getCompleteUrl()).thenReturn("test");
+
+    setupLastUpdatedMocks();
+  }
+
+  /** Sets up the default entity manager mocks. */
+  private void mockEntityManager() {
+    CriteriaBuilder criteriaBuilder = mock(CriteriaBuilder.class);
+    CriteriaQuery<Beneficiary> mockCriteria = mock(CriteriaQuery.class);
+    Root<Beneficiary> root = mock(Root.class);
+    Path mockPath = mock(Path.class);
+    Subquery mockSubquery = mock(Subquery.class);
+    when(entityManager.getCriteriaBuilder()).thenReturn(criteriaBuilder);
+    doReturn(mockCriteria).when(criteriaBuilder).createQuery(any());
+    when(mockCriteria.select(any())).thenReturn(mockCriteria);
+    when(mockCriteria.from(any(Class.class))).thenReturn(root);
+    when(root.get(isNull(SingularAttribute.class))).thenReturn(mockPath);
+    when(entityManager.createQuery(mockCriteria)).thenReturn(mockQuery);
+    when(mockQuery.setHint(any(), anyBoolean())).thenReturn(mockQuery);
+    when(mockQuery.setMaxResults(anyInt())).thenReturn(mockQuery);
+    when(mockQuery.getResultList()).thenReturn(List.of(testBene));
+    when(mockQuery.getSingleResult()).thenReturn(testBene);
+    when(mockCriteria.subquery(any())).thenReturn(mockSubquery);
+    when(mockCriteria.distinct(anyBoolean())).thenReturn(mockCriteria);
+    when(mockSubquery.select(any())).thenReturn(mockSubquery);
+    when(mockSubquery.from(any(Class.class))).thenReturn(root);
+  }
+
+  /** Sets up the last updated mocks. */
+  private void setupLastUpdatedMocks() {
+    Meta mockMeta = mock(Meta.class);
+    when(mockMeta.getLastUpdated())
+        .thenReturn(Date.from(Instant.now().minus(1, ChronoUnit.SECONDS)));
+    when(testCoverage.getMeta()).thenReturn(mockMeta);
+    when(loadedFilterManager.getTransactionTime()).thenReturn(Instant.now());
+  }
+
+  /**
+   * Tests that when the coverage id is formatted in a valid way, but the bene is not found in the
+   * search query, an exception is thrown.
+   */
+  @Test
+  public void testCoverageReadWhereMissingBeneExpectException() {
+    when(mockQuery.getSingleResult()).thenThrow(NoResultException.class);
+
+    assertThrows(
+        ResourceNotFoundException.class,
+        () -> {
+          coverageProvider.read(coverageId);
+        });
+  }
+
+  /**
+   * Tests that the validator (for the format of the coverage id) works when the id part is a
+   * negative number (such as we use for our synthetic data).
+   */
+  @Test
+  public void testCoverageReadWhereNegativeIdPartExpectNoError() {
+    when(coverageId.getIdPart()).thenReturn("part-a--9145");
+
+    Coverage coverage = coverageProvider.read(coverageId);
+
+    assertNotNull(coverage);
   }
 
   /**
    * Verifies that {@link R4CoverageResourceProvider#read} throws an exception when the {@link
-   * org.hl7.fhir.r4.model.IdType} has an invalidly formatted coverageId parameter.
+   * IdType} has an invalidly formatted coverageId parameter.
    */
   @Test
   public void testCoverageReadWhereInvalidIdExpectException() {
@@ -62,7 +217,7 @@ public class R4CoverageResourceProviderTest {
 
   /**
    * Verifies that {@link R4CoverageResourceProvider#read} throws an exception when the {@link
-   * org.hl7.fhir.r4.model.IdType} has a blank value.
+   * IdType} has a blank value.
    */
   @Test
   public void testCoverageReadWhereBlankIdExpectException() {
@@ -79,23 +234,24 @@ public class R4CoverageResourceProviderTest {
 
   /**
    * Verifies that {@link R4CoverageResourceProvider#read} throws an exception when the {@link
-   * org.hl7.fhir.r4.model.IdType} has a null value.
+   * IdType} has a null value.
    */
   @Test
   public void testCoverageReadWhereNullIdExpectException() {
+
     InvalidRequestException exception =
         assertThrows(
             InvalidRequestException.class,
             () -> {
-              coverageProvider.read(coverageId);
+              coverageProvider.read(null);
             });
     assertEquals("Missing required coverage ID", exception.getLocalizedMessage());
   }
 
   /**
    * Verifies that {@link R4CoverageResourceProvider#read} throws an exception when the {@link
-   * org.hl7.fhir.r4.model.IdType} has a version supplied with the coverageId parameter, as our read
-   * requests do not support versioned requests.
+   * IdType} has a version supplied with the coverageId parameter, as our read requests do not
+   * support versioned requests.
    */
   @Test
   public void testCoverageReadWhereVersionedIdExpectException() {
@@ -108,5 +264,57 @@ public class R4CoverageResourceProviderTest {
               coverageProvider.read(coverageId);
             });
     assertEquals("Coverage ID must not define a version", exception.getLocalizedMessage());
+  }
+
+  /**
+   * Tests that when searching by beneficiary, if no beneficiary is found, 0 results are returned in
+   * the bundle.
+   */
+  @Test
+  public void testCoverageByBeneficiaryWhereMissingBeneExpectEmptyBundle() {
+    when(mockQuery.getSingleResult()).thenThrow(NoResultException.class);
+
+    Bundle bundle = coverageProvider.searchByBeneficiary(beneficiary, null, null, requestDetails);
+
+    assertEquals(0, bundle.getTotal());
+  }
+
+  /** Test coverage by beneficiary when paging is requested, expect paging links are returned. */
+  @Test
+  public void testCoverageByBeneficiaryWherePagingRequestedExpectPageData() {
+    // Set paging params
+    Map<String, String[]> params = new HashMap<>();
+    params.put(Constants.PARAM_COUNT, new String[] {"1"});
+    when(requestDetails.getParameters()).thenReturn(params);
+
+    // Note: startIndex in the param is not used, must be passed from requestDetails
+    Bundle bundle = coverageProvider.searchByBeneficiary(beneficiary, null, null, requestDetails);
+
+    /*
+     * Check paging; Verify that only the first and last paging links exist, since there should
+     * only be one page.
+     */
+    assertNotNull(bundle.getLink(Constants.LINK_FIRST));
+    assertNull(bundle.getLink(Constants.LINK_NEXT));
+    assertNull(bundle.getLink(Constants.LINK_PREVIOUS));
+    assertNotNull(bundle.getLink(Constants.LINK_LAST));
+  }
+
+  /**
+   * Test coverage by beneficiary when paging is not requested, expect no paging links are returned.
+   */
+  @Test
+  public void testCoverageByBeneficiaryWhereNoPagingRequestedExpectNoPageData() {
+    when(requestDetails.getHeader(any())).thenReturn("");
+
+    Bundle bundle = coverageProvider.searchByBeneficiary(beneficiary, null, null, requestDetails);
+
+    /*
+     * Check that no paging was added when not requested
+     */
+    assertNull(bundle.getLink(Constants.LINK_FIRST));
+    assertNull(bundle.getLink(Constants.LINK_NEXT));
+    assertNull(bundle.getLink(Constants.LINK_PREVIOUS));
+    assertNull(bundle.getLink(Constants.LINK_LAST));
   }
 }


### PR DESCRIPTION

<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BFD-2600](https://jira.cms.gov/browse/BFD-2600)

**User Story or Bug Summary:**
<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->
As a BFD engineer I would like the transformer classes to be managed by spring so that the provider and transformer classes can be better tested in isolation.

---

### What Does This PR Do?
<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

- Adjusts the coverage transformer to be a non-static singleton component managed by spring and its dependencies to be injected.
- Adjusts the coverage resource provider to use the transformer component instance instead of calling the class statically
- Renames the coverage resource provider ITs to E2E
- Converts some of the E2E tests that can be unit tests into unit tests

### What Should Reviewers Watch For?
<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items to the following list here -->
* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [x] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [x] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [x] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] The data dictionary has been updated with any field mapping changes, if any were made.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    