### PR TITLE
BFD-2586: Add server terraservice to standard deployments

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -291,6 +291,9 @@ try {
 						terraform.deployTerraservice(
 							env: bfdEnv,
 							directory: "ops/terraform/services/server",
+							tfVars: [
+                            	ami_id_override: amiIds.bfdServerAmiId
+                            ]
 						)
 
 						awsAuth.assumeRole()
@@ -447,13 +450,15 @@ try {
 					lock(resource: 'env_prod_sbx') {
 						milestone(label: 'stage_deploy_prod_sbx_start')
 						container('bfd-cbc-build') {
-							awsAuth.assumeRole()
 							
-						        awsAuth.assumeRole()
-						        terraform.deployTerraservice(
-							        env: bfdEnv,
-							        directory: "ops/terraform/services/server",
-						        )
+                            awsAuth.assumeRole()
+                            terraform.deployTerraservice(
+                                env: bfdEnv,
+                                directory: "ops/terraform/services/server",
+                                tfVars: [
+                                    ami_id_override: amiIds.bfdServerAmiId
+                                ]
+                            )
 
 							awsAuth.assumeRole()
 							terraform.deployTerraservice(
@@ -596,6 +601,9 @@ try {
 						        terraform.deployTerraservice(
 							        env: bfdEnv,
 							        directory: "ops/terraform/services/server",
+							        tfVars: [
+                                        ami_id_override: amiIds.bfdServerAmiId
+                                    ]
 						        )
 
 							awsAuth.assumeRole()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -286,7 +286,12 @@ try {
 
 					container('bfd-cbc-build') {
 						awsAuth.assumeRole()
-						scriptForDeploys.deploy('test', gitBranchName, gitCommitId, amiIds)
+
+						awsAuth.assumeRole()
+						terraform.deployTerraservice(
+							env: bfdEnv,
+							directory: "ops/terraform/services/server",
+						)
 
 						awsAuth.assumeRole()
 						terraform.deployTerraservice(
@@ -443,7 +448,12 @@ try {
 						milestone(label: 'stage_deploy_prod_sbx_start')
 						container('bfd-cbc-build') {
 							awsAuth.assumeRole()
-							scriptForDeploys.deploy('prod-sbx', gitBranchName, gitCommitId, amiIds)
+							
+						        awsAuth.assumeRole()
+						        terraform.deployTerraservice(
+							        env: bfdEnv,
+							        directory: "ops/terraform/services/server",
+						        )
 
 							awsAuth.assumeRole()
 							terraform.deployTerraservice(
@@ -581,7 +591,12 @@ try {
 
 						container('bfd-cbc-build') {
 							awsAuth.assumeRole()
-							scriptForDeploys.deploy('prod', gitBranchName, gitCommitId, amiIds)
+
+						        awsAuth.assumeRole()
+						        terraform.deployTerraservice(
+							        env: bfdEnv,
+							        directory: "ops/terraform/services/server",
+						        )
 
 							awsAuth.assumeRole()
 							terraform.deployTerraservice(

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -292,8 +292,8 @@ try {
 							env: bfdEnv,
 							directory: "ops/terraform/services/server",
 							tfVars: [
-                            	ami_id_override: amiIds.bfdServerAmiId
-                            ]
+								ami_id_override: amiIds.bfdServerAmiId
+							]
 						)
 
 						awsAuth.assumeRole()
@@ -451,14 +451,14 @@ try {
 						milestone(label: 'stage_deploy_prod_sbx_start')
 						container('bfd-cbc-build') {
 							
-                            awsAuth.assumeRole()
-                            terraform.deployTerraservice(
-                                env: bfdEnv,
-                                directory: "ops/terraform/services/server",
-                                tfVars: [
-                                    ami_id_override: amiIds.bfdServerAmiId
-                                ]
-                            )
+							awsAuth.assumeRole()
+							terraform.deployTerraservice(
+								env: bfdEnv,
+								directory: "ops/terraform/services/server",
+								tfVars: [
+									ami_id_override: amiIds.bfdServerAmiId
+								]
+							)
 
 							awsAuth.assumeRole()
 							terraform.deployTerraservice(
@@ -596,15 +596,13 @@ try {
 
 						container('bfd-cbc-build') {
 							awsAuth.assumeRole()
-
-						        awsAuth.assumeRole()
-						        terraform.deployTerraservice(
-							        env: bfdEnv,
-							        directory: "ops/terraform/services/server",
-							        tfVars: [
-                                        ami_id_override: amiIds.bfdServerAmiId
-                                    ]
-						        )
+							terraform.deployTerraservice(
+								env: bfdEnv,
+								directory: "ops/terraform/services/server",
+								tfVars: [
+									ami_id_override: amiIds.bfdServerAmiId
+								]
+							)
 
 							awsAuth.assumeRole()
 							terraform.deployTerraservice(

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -286,8 +286,6 @@ try {
 
 					container('bfd-cbc-build') {
 						awsAuth.assumeRole()
-
-						awsAuth.assumeRole()
 						terraform.deployTerraservice(
 							env: bfdEnv,
 							directory: "ops/terraform/services/server",
@@ -450,7 +448,6 @@ try {
 					lock(resource: 'env_prod_sbx') {
 						milestone(label: 'stage_deploy_prod_sbx_start')
 						container('bfd-cbc-build') {
-							
 							awsAuth.assumeRole()
 							terraform.deployTerraservice(
 								env: bfdEnv,

--- a/ops/jenkins/bfd-deploy-apps/Jenkinsfile
+++ b/ops/jenkins/bfd-deploy-apps/Jenkinsfile
@@ -303,6 +303,13 @@ spec:
                                     tfVars: terraformVars
                             )
 
+                            // Deploy the API requests Insights Lambda
+                            awsAuth.assumeRole()
+                            terraform.deployTerraservice(
+                                    env: trimmedEnv,
+                                    directory: 'ops/terraform/services/server'
+                            )
+
                             awsAuth.assumeRole()
                             terraform.deployTerraservice(
                                     env: trimmedEnv,

--- a/ops/jenkins/bfd-deploy-apps/Jenkinsfile
+++ b/ops/jenkins/bfd-deploy-apps/Jenkinsfile
@@ -303,13 +303,6 @@ spec:
                                     tfVars: terraformVars
                             )
 
-                            // Deploy the API requests Insights Lambda
-                            awsAuth.assumeRole()
-                            terraform.deployTerraservice(
-                                    env: trimmedEnv,
-                                    directory: 'ops/terraform/services/server'
-                            )
-
                             awsAuth.assumeRole()
                             terraform.deployTerraservice(
                                     env: trimmedEnv,

--- a/ops/jenkins/bfd-deploy-apps/Jenkinsfile
+++ b/ops/jenkins/bfd-deploy-apps/Jenkinsfile
@@ -114,7 +114,7 @@ spec:
         )
 
         string(
-        name: 'server_ami',
+        name: 'server_ami_override',
         description: 'The AMI ID to deploy server from',
         defaultValue: null
         )
@@ -291,31 +291,17 @@ spec:
                 script {
                     currentStage = env.STAGE_NAME
                     try {
-                        def serverAmi = params.server_ami?.trim()
+                        def terraformVars = (params.server_ami_override?.trim())
+                                                  ? [ami_id_override: params.server_ami_override?.trim()]
+                                                  : []
                         lock(resource: lockResource) {
+                            // Deploy the Server
                             awsAuth.assumeRole()
-                                dir("${workspace}/ops/terraform/env/${trimmedEnv}/stateless") {
-                                    // Debug output terraform version
-                                    sh "terraform --version"
-
-                                    // Initilize terraform
-                                    sh "terraform init -no-color"
-
-                                    // Gathering terraform plan
-                                    echo "Timestamp: ${java.time.LocalDateTime.now().toString()}"
-                                    sh "terraform plan \
-                                    -var='fhir_ami=${serverAmi}' \
-                                    -var='ssh_key_name=bfd-${trimmedEnv}' \
-                                    -var='git_branch_name=${gitBranchName}' \
-                                    -var='git_commit_id=${gitCommitId}' \
-                                    -no-color -out=tfplan"
-
-                                    // Apply Terraform plan
-                                    echo "Timestamp: ${java.time.LocalDateTime.now().toString()}"
-                                    sh "terraform apply \
-                                    -no-color -input=false tfplan"
-                                    echo "Timestamp: ${java.time.LocalDateTime.now().toString()}"
-                                }
+                            terraform.deployTerraservice(
+                                    env: trimmedEnv,
+                                    directory: 'ops/terraform/services/server',
+                                    tfVars: terraformVars
+                            )
 
                             awsAuth.assumeRole()
                             terraform.deployTerraservice(

--- a/ops/terraform/services/server/modules/bfd_server_asg/data-sources.tf
+++ b/ops/terraform/services/server/modules/bfd_server_asg/data-sources.tf
@@ -21,6 +21,7 @@ data "aws_rds_cluster" "rds" {
 data "external" "rds" {
   program = [
     "${path.module}/scripts/rds-cluster-config.sh", # helper script
-    data.aws_rds_cluster.rds.cluster_identifier     # verified, positional argument to script
+    data.aws_rds_cluster.rds.cluster_identifier,    # verified, positional argument to script
+    local.env                                       # environment name, almost exclusively here to provide beta reader functionality for production
   ]
 }

--- a/ops/terraform/services/server/modules/bfd_server_asg/main.tf
+++ b/ops/terraform/services/server/modules/bfd_server_asg/main.tf
@@ -1,8 +1,8 @@
 locals {
   env = terraform.workspace
 
-  rds_availability_zone = data.external.rds.result["WriterAZ"]
-  rds_writer_endpoint   = data.external.rds.result["Endpoint"]
+  # When the CustomEndpoint is empty, fall back to the ReaderEndpoint
+  rds_reader_endpoint = data.external.rds.result["CustomEndpoint"] == "" ? data.external.rds.result["ReaderEndpoint"] : data.external.rds.result["CustomEndpoint"]
 
   additional_tags = { Layer = var.layer, role = var.role }
 }
@@ -101,7 +101,7 @@ resource "aws_launch_template" "main" {
     env                = local.env
     port               = var.lb_config.port
     accountId          = var.launch_config.account_id
-    data_server_db_url = "jdbc:postgresql://${local.rds_writer_endpoint}:5432/fhirdb${var.jdbc_suffix}"
+    data_server_db_url = "jdbc:postgresql://${local.rds_reader_endpoint}:5432/fhirdb${var.jdbc_suffix}"
   }))
 
   tag_specifications {

--- a/ops/terraform/services/server/modules/bfd_server_asg/scripts/rds-cluster-config.sh
+++ b/ops/terraform/services/server/modules/bfd_server_asg/scripts/rds-cluster-config.sh
@@ -2,7 +2,7 @@
 #######################################
 # Results in two calls to the AWS RDS APIs for describe-db-clusters and describe-db-instances.
 # Returns a well-formatted json object including the following keys:
-# "DBClusterIdentifier", "Endpoint", "ReaderEndpoint", "WriterAZ", and "WriterNode".
+# "DBClusterIdentifier", "Endpoint", "ReaderEndpoint", "WriterAZ", "WriterNode" and "CustomEndpoint".
 #
 # This exists to accommodate the desire for placing write-intensive workloads in the same AZ as the
 # writer node. As of May 2022, the data source for DB instances does not expose the `IsClusterWriter`
@@ -12,6 +12,7 @@
 #
 # Globals:
 #   CLUSTER_IDENTIFIER mapped to the "$1" positional argument
+#   BFD_ENV mapped to the "$2" positional argument
 #   CLUSTER a modified json object from the aws rds describe-db-clusters command
 #   WRITER_NODE a string representing the writer node's db-instance-identifier
 #   WRITER_AZ a string representing the writer node's availability zone
@@ -23,10 +24,15 @@
 set -euo pipefail
 
 CLUSTER_IDENTIFIER="$1"
+BFD_ENV="$2"
+
+ENDPOINT_IDENTIFIER="bfd-${BFD_ENV}-beta-reader"
 
 CLUSTER="$(aws rds describe-db-clusters \
     --query 'DBClusters[].{DBClusterIdentifier:DBClusterIdentifier,Endpoint:Endpoint,ReaderEndpoint:ReaderEndpoint,Members:DBClusterMembers}[0]' \
     --db-cluster-identifier "$CLUSTER_IDENTIFIER")"
+
+CUSTOM_ENDPOINT="$(aws rds describe-db-cluster-endpoints --db-cluster-identifier "$CLUSTER_IDENTIFIER" | jq -r --arg endpoint "$ENDPOINT_IDENTIFIER" '.[][] | select(.DBClusterEndpointIdentifier == $endpoint).Endpoint')"
 
 WRITER_NODE="$(jq -r '.Members[] | select(.IsClusterWriter == true) | .DBInstanceIdentifier' <<<"$CLUSTER")"
 
@@ -34,4 +40,6 @@ WRITER_AZ="$(aws rds describe-db-instances --db-instance-identifier "$WRITER_NOD
 
 WRITER_CONFIG="$(jq --null-input --arg writer_node "$WRITER_NODE" --arg writer_az "$WRITER_AZ" '{ WriterNode: $writer_node, WriterAZ: $writer_az }')"
 
-jq --argjson obj "$WRITER_CONFIG" '. += $obj | del(.Members)' <<<$CLUSTER
+# Construct the final object keeping just "DBClusterIdentifier", "Endpoint", "ReaderEndpoint", "WriterAZ" from the $CLUSTER
+# Add the objects representing "WriterNode" and "CustomEndpoint"
+jq --argjson obj1 "$WRITER_CONFIG" --arg str1 "$CUSTOM_ENDPOINT"   '. += $obj1 | . += { "CustomEndpoint": $str1 } | del(.Members)' <<<$CLUSTER

--- a/ops/terraform/services/server/modules/bfd_server_asg/scripts/rds-cluster-config.sh
+++ b/ops/terraform/services/server/modules/bfd_server_asg/scripts/rds-cluster-config.sh
@@ -26,7 +26,7 @@ set -euo pipefail
 CLUSTER_IDENTIFIER="$1"
 BFD_ENV="$2"
 
-ENDPOINT_IDENTIFIER="bfd-${BFD_ENV}-beta-reader"
+ENDPOINT_IDENTIFIER="bfd-${BFD_ENV}-ro"
 
 CLUSTER="$(aws rds describe-db-clusters \
     --query 'DBClusters[].{DBClusterIdentifier:DBClusterIdentifier,Endpoint:Endpoint,ReaderEndpoint:ReaderEndpoint,Members:DBClusterMembers}[0]' \


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BFD-2586](https://jira.cms.gov/browse/BFD-2586)

**User Story or Bug Summary:**
<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->
As a release engineer, I want the path-to-production deployment process to use the server terraservice so that I can avoid any drift-related issues between ephemeral and established environment deployments.

AC
path-to-production environments test, prod-sbx, and prod resources are imported into environment specific workspaces in the server terraservice remote state
Jenkins file is updated to make use of the server terraservice in typical path-to-production deployments


---

### What Does This PR Do?


Add server to deployment specific environments. Additionally, migration from stateless to the terraservice pattern was accommodated through the following statements for each of the established path-to-production SDLC environments `test`, `prod-sbx`, and `prod`:

<details><summary>Statements</summary>

```sh
terraform state mv 'module.stateless.aws_iam_role_policy_attachment.fhir_iam_ansible_vault_pw_ro_s3' 'aws_iam_role_policy_attachment.fhir_iam_ansible_vault_pw_ro_s3'
terraform state mv 'module.stateless.module.bfd_dashboards.aws_cloudwatch_dashboard.bfd_dashboard' 'module.bfd_dashboards[0].aws_cloudwatch_dashboard.bfd_dashboard'
terraform state mv 'module.stateless.module.bfd_dashboards.aws_cloudwatch_dashboard.bfd_dashboard_slos' 'module.bfd_dashboards[0].aws_cloudwatch_dashboard.bfd_dashboard_slos'
terraform state mv 'module.stateless.module.bfd_server_log_alarms.aws_cloudwatch_metric_alarm.server-log-availability-1hr' 'module.bfd_server_log_alarms[0].aws_cloudwatch_metric_alarm.server-log-availability-1hr'
terraform state mv 'module.stateless.module.bfd_server_log_alarms.aws_cloudwatch_metric_alarm.server-query-logging-listener-warning' 'module.bfd_server_log_alarms[0].aws_cloudwatch_metric_alarm.server-query-logging-listener-warning'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_count["all_all_partners"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_count["all_all_partners"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_count["all_by_partner"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_count["all_by_partner"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_count["claim_all_all_partners"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_count["claim_all_all_partners"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_count["claim_all_by_partner"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_count["claim_all_by_partner"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_count["claim_response_all_all_partners"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_count["claim_response_all_all_partners"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_count["claim_response_all_by_partner"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_count["claim_response_all_by_partner"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_count["coverage_all_all_partners"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_count["coverage_all_all_partners"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_count["coverage_all_by_partner"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_count["coverage_all_by_partner"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_count["eob_all_all_partners"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_count["eob_all_all_partners"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_count["eob_all_by_partner"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_count["eob_all_by_partner"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_count["metadata_all_partners"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_count["metadata_all_partners"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_count["metadata_by_partner"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_count["metadata_by_partner"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_count["patient_all_all_partners"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_count["patient_all_all_partners"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_count["patient_all_by_partner"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_count["patient_all_by_partner"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_count_500_responses["all_partners"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_count_500_responses["all_partners"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_count_500_responses["by_partner"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_count_500_responses["by_partner"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_count_non_2xx_responses["all_partners"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_count_non_2xx_responses["all_partners"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_count_non_2xx_responses["by_partner"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_count_non_2xx_responses["by_partner"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency["all_all_partners"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency["all_all_partners"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency["all_by_partner"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency["all_by_partner"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency["claim_all_all_partners"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency["claim_all_all_partners"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency["claim_all_by_partner"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency["claim_all_by_partner"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency["claim_response_all_all_partners"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency["claim_response_all_all_partners"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency["claim_response_all_by_partner"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency["claim_response_all_by_partner"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency["coverage_all_all_partners"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency["coverage_all_all_partners"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency["coverage_all_by_partner"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency["coverage_all_by_partner"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency["eob_all_all_partners"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency["eob_all_all_partners"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency["eob_all_by_partner"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency["eob_all_by_partner"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency["metadata_all_partners"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency["metadata_all_partners"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency["metadata_by_partner"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency["metadata_by_partner"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency["patient_all_all_partners"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency["patient_all_all_partners"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency["patient_all_by_partner"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency["patient_all_by_partner"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency_by_kb_claim_all_with_resources["all_partners"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency_by_kb_claim_all_with_resources["all_partners"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency_by_kb_claim_all_with_resources["by_partner"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency_by_kb_claim_all_with_resources["by_partner"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency_by_kb_claimresponse_all_with_resources["all_partners"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency_by_kb_claimresponse_all_with_resources["all_partners"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency_by_kb_claimresponse_all_with_resources["by_partner"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency_by_kb_claimresponse_all_with_resources["by_partner"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency_by_kb_eob_all["all_partners"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency_by_kb_eob_all["all_partners"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency_by_kb_eob_all["by_partner"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency_by_kb_eob_all["by_partner"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency_by_kb_eob_all_with_resources["all_partners"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency_by_kb_eob_all_with_resources["all_partners"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency_by_kb_eob_all_with_resources["by_partner"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency_by_kb_eob_all_with_resources["by_partner"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency_claim_all_no_resources["all_partners"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency_claim_all_no_resources["all_partners"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency_claim_all_no_resources["by_partner"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency_claim_all_no_resources["by_partner"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency_claim_all_with_resources["all_partners"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency_claim_all_with_resources["all_partners"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency_claim_all_with_resources["by_partner"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency_claim_all_with_resources["by_partner"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency_claimresponse_all_no_resources["all_partners"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency_claimresponse_all_no_resources["all_partners"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency_claimresponse_all_no_resources["by_partner"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency_claimresponse_all_no_resources["by_partner"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency_claimresponse_all_with_resources["all_partners"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency_claimresponse_all_with_resources["all_partners"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency_claimresponse_all_with_resources["by_partner"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency_claimresponse_all_with_resources["by_partner"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency_eob_all_no_resources["all_partners"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency_eob_all_no_resources["all_partners"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency_eob_all_no_resources["by_partner"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency_eob_all_no_resources["by_partner"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency_eob_all_with_resources["all_partners"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency_eob_all_with_resources["all_partners"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency_eob_all_with_resources["by_partner"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency_eob_all_with_resources["by_partner"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency_patient_by_contract_count_4000["all_partners"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency_patient_by_contract_count_4000["all_partners"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency_patient_by_contract_count_4000["by_partner"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency_patient_by_contract_count_4000["by_partner"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency_patient_not_by_contract["all_partners"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency_patient_not_by_contract["all_partners"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.http_requests_latency_patient_not_by_contract["by_partner"]' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.http_requests_latency_patient_not_by_contract["by_partner"]'
terraform state mv 'module.stateless.module.bfd_server_metrics.aws_cloudwatch_log_metric_filter.query_logging_listener_count_warning_messages' 'module.bfd_server_metrics[0].aws_cloudwatch_log_metric_filter.query_logging_listener_count_warning_messages'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_availability_failures_sum["slo_availability_failures_sum_5m_alert"]' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_availability_failures_sum["slo_availability_failures_sum_5m_alert"]'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_availability_failures_sum["slo_availability_failures_sum_5m_warning"]' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_availability_failures_sum["slo_availability_failures_sum_5m_warning"]'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_availability_uptime_percent["slo_availability_uptime_percent_24hr_alert"]' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_availability_uptime_percent["slo_availability_uptime_percent_24hr_alert"]'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_availability_uptime_percent["slo_availability_uptime_percent_24hr_warning"]' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_availability_uptime_percent["slo_availability_uptime_percent_24hr_warning"]'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_claim_no_resources_latency_mean_15m_alert' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_claim_no_resources_latency_mean_15m_alert'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_claim_no_resources_latency_mean_15m_warning' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_claim_no_resources_latency_mean_15m_warning'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_claimresponse_no_resources_latency_mean_15m_alert' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_claimresponse_no_resources_latency_mean_15m_alert'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_claimresponse_no_resources_latency_mean_15m_warning' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_claimresponse_no_resources_latency_mean_15m_warning'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_coverage_bulk_latency_99p_15m_alert["bcda"]' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_coverage_bulk_latency_99p_15m_alert["bcda"]'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_coverage_bulk_latency_99p_15m_alert["dpc"]' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_coverage_bulk_latency_99p_15m_alert["dpc"]'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_coverage_bulk_latency_99p_15m_warning["bcda"]' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_coverage_bulk_latency_99p_15m_warning["bcda"]'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_coverage_bulk_latency_99p_15m_warning["dpc"]' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_coverage_bulk_latency_99p_15m_warning["dpc"]'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_coverage_latency_mean_15m_alert' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_coverage_latency_mean_15m_alert'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_coverage_latency_mean_15m_warning' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_coverage_latency_mean_15m_warning'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_coverage_nonbulk_latency_99p_15m_alert["bb"]' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_coverage_nonbulk_latency_99p_15m_alert["bb"]'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_coverage_nonbulk_latency_99p_15m_warning["bb"]' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_coverage_nonbulk_latency_99p_15m_warning["bb"]'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_eob_no_resources_latency_mean_15m_alert' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_eob_no_resources_latency_mean_15m_alert'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_eob_no_resources_latency_mean_15m_warning' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_eob_no_resources_latency_mean_15m_warning'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_eob_with_resources_bulk_latency_99p_15m_alert["ab2d"]' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_eob_with_resources_bulk_latency_99p_15m_alert["ab2d"]'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_eob_with_resources_bulk_latency_99p_15m_alert["bcda"]' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_eob_with_resources_bulk_latency_99p_15m_alert["bcda"]'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_eob_with_resources_bulk_latency_99p_15m_alert["dpc"]' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_eob_with_resources_bulk_latency_99p_15m_alert["dpc"]'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_eob_with_resources_bulk_latency_per_kb_99p_15m_warning["ab2d"]' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_eob_with_resources_bulk_latency_per_kb_99p_15m_warning["ab2d"]'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_eob_with_resources_bulk_latency_per_kb_99p_15m_warning["bcda"]' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_eob_with_resources_bulk_latency_per_kb_99p_15m_warning["bcda"]'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_eob_with_resources_bulk_latency_per_kb_99p_15m_warning["dpc"]' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_eob_with_resources_bulk_latency_per_kb_99p_15m_warning["dpc"]'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_eob_with_resources_latency_per_kb_mean_15m_alert' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_eob_with_resources_latency_per_kb_mean_15m_alert'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_eob_with_resources_latency_per_kb_mean_15m_warning' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_eob_with_resources_latency_per_kb_mean_15m_warning'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_eob_with_resources_nonbulk_latency_per_kb_99p_15m_alert["bb"]' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_eob_with_resources_nonbulk_latency_per_kb_99p_15m_alert["bb"]'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_eob_with_resources_nonbulk_latency_per_kb_99p_15m_warning["bb"]' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_eob_with_resources_nonbulk_latency_per_kb_99p_15m_warning["bb"]'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_http500_count_percent["slo_http500_percent_1hr_alert"]' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_http500_count_percent["slo_http500_percent_1hr_alert"]'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_http500_count_percent["slo_http500_percent_1hr_warning"]' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_http500_count_percent["slo_http500_percent_1hr_warning"]'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_http500_count_percent["slo_http500_percent_24hr_alert"]' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_http500_count_percent["slo_http500_percent_24hr_alert"]'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_http500_count_percent["slo_http500_percent_24hr_warning"]' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_http500_count_percent["slo_http500_percent_24hr_warning"]'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_patient_by_contract_count_4000_latency_99p_15m_alert["ab2d"]' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_patient_by_contract_count_4000_latency_99p_15m_alert["ab2d"]'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_patient_by_contract_count_4000_latency_99p_15m_warning["ab2d"]' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_patient_by_contract_count_4000_latency_99p_15m_warning["ab2d"]'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_patient_by_contract_count_4000_latency_mean_15m_alert' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_patient_by_contract_count_4000_latency_mean_15m_alert'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_patient_by_contract_count_4000_latency_mean_15m_warning' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_patient_by_contract_count_4000_latency_mean_15m_warning'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_patient_no_contract_bulk_latency_99p_15m_alert["bcda"]' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_patient_no_contract_bulk_latency_99p_15m_alert["bcda"]'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_patient_no_contract_bulk_latency_99p_15m_alert["dpc"]' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_patient_no_contract_bulk_latency_99p_15m_alert["dpc"]'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_patient_no_contract_bulk_latency_99p_15m_warning["bcda"]' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_patient_no_contract_bulk_latency_99p_15m_warning["bcda"]'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_patient_no_contract_bulk_latency_99p_15m_warning["dpc"]' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_patient_no_contract_bulk_latency_99p_15m_warning["dpc"]'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_patient_no_contract_latency_mean_15m_alert' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_patient_no_contract_latency_mean_15m_alert'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_patient_no_contract_latency_mean_15m_warning' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_patient_no_contract_latency_mean_15m_warning'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_patient_no_contract_nonbulk_latency_99p_15m_alert["bb"]' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_patient_no_contract_nonbulk_latency_99p_15m_alert["bb"]'
terraform state mv 'module.stateless.module.bfd_server_slo_alarms.aws_cloudwatch_metric_alarm.slo_patient_no_contract_nonbulk_latency_99p_15m_warning["bb"]' 'module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_patient_no_contract_nonbulk_latency_99p_15m_warning["bb"]'
terraform state mv 'module.stateless.module.disk_usage_alarms.aws_autoscaling_notification.this' 'module.disk_usage_alarms[0].aws_autoscaling_notification.this'
terraform state mv 'module.stateless.module.disk_usage_alarms.aws_iam_policy.autoscaling' 'module.disk_usage_alarms[0].aws_iam_policy.autoscaling'
terraform state mv 'module.stateless.module.disk_usage_alarms.aws_iam_policy.cloudwatch' 'module.disk_usage_alarms[0].aws_iam_policy.cloudwatch'
terraform state mv 'module.stateless.module.disk_usage_alarms.aws_iam_policy.kms' 'module.disk_usage_alarms[0].aws_iam_policy.kms'
terraform state mv 'module.stateless.module.disk_usage_alarms.aws_iam_policy.logs' 'module.disk_usage_alarms[0].aws_iam_policy.logs'
terraform state mv 'module.stateless.module.disk_usage_alarms.aws_iam_role.this' 'module.disk_usage_alarms[0].aws_iam_role.this'
terraform state mv 'module.stateless.module.disk_usage_alarms.aws_lambda_function.this' 'module.disk_usage_alarms[0].aws_lambda_function.this'
terraform state mv 'module.stateless.module.disk_usage_alarms.aws_lambda_permission.this' 'module.disk_usage_alarms[0].aws_lambda_permission.this'
terraform state mv 'module.stateless.module.disk_usage_alarms.aws_sns_topic.this' 'module.disk_usage_alarms[0].aws_sns_topic.this'
terraform state mv 'module.stateless.module.disk_usage_alarms.aws_sns_topic_subscription.this' 'module.disk_usage_alarms[0].aws_sns_topic_subscription.this'
terraform state mv 'module.stateless.module.fhir_asg.aws_autoscaling_group.main' 'module.fhir_asg.aws_autoscaling_group.main'
terraform state mv 'module.stateless.module.fhir_asg.aws_autoscaling_policy.high-cpu' 'module.fhir_asg.aws_autoscaling_policy.high-cpu'
terraform state mv 'module.stateless.module.fhir_asg.aws_autoscaling_policy.low-cpu' 'module.fhir_asg.aws_autoscaling_policy.low-cpu'
terraform state mv 'module.stateless.module.fhir_asg.aws_cloudwatch_metric_alarm.high-cpu' 'module.fhir_asg.aws_cloudwatch_metric_alarm.high-cpu'
terraform state mv 'module.stateless.module.fhir_asg.aws_cloudwatch_metric_alarm.low-cpu' 'module.fhir_asg.aws_cloudwatch_metric_alarm.low-cpu'
terraform state mv 'module.stateless.module.fhir_asg.aws_launch_template.main' 'module.fhir_asg.aws_launch_template.main'
terraform state mv 'module.stateless.module.fhir_asg.aws_security_group.app[0]' 'module.fhir_asg.aws_security_group.app[0]'
terraform state mv 'module.stateless.module.fhir_asg.aws_security_group.base' 'module.fhir_asg.aws_security_group.base'
terraform state mv 'module.stateless.module.fhir_asg.aws_security_group_rule.allow_db_access[0]' 'module.fhir_asg.aws_security_group_rule.allow_db_access[0]'
terraform state mv 'module.stateless.module.fhir_iam.aws_iam_instance_profile.instance' 'module.fhir_iam.aws_iam_instance_profile.instance'
terraform state mv 'module.stateless.module.fhir_iam.aws_iam_policy.kms_mgmt' 'module.fhir_iam.aws_iam_policy.kms_mgmt'
terraform state mv 'module.stateless.module.fhir_iam.aws_iam_policy.ssm' 'module.fhir_iam.aws_iam_policy.ssm'
terraform state mv 'module.stateless.module.fhir_iam.aws_iam_policy.ssm_mgmt' 'module.fhir_iam.aws_iam_policy.ssm_mgmt'
terraform state mv 'module.stateless.module.fhir_iam.aws_iam_role.instance' 'module.fhir_iam.aws_iam_role.instance'
terraform state mv 'module.stateless.module.fhir_iam.aws_iam_role_policy_attachment.cloudwatch_agent_policy_attachment' 'module.fhir_iam.aws_iam_role_policy_attachment.cloudwatch_agent_policy_attachment'
terraform state mv 'module.stateless.module.fhir_iam.aws_iam_role_policy_attachment.cloudwatch_xray_policy' 'module.fhir_iam.aws_iam_role_policy_attachment.cloudwatch_xray_policy'
terraform state mv 'module.stateless.module.fhir_iam.aws_iam_role_policy_attachment.kms_mgmt' 'module.fhir_iam.aws_iam_role_policy_attachment.kms_mgmt'
terraform state mv 'module.stateless.module.fhir_iam.aws_iam_role_policy_attachment.ssm' 'module.fhir_iam.aws_iam_role_policy_attachment.ssm'
terraform state mv 'module.stateless.module.fhir_iam.aws_iam_role_policy_attachment.ssm_mgmt' 'module.fhir_iam.aws_iam_role_policy_attachment.ssm_mgmt'
terraform state mv 'module.stateless.module.fhir_lb.aws_elb.main' 'module.fhir_lb.aws_elb.main'
terraform state mv 'module.stateless.module.fhir_lb.aws_s3_bucket_policy.logs' 'module.fhir_lb.aws_s3_bucket_policy.logs'
terraform state mv 'module.stateless.module.fhir_lb.aws_security_group.lb' 'module.fhir_lb.aws_security_group.lb'
terraform state mv 'module.stateless.module.lb_alarms.aws_cloudwatch_metric_alarm.healthy_hosts[0]' 'module.lb_alarms[0].aws_cloudwatch_metric_alarm.healthy_hosts[0]'
terraform state rm 'module.stateless.module.cw_alarms_slack_notifier.aws_iam_policy.kms["bfd_alerts"]'
terraform state rm 'module.stateless.module.cw_alarms_slack_notifier.aws_iam_policy.kms["bfd_notices"]'
terraform state rm 'module.stateless.module.cw_alarms_slack_notifier.aws_iam_policy.kms["bfd_test"]'
terraform state rm 'module.stateless.module.cw_alarms_slack_notifier.aws_iam_policy.kms["bfd_warnings"]'
terraform state rm 'module.stateless.module.cw_alarms_slack_notifier.aws_iam_policy.logs["bfd_alerts"]'
terraform state rm 'module.stateless.module.cw_alarms_slack_notifier.aws_iam_policy.logs["bfd_notices"]'
terraform state rm 'module.stateless.module.cw_alarms_slack_notifier.aws_iam_policy.logs["bfd_test"]'
terraform state rm 'module.stateless.module.cw_alarms_slack_notifier.aws_iam_policy.logs["bfd_warnings"]'
terraform state rm 'module.stateless.module.cw_alarms_slack_notifier.aws_iam_policy.ssm["bfd_alerts"]'
terraform state rm 'module.stateless.module.cw_alarms_slack_notifier.aws_iam_policy.ssm["bfd_notices"]'
terraform state rm 'module.stateless.module.cw_alarms_slack_notifier.aws_iam_policy.ssm["bfd_test"]'
terraform state rm 'module.stateless.module.cw_alarms_slack_notifier.aws_iam_policy.ssm["bfd_warnings"]'
terraform state rm 'module.stateless.module.cw_alarms_slack_notifier.aws_iam_role.this["bfd_alerts"]'
terraform state rm 'module.stateless.module.cw_alarms_slack_notifier.aws_iam_role.this["bfd_notices"]'
terraform state rm 'module.stateless.module.cw_alarms_slack_notifier.aws_iam_role.this["bfd_test"]'
terraform state rm 'module.stateless.module.cw_alarms_slack_notifier.aws_iam_role.this["bfd_warnings"]'
terraform state rm 'module.stateless.module.cw_alarms_slack_notifier.aws_lambda_function.this["bfd_alerts"]'
terraform state rm 'module.stateless.module.cw_alarms_slack_notifier.aws_lambda_function.this["bfd_notices"]'
terraform state rm 'module.stateless.module.cw_alarms_slack_notifier.aws_lambda_function.this["bfd_test"]'
terraform state rm 'module.stateless.module.cw_alarms_slack_notifier.aws_lambda_function.this["bfd_warnings"]'
terraform state rm 'module.stateless.module.cw_alarms_slack_notifier.aws_lambda_permission.this["bfd_alerts"]'
terraform state rm 'module.stateless.module.cw_alarms_slack_notifier.aws_lambda_permission.this["bfd_notices"]'
terraform state rm 'module.stateless.module.cw_alarms_slack_notifier.aws_lambda_permission.this["bfd_test"]'
terraform state rm 'module.stateless.module.cw_alarms_slack_notifier.aws_lambda_permission.this["bfd_warnings"]'
terraform state rm 'module.stateless.module.cw_alarms_slack_notifier.aws_sns_topic_subscription.this["bfd_alerts"]'
terraform state rm 'module.stateless.module.cw_alarms_slack_notifier.aws_sns_topic_subscription.this["bfd_notices"]'
terraform state rm 'module.stateless.module.cw_alarms_slack_notifier.aws_sns_topic_subscription.this["bfd_test"]'
terraform state rm 'module.stateless.module.cw_alarms_slack_notifier.aws_sns_topic_subscription.this["bfd_warnings"]'
```

</details>

### What Should Reviewers Watch For?
<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items to the following list here -->
* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [X] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [X] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [X] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [X] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [X] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [X] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [X] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [X] The data dictionary has been updated with any field mapping changes, if any were made.
* [X] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [X] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [X] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [X] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    