### PR TITLE
BFD-2575: refactor to use inputstream instead of file for unit tests

### DIFF
--- a/apps/bfd-data-npi/src/main/java/gov/cms/bfd/data/npi/utility/App.java
+++ b/apps/bfd-data-npi/src/main/java/gov/cms/bfd/data/npi/utility/App.java
@@ -28,6 +28,8 @@ public final class App {
    *       <li><code>OUTPUT_DIR</code>: the first (and only) argument for this application, which
    *           should be the path to the project's rsource directory
    *     </ol>
+   *
+   * @throws IOException if there is an issue reading file
    */
   public static void main(String[] args) throws IOException {
     if (args.length < 1) {

--- a/apps/bfd-data-npi/src/main/java/gov/cms/bfd/data/npi/utility/DataUtilityCommons.java
+++ b/apps/bfd-data-npi/src/main/java/gov/cms/bfd/data/npi/utility/DataUtilityCommons.java
@@ -47,6 +47,8 @@ public class DataUtilityCommons {
    * @param outputDir the output directory
    * @param downloadUrl the downloadUrl passed in
    * @param npiFile the npi file
+   * @throws IOException if there is an issue reading file
+   * @throws IllegalStateException if there is an issue with the output directory
    */
   public static void getNPIOrgNames(String outputDir, Optional<String> downloadUrl, String npiFile)
       throws IOException, IllegalStateException {
@@ -128,6 +130,7 @@ public class DataUtilityCommons {
    * @param workingDir a directory that temporary/working files can be written to
    * @param fileName the output file/resource to produce
    * @throws IOException (any errors encountered will be bubbled up)
+   * @throws IllegalStateException if there is an issue with NPI File
    * @return path to file
    */
   public static Path getOriginalNpiDataFile(Path workingDir, String fileName)
@@ -302,7 +305,7 @@ public class DataUtilityCommons {
    * @param fields the string array of header values.
    * @return map of indexes and field names
    */
-  private static Map<String, Integer> getIndexNumbers(String[] fields) {
+  protected static Map<String, Integer> getIndexNumbers(String[] fields) {
     Map<String, Integer> indexNumbers = new HashMap<String, Integer>();
     Integer indexCounter = 0;
     for (String field : fields) {
@@ -319,7 +322,7 @@ public class DataUtilityCommons {
    * @param indexNumbers the map of header values and indexes.
    * @return int of index
    */
-  private static int getIndexNumberForField(Map<String, Integer> indexNumbers, String fieldName) {
+  protected static int getIndexNumberForField(Map<String, Integer> indexNumbers, String fieldName) {
     if (indexNumbers.containsKey(fieldName)) {
       return indexNumbers.get(fieldName);
     }

--- a/apps/bfd-data-npi/src/main/java/gov/cms/bfd/data/npi/utility/FileNameCalculation.java
+++ b/apps/bfd-data-npi/src/main/java/gov/cms/bfd/data/npi/utility/FileNameCalculation.java
@@ -7,7 +7,8 @@ import java.util.Map;
 /** Extracts a file name. */
 public class FileNameCalculation {
   /** Base url for the nppes download. */
-  private static final String BASE_URL = "https://download.cms.gov/nppes/NPPES_Data_Dissemination_";
+  protected static final String BASE_URL =
+      "https://download.cms.gov/nppes/NPPES_Data_Dissemination_";
 
   /**
    * Extracts a file name.

--- a/apps/bfd-data-npi/src/test/java/gov/cms/bfd/data/npi/lookup/NPIOrgLookupE2ETest.java
+++ b/apps/bfd-data-npi/src/test/java/gov/cms/bfd/data/npi/lookup/NPIOrgLookupE2ETest.java
@@ -1,0 +1,40 @@
+package gov.cms.bfd.data.npi.lookup;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.io.IOException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** NPI lookup end to end test. */
+public class NPIOrgLookupE2ETest {
+
+  /** Global variable for NPILookup. */
+  NPIOrgLookup npiOrgDataLookup;
+
+  /** Global variable for npiOrgDisplay. */
+  Optional<String> npiOrgDisplay;
+
+  /** Setup method. */
+  @BeforeEach
+  void setup() throws IOException {
+    npiOrgDataLookup = NPIOrgLookup.createNpiOrgLookupForProduction();
+    npiOrgDisplay = Optional.empty();
+  }
+
+  /** End to End test for Npi Org Data with real npi number. */
+  @Test
+  public void shouldReturnRealOrgNPIDataReturnsRightOrganization() throws IOException {
+    npiOrgDisplay = npiOrgDataLookup.retrieveNPIOrgDisplay(Optional.of("1992903249"));
+    assertEquals("CAMPBELL CLINIC", npiOrgDisplay.get());
+  }
+
+  /** End to End test for Npi Org Data with wrong npi number. */
+  @Test
+  public void shouldReturnEmptyOrganizationWithAWrongNpiNumber() throws IOException {
+    npiOrgDisplay = npiOrgDataLookup.retrieveNPIOrgDisplay(Optional.of("000"));
+    assertFalse(npiOrgDisplay.isPresent());
+  }
+}

--- a/apps/bfd-data-npi/src/test/java/gov/cms/bfd/data/npi/lookup/NPIOrgLookupTest.java
+++ b/apps/bfd-data-npi/src/test/java/gov/cms/bfd/data/npi/lookup/NPIOrgLookupTest.java
@@ -1,51 +1,48 @@
 package gov.cms.bfd.data.npi.lookup;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /** NPI org lookup test. */
 public class NPIOrgLookupTest {
 
+  /** Global variable for NPILookup. */
+  NPIOrgLookup npiOrgDataLookup;
+
+  /** Global variable for npiOrgDisplay. */
+  Optional<String> npiOrgDisplay;
+
+  /** Setup Before Each test method. */
+  @BeforeEach
+  void setup() throws IOException {
+    npiOrgDataLookup = NPIOrgLookup.createNpiOrgLookupForTesting();
+    npiOrgDisplay = Optional.empty();
+  }
+
   /** Return Fake NPI Org Data when the parameter bfdServer.include.fake.drug.code is true. */
   @Test
   public void shouldReturnFakeOrgDataWhenConstructorSetToTrue() throws IOException {
-    NPIOrgLookup npiOrgDataLookup = NPIOrgLookup.createNpiOrgLookupForTesting();
-    Optional<String> npiOrgDisplay =
+    npiOrgDisplay =
         npiOrgDataLookup.retrieveNPIOrgDisplay(Optional.of(NPIOrgLookup.FAKE_NPI_NUMBER));
     assertNotEquals(null, npiOrgDisplay.get());
-  }
-
-  /**
-   * Do Not Return Fake NPI Org Data when the parameter bfdServer.include.fake.drug.code is false.
-   */
-  @Test
-  public void shouldNotReturnFakeOrgWhenConstructorSetToFalse() throws IOException {
-    NPIOrgLookup npiOrgDataLookup = NPIOrgLookup.createNpiOrgLookupForProduction();
-    Optional<String> npiOrgDisplay =
-        npiOrgDataLookup.retrieveNPIOrgDisplay(Optional.of(NPIOrgLookup.FAKE_NPI_NUMBER));
-    assertEquals(false, npiOrgDisplay.isPresent());
   }
 
   /** Return Fake NPI Org Name when the parameter bfdServer.include.fake.drug.code is true. */
   @Test
   public void shouldReturnFakeNPIOrgNameWhenConstructorSetToTrue() throws IOException {
-    NPIOrgLookup npiOrgDataLookup = NPIOrgLookup.createNpiOrgLookupForTesting();
-    Optional<String> npiOrgDisplay =
+    npiOrgDisplay =
         npiOrgDataLookup.retrieveNPIOrgDisplay(Optional.of(NPIOrgLookup.FAKE_NPI_NUMBER));
     assertEquals(NPIOrgLookup.FAKE_NPI_ORG_NAME, npiOrgDisplay.get());
-  }
-
-  /** Return Fake NPI Org Name when the parameter bfdServer.include.fake.drug.code is true. */
-  @Test
-  public void shouldNotReturnFakeNPIOrgNameWhenConstructorSetToFalse() throws IOException {
-    NPIOrgLookup npiOrgDataLookup = NPIOrgLookup.createNpiOrgLookupForProduction();
-    Optional<String> npiOrgDisplay =
-        npiOrgDataLookup.retrieveNPIOrgDisplay(Optional.of(NPIOrgLookup.FAKE_NPI_NUMBER));
-    assertEquals(false, npiOrgDisplay.isPresent());
   }
 
   /**
@@ -54,8 +51,7 @@ public class NPIOrgLookupTest {
    */
   @Test
   public void shouldNotReturnWhenNPINumberIsEmptyAndWhenConstructorSetToTrue() throws IOException {
-    NPIOrgLookup npiOrgDataLookup = NPIOrgLookup.createNpiOrgLookupForTesting();
-    Optional<String> npiOrgDisplay = npiOrgDataLookup.retrieveNPIOrgDisplay(Optional.empty());
+    npiOrgDisplay = npiOrgDataLookup.retrieveNPIOrgDisplay(Optional.empty());
     assertEquals(false, npiOrgDisplay.isPresent());
   }
 
@@ -66,8 +62,43 @@ public class NPIOrgLookupTest {
   @Test
   public void shouldNotReturnWhenNPINumberIEmptyStringAndWhenConstructorSetToTrue()
       throws IOException {
-    NPIOrgLookup npiOrgDataLookup = NPIOrgLookup.createNpiOrgLookupForTesting();
-    Optional<String> npiOrgDisplay = npiOrgDataLookup.retrieveNPIOrgDisplay(Optional.of(""));
+    npiOrgDisplay = npiOrgDataLookup.retrieveNPIOrgDisplay(Optional.of(""));
     assertEquals(false, npiOrgDisplay.isPresent());
+  }
+
+  /** Should Return Map When Input Stream Is Formatted Correctly. */
+  @Test
+  public void shouldReturnMapWhenInputStreamIsFormattedCorrectly() throws IOException {
+    String initialString =
+        npiOrgDataLookup.FAKE_NPI_NUMBER + "\t" + npiOrgDataLookup.FAKE_NPI_ORG_NAME;
+    InputStream targetStream = new ByteArrayInputStream(initialString.getBytes());
+    Map<String, String> npiOrgMap = npiOrgDataLookup.readNPIOrgDataStream(targetStream);
+    assertFalse(isNullOrEmptyMap(npiOrgMap));
+    assertEquals(
+        npiOrgDataLookup.FAKE_NPI_ORG_NAME, npiOrgMap.get(npiOrgDataLookup.FAKE_NPI_NUMBER));
+  }
+
+  /** Should Not Return Map When Input Stream Is Not Formatted Correctly. */
+  @Test
+  public void shouldReturnMapWhenInputStreamIsNotFormattedCorrectly() throws IOException {
+    String initialString =
+        npiOrgDataLookup.FAKE_NPI_NUMBER
+            + "\t"
+            + npiOrgDataLookup.FAKE_NPI_ORG_NAME
+            + "\t"
+            + "Extra Org";
+    InputStream targetStream = new ByteArrayInputStream(initialString.getBytes());
+    Map<String, String> npiOrgMap = npiOrgDataLookup.readNPIOrgDataStream(targetStream);
+    assertTrue(isNullOrEmptyMap(npiOrgMap));
+  }
+
+  /**
+   * Check to see if a Map is empty or null.
+   *
+   * @param map being passed in to test whether null or empty
+   * @return boolean of whether the map is empty or null
+   */
+  private static boolean isNullOrEmptyMap(Map<?, ?> map) {
+    return (map == null || map.isEmpty());
   }
 }

--- a/apps/bfd-data-npi/src/test/java/gov/cms/bfd/data/npi/utility/DataUtilityCommonsTest.java
+++ b/apps/bfd-data-npi/src/test/java/gov/cms/bfd/data/npi/utility/DataUtilityCommonsTest.java
@@ -1,0 +1,64 @@
+package gov.cms.bfd.data.npi.utility;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Data Utility Commons Test. */
+public class DataUtilityCommonsTest {
+
+  /** This returns the correct map for a file header line. */
+  @Test
+  public void returnCorrectMapForAFileHeaderLine() {
+    String[] fields = new String[] {"field1", "field2", "field3", "field4", "field5"};
+    Map<String, Integer> mapOfIndexResults = DataUtilityCommons.getIndexNumbers(fields);
+
+    for (int i = fields.length - 1; i > 0; i--) {
+      assertEquals(i, mapOfIndexResults.get(fields[i]));
+    }
+  }
+
+  /** This returns the correct index number for a field in a map of header fields. */
+  @Test
+  public void returnsCorrectIndexNumberForAMapOfHeaderFields() {
+
+    String fieldToFind = "field1";
+
+    Map<String, Integer> mapOfIndexResults =
+        new HashMap<String, Integer>() {
+          {
+            put(fieldToFind, 1);
+            put("field2", 2);
+          }
+        };
+    assertEquals(
+        mapOfIndexResults.get(fieldToFind),
+        DataUtilityCommons.getIndexNumberForField(mapOfIndexResults, fieldToFind));
+  }
+
+  /** This returns a exception when a field in a map of header fields cannot be found. */
+  @Test
+  public void returnsExceptionWhenFieldCantBeFoundInMap() {
+
+    Map<String, Integer> mapOfIndexResults =
+        new HashMap<String, Integer>() {
+          {
+            put("field1", 1);
+            put("field2", 2);
+          }
+        };
+
+    Exception exception =
+        assertThrows(
+            IllegalStateException.class,
+            () -> {
+              DataUtilityCommons.getIndexNumberForField(mapOfIndexResults, "field3");
+            });
+
+    String expectedMessage = "NPI Org File Processing Error: Cannot field fieldname field3";
+    assertEquals(expectedMessage, exception.getMessage());
+  }
+}

--- a/apps/bfd-data-npi/src/test/java/gov/cms/bfd/data/npi/utility/FileNameCalculationTest.java
+++ b/apps/bfd-data-npi/src/test/java/gov/cms/bfd/data/npi/utility/FileNameCalculationTest.java
@@ -1,0 +1,82 @@
+package gov.cms.bfd.data.npi.utility;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** File Name Calculation Test. */
+public class FileNameCalculationTest {
+  /** The calendar to use. */
+  public Calendar calendar;
+
+  /** The current month to use. */
+  public int currentMonth;
+
+  /** The current year to use. */
+  public int currentYear;
+
+  /** The expected file name to use. */
+  public String expectedFileName;
+
+  /** The File Name calcultion class to use. */
+  public FileNameCalculation fileNameCalculation;
+
+  /** Map of all the months. */
+  private Map<Integer, String> months =
+      new HashMap<Integer, String>() {
+        {
+          put(0, "January");
+          put(1, "February");
+          put(2, "March");
+          put(3, "April");
+          put(4, "May");
+          put(5, "June");
+          put(6, "July");
+          put(7, "August");
+          put(8, "September");
+          put(9, "October");
+          put(10, "November");
+          put(11, "December");
+        }
+      };
+
+  /** Setup method. */
+  @BeforeEach
+  public void setup() {
+    calendar = Calendar.getInstance();
+    currentMonth = calendar.get(Calendar.MONTH);
+    currentYear = calendar.get(Calendar.YEAR);
+    fileNameCalculation = new FileNameCalculation();
+    expectedFileName = "";
+  }
+
+  /** Happy path for file Name calculation. */
+  @Test
+  public void returnTheCorrectFileNameForCurrentMonth() {
+    String month = months.get(currentMonth);
+    expectedFileName = FileNameCalculation.BASE_URL + month + "_" + currentYear + ".zip";
+    String fileName = fileNameCalculation.getFileName(false);
+
+    assertEquals(expectedFileName, fileName);
+  }
+
+  /** Returns the month before, if its January, it will return December and the year before. */
+  @Test
+  public void returnsTheCorrectMonthBefore() {
+    String month = "";
+    if (currentMonth == 0) {
+      month = months.get(11);
+      currentYear = currentYear - 1;
+    } else {
+      month = months.get(currentMonth - 1);
+    }
+    expectedFileName = FileNameCalculation.BASE_URL + month + "_" + currentYear + ".zip";
+    String fileName = fileNameCalculation.getFileName(true);
+
+    assertEquals(expectedFileName, fileName);
+  }
+}


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BFD-2575](https://jira.cms.gov/browse/BFD-2575)

**User Story or Bug Summary:**
<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->
User Story:
TODO

Background:
This is a follow up story from a PI 3 Hackathon project aimed at cleaning up our NPI Library.

Get rid of javadoc warnings that are in the build
Decouple the unit tests that rely on the current file instead of mocking the file stream
AC:
TODO

---

### What Does This PR Do?
<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

Adds unit tests to NPI library by refactoring to use a input stream instead of the real file.  Separates End to End tests in a different file and get rids of javadoc warnings.

### What Should Reviewers Watch For?
<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items to the following list here -->
* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [X] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [X] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [X] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [X] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [X] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [X] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [X] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [X] The data dictionary has been updated with any field mapping changes, if any were made.
* [X] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [X] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [X] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [X] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    