### PR TITLE
BFD-2614: Convert subset of V2 EOB Provider E2E tests into unit tests

### DIFF
--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/pom.xml
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/pom.xml
@@ -200,6 +200,12 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3-transfer-manager</artifactId>
         </dependency>
+        <!-- Allows use of AWS common runtime client for file copying, which has improved performance -->
+        <dependency>
+            <groupId>software.amazon.awssdk.crt</groupId>
+            <artifactId>aws-crt</artifactId>
+            <version>${aws.crt.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/R4ExplanationOfBenefitResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/R4ExplanationOfBenefitResourceProvider.java
@@ -376,7 +376,7 @@ public final class R4ExplanationOfBenefitResourceProvider extends AbstractResour
           transformToEobs(
               ClaimTypeV2.CARRIER,
               findClaimTypeByPatient(ClaimTypeV2.CARRIER, beneficiaryId, lastUpdated, serviceDate),
-              Optional.of(includeTaxNumbers)));
+              includeTaxNumbers));
     }
 
     if (claimTypes.contains(ClaimTypeV2.DME) && bitSet.get(QueryUtils.DME_HAS_DATA)) {
@@ -384,7 +384,7 @@ public final class R4ExplanationOfBenefitResourceProvider extends AbstractResour
           transformToEobs(
               ClaimTypeV2.DME,
               findClaimTypeByPatient(ClaimTypeV2.DME, beneficiaryId, lastUpdated, serviceDate),
-              Optional.of(includeTaxNumbers)));
+              includeTaxNumbers));
     }
 
     if (claimTypes.contains(ClaimTypeV2.HHA) && bitSet.get(QueryUtils.HHA_HAS_DATA)) {
@@ -392,7 +392,7 @@ public final class R4ExplanationOfBenefitResourceProvider extends AbstractResour
           transformToEobs(
               ClaimTypeV2.HHA,
               findClaimTypeByPatient(ClaimTypeV2.HHA, beneficiaryId, lastUpdated, serviceDate),
-              Optional.of(includeTaxNumbers)));
+              includeTaxNumbers));
     }
 
     if (claimTypes.contains(ClaimTypeV2.HOSPICE) && bitSet.get(QueryUtils.HOSPICE_HAS_DATA)) {
@@ -400,7 +400,7 @@ public final class R4ExplanationOfBenefitResourceProvider extends AbstractResour
           transformToEobs(
               ClaimTypeV2.HOSPICE,
               findClaimTypeByPatient(ClaimTypeV2.HOSPICE, beneficiaryId, lastUpdated, serviceDate),
-              Optional.of(includeTaxNumbers)));
+              includeTaxNumbers));
     }
 
     if (claimTypes.contains(ClaimTypeV2.INPATIENT) && bitSet.get(QueryUtils.INPATIENT_HAS_DATA)) {
@@ -409,7 +409,7 @@ public final class R4ExplanationOfBenefitResourceProvider extends AbstractResour
               ClaimTypeV2.INPATIENT,
               findClaimTypeByPatient(
                   ClaimTypeV2.INPATIENT, beneficiaryId, lastUpdated, serviceDate),
-              Optional.of(includeTaxNumbers)));
+              includeTaxNumbers));
     }
 
     if (claimTypes.contains(ClaimTypeV2.OUTPATIENT) && bitSet.get(QueryUtils.OUTPATIENT_HAS_DATA)) {
@@ -418,7 +418,7 @@ public final class R4ExplanationOfBenefitResourceProvider extends AbstractResour
               ClaimTypeV2.OUTPATIENT,
               findClaimTypeByPatient(
                   ClaimTypeV2.OUTPATIENT, beneficiaryId, lastUpdated, serviceDate),
-              Optional.of(includeTaxNumbers)));
+              includeTaxNumbers));
     }
 
     if (claimTypes.contains(ClaimTypeV2.PDE) && bitSet.get(QueryUtils.PART_D_HAS_DATA)) {
@@ -426,7 +426,7 @@ public final class R4ExplanationOfBenefitResourceProvider extends AbstractResour
           transformToEobs(
               ClaimTypeV2.PDE,
               findClaimTypeByPatient(ClaimTypeV2.PDE, beneficiaryId, lastUpdated, serviceDate),
-              Optional.of(includeTaxNumbers)));
+              includeTaxNumbers));
     }
 
     if (claimTypes.contains(ClaimTypeV2.SNF) && bitSet.get(QueryUtils.SNF_HAS_DATA)) {
@@ -434,7 +434,7 @@ public final class R4ExplanationOfBenefitResourceProvider extends AbstractResour
           transformToEobs(
               ClaimTypeV2.SNF,
               findClaimTypeByPatient(ClaimTypeV2.SNF, beneficiaryId, lastUpdated, serviceDate),
-              Optional.of(includeTaxNumbers)));
+              includeTaxNumbers));
     }
 
     if (Boolean.parseBoolean(excludeSamhsa)) {
@@ -602,9 +602,9 @@ public final class R4ExplanationOfBenefitResourceProvider extends AbstractResour
    */
   @Trace
   private List<ExplanationOfBenefit> transformToEobs(
-      ClaimTypeV2 claimType, List<?> claims, Optional<Boolean> includeTaxNumbers) {
+      ClaimTypeV2 claimType, List<?> claims, boolean includeTaxNumbers) {
     return claims.stream()
-        .map(c -> transformEobClaim(c, claimType, includeTaxNumbers.orElse(false)))
+        .map(c -> transformEobClaim(c, claimType, includeTaxNumbers))
         .collect(Collectors.toList());
   }
 

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/ServerExecutor.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/ServerExecutor.java
@@ -1,8 +1,8 @@
 package gov.cms.bfd.server.war;
 
 import static gov.cms.bfd.DatabaseTestUtils.TEST_CONTAINER_DATABASE_IMAGE_DEFAULT;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import gov.cms.bfd.ProcessOutputConsumer;
 import java.io.IOException;
@@ -108,11 +108,11 @@ public class ServerExecutor {
       }
       // Fail fast if we didn't start the server correctly
       assertFalse(
-          "Server failed to start due to an error. STDOUT: " + appRunConsumer.getStdoutContents(),
-          appRunConsumer.getStdoutContents().contains(failureMessage));
+          appRunConsumer.getStdoutContents().contains(failureMessage),
+          "Server failed to start due to an error. STDOUT: " + appRunConsumer.getStdoutContents());
       assertTrue(
-          "Did not find the server start message in STDOUT: " + appRunConsumer.getStdoutContents(),
-          appRunConsumer.getStdoutContents().contains(successMessage));
+          appRunConsumer.getStdoutContents().contains(successMessage),
+          "Did not find the server start message in STDOUT: " + appRunConsumer.getStdoutContents());
     }
     // do nothing if we've already got a server started
 

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/ServerRequiredTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/ServerRequiredTest.java
@@ -31,7 +31,7 @@ public class ServerRequiredTest {
 
   /** Sets up the test server (and required datasource) if the server is not already running. */
   @BeforeAll
-  static void setup() throws IOException {
+  protected static void setup() throws IOException {
     if (!ServerExecutor.isRunning()) {
       assertTrue(
           ServerTestUtils.isValidServerDatabase(dbUrl),

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/commons/QueryUtilsTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/commons/QueryUtilsTest.java
@@ -1,8 +1,8 @@
 package gov.cms.bfd.server.war.commons;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/CarrierClaimTransformerV2Test.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/CarrierClaimTransformerV2Test.java
@@ -631,11 +631,28 @@ public class CarrierClaimTransformerV2Test {
     assertEquals(4, eob.getCareTeam().size());
   }
 
-  /** Tests that the transformer sets the expected values for the care team member entries. */
+  /** Tests that the transformer sets the expected values for the care team member entries, and does not contain
+   * duplicate entries. */
   @Test
   public void shouldHaveCareTeamMembers() {
+
+    // Load a claim with multiple lines, to test we dont get duplicate entries
+    List<Object> parsedRecords =
+            ServerTestUtils.parseData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A_MULTIPLE_CARRIER_LINES.getResources()));
+
+    CarrierClaim loadedClaim =
+            parsedRecords.stream()
+                         .filter(r -> r instanceof CarrierClaim)
+                         .map(r -> (CarrierClaim) r)
+                         .findFirst()
+                         .get();
+    loadedClaim.setLastUpdated(Instant.now());
+
+    ExplanationOfBenefit genEob = carrierClaimTransformer.transform(loadedClaim, false);
+
+
     // First member
-    CareTeamComponent member1 = TransformerTestUtilsV2.findCareTeamBySequence(1, eob.getCareTeam());
+    CareTeamComponent member1 = TransformerTestUtilsV2.findCareTeamBySequence(1, genEob.getCareTeam());
     CareTeamComponent compare1 =
         TransformerTestUtilsV2.createNpiCareTeamMember(
             1,
@@ -647,7 +664,7 @@ public class CarrierClaimTransformerV2Test {
     assertTrue(compare1.equalsDeep(member1));
 
     // Second member
-    CareTeamComponent member2 = TransformerTestUtilsV2.findCareTeamBySequence(2, eob.getCareTeam());
+    CareTeamComponent member2 = TransformerTestUtilsV2.findCareTeamBySequence(2, genEob.getCareTeam());
     CareTeamComponent compare2 =
         TransformerTestUtilsV2.createNpiCareTeamMember(
             2,
@@ -659,7 +676,7 @@ public class CarrierClaimTransformerV2Test {
     assertTrue(compare2.equalsDeep(member2));
 
     //     // Third member
-    CareTeamComponent member3 = TransformerTestUtilsV2.findCareTeamBySequence(3, eob.getCareTeam());
+    CareTeamComponent member3 = TransformerTestUtilsV2.findCareTeamBySequence(3, genEob.getCareTeam());
     CareTeamComponent compare3 =
         TransformerTestUtilsV2.createNpiCareTeamMember(
             3,
@@ -693,7 +710,7 @@ public class CarrierClaimTransformerV2Test {
     assertTrue(compare3.equalsDeep(member3));
 
     // Fourth member
-    CareTeamComponent member4 = TransformerTestUtilsV2.findCareTeamBySequence(4, eob.getCareTeam());
+    CareTeamComponent member4 = TransformerTestUtilsV2.findCareTeamBySequence(4, genEob.getCareTeam());
     CareTeamComponent compare4 =
         TransformerTestUtilsV2.createNpiCareTeamMember(
             4,
@@ -704,6 +721,8 @@ public class CarrierClaimTransformerV2Test {
     compare4.getProvider().setDisplay("Fake ORG Name");
 
     assertTrue(compare4.equalsDeep(member4));
+
+    assertEquals(4, genEob.getCareTeam().size());
   }
 
   /**

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/CarrierClaimTransformerV2Test.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/CarrierClaimTransformerV2Test.java
@@ -631,28 +631,31 @@ public class CarrierClaimTransformerV2Test {
     assertEquals(4, eob.getCareTeam().size());
   }
 
-  /** Tests that the transformer sets the expected values for the care team member entries, and does not contain
-   * duplicate entries. */
+  /**
+   * Tests that the transformer sets the expected values for the care team member entries, and does
+   * not contain duplicate entries.
+   */
   @Test
   public void shouldHaveCareTeamMembers() {
 
     // Load a claim with multiple lines, to test we dont get duplicate entries
     List<Object> parsedRecords =
-            ServerTestUtils.parseData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A_MULTIPLE_CARRIER_LINES.getResources()));
+        ServerTestUtils.parseData(
+            Arrays.asList(StaticRifResourceGroup.SAMPLE_A_MULTIPLE_CARRIER_LINES.getResources()));
 
     CarrierClaim loadedClaim =
-            parsedRecords.stream()
-                         .filter(r -> r instanceof CarrierClaim)
-                         .map(r -> (CarrierClaim) r)
-                         .findFirst()
-                         .get();
+        parsedRecords.stream()
+            .filter(r -> r instanceof CarrierClaim)
+            .map(r -> (CarrierClaim) r)
+            .findFirst()
+            .get();
     loadedClaim.setLastUpdated(Instant.now());
 
     ExplanationOfBenefit genEob = carrierClaimTransformer.transform(loadedClaim, false);
 
-
     // First member
-    CareTeamComponent member1 = TransformerTestUtilsV2.findCareTeamBySequence(1, genEob.getCareTeam());
+    CareTeamComponent member1 =
+        TransformerTestUtilsV2.findCareTeamBySequence(1, genEob.getCareTeam());
     CareTeamComponent compare1 =
         TransformerTestUtilsV2.createNpiCareTeamMember(
             1,
@@ -664,7 +667,8 @@ public class CarrierClaimTransformerV2Test {
     assertTrue(compare1.equalsDeep(member1));
 
     // Second member
-    CareTeamComponent member2 = TransformerTestUtilsV2.findCareTeamBySequence(2, genEob.getCareTeam());
+    CareTeamComponent member2 =
+        TransformerTestUtilsV2.findCareTeamBySequence(2, genEob.getCareTeam());
     CareTeamComponent compare2 =
         TransformerTestUtilsV2.createNpiCareTeamMember(
             2,
@@ -676,7 +680,8 @@ public class CarrierClaimTransformerV2Test {
     assertTrue(compare2.equalsDeep(member2));
 
     //     // Third member
-    CareTeamComponent member3 = TransformerTestUtilsV2.findCareTeamBySequence(3, genEob.getCareTeam());
+    CareTeamComponent member3 =
+        TransformerTestUtilsV2.findCareTeamBySequence(3, genEob.getCareTeam());
     CareTeamComponent compare3 =
         TransformerTestUtilsV2.createNpiCareTeamMember(
             3,
@@ -710,7 +715,8 @@ public class CarrierClaimTransformerV2Test {
     assertTrue(compare3.equalsDeep(member3));
 
     // Fourth member
-    CareTeamComponent member4 = TransformerTestUtilsV2.findCareTeamBySequence(4, genEob.getCareTeam());
+    CareTeamComponent member4 =
+        TransformerTestUtilsV2.findCareTeamBySequence(4, genEob.getCareTeam());
     CareTeamComponent compare4 =
         TransformerTestUtilsV2.createNpiCareTeamMember(
             4,

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/R4ExplanationOfBenefitResourceProviderTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/R4ExplanationOfBenefitResourceProviderTest.java
@@ -1,27 +1,84 @@
 package gov.cms.bfd.server.war.r4.providers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ca.uhn.fhir.rest.api.Constants;
+import ca.uhn.fhir.rest.param.ReferenceParam;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import gov.cms.bfd.model.rif.Beneficiary;
+import gov.cms.bfd.model.rif.CarrierClaim;
+import gov.cms.bfd.model.rif.DMEClaim;
+import gov.cms.bfd.model.rif.HHAClaim;
+import gov.cms.bfd.model.rif.HospiceClaim;
+import gov.cms.bfd.model.rif.InpatientClaim;
+import gov.cms.bfd.model.rif.OutpatientClaim;
+import gov.cms.bfd.model.rif.PartDEvent;
+import gov.cms.bfd.model.rif.SNFClaim;
+import gov.cms.bfd.model.rif.samples.StaticRifResourceGroup;
+import gov.cms.bfd.server.war.ServerTestUtils;
+import gov.cms.bfd.server.war.commons.CommonHeaders;
 import gov.cms.bfd.server.war.commons.LoadedFilterManager;
+import gov.cms.bfd.server.war.commons.QueryUtils;
+import gov.cms.bfd.server.war.commons.TransformerConstants;
+import gov.cms.bfd.server.war.stu3.providers.ExplanationOfBenefitResourceProvider;
+import java.sql.Date;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.persistence.EntityManager;
+import javax.persistence.NoResultException;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Path;
+import javax.persistence.criteria.Root;
+import javax.persistence.criteria.Subquery;
+import javax.persistence.metamodel.SingularAttribute;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.ExplanationOfBenefit;
 import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Identifier;
+import org.hl7.fhir.r4.model.Meta;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 /**
  * Units tests for the {@link R4ExplanationOfBenefitResourceProvider} that do not require a full
  * fhir setup to validate. Anything we want to validate from the fhir client level should go in
- * {@link R4ExplanationOfBenefitResourceProviderIT}.
+ * {@link R4ExplanationOfBenefitResourceProviderE2E}.
  */
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class R4ExplanationOfBenefitResourceProviderTest {
 
   /** The class under test. */
@@ -33,6 +90,9 @@ public class R4ExplanationOfBenefitResourceProviderTest {
   /** The mocked input id value. */
   @Mock IdType eobId;
 
+  /** The mocked reference param used for search by patient. */
+  @Mock ReferenceParam patientParam;
+
   /** The mock metric registry. */
   @Mock private MetricRegistry metricRegistry;
   /** The mock samhsa matcher. */
@@ -40,23 +100,75 @@ public class R4ExplanationOfBenefitResourceProviderTest {
   /** The mock loaded filter manager. */
   @Mock private LoadedFilterManager loadedFilterManager;
 
+  /** The mock entity manager for mocking database calls. */
+  @Mock private EntityManager entityManager;
+
+  /** The mock query, for mocking DB returns. */
+  @Mock TypedQuery mockQuery;
+
+  /** The test data bene. */
+  Beneficiary testBene;
+
+  /** The mock EOB returned from a transformer. */
+  @Mock ExplanationOfBenefit testEob;
+
+  /** The mock metric timer. */
+  @Mock Timer mockTimer;
+
+  /** The mock metric timer context (used to stop the metric). */
+  @Mock Timer.Context mockTimerContext;
+
   // Mock transformers
   /** The mock transformer for carrier claims. */
-  @Mock private CarrierClaimTransformerV2 carrierClaimTransformerV2;
+  @Mock private CarrierClaimTransformerV2 carrierClaimTransformer;
+
+  /** The carrier claim returned in tests. */
+  @Mock CarrierClaim testCarrierClaim;
+
   /** The mock transformer for dme claims. */
   @Mock private DMEClaimTransformerV2 dmeClaimTransformer;
+
+  /** The carrier claim returned in tests. */
+  @Mock DMEClaim testDmeClaim;
+
   /** The mock transformer for hha claims. */
   @Mock private HHAClaimTransformerV2 hhaClaimTransformer;
+
+  /** The HHA claim returned in tests. */
+  @Mock HHAClaim testHhaClaim;
+
   /** The mock transformer for hospice claims. */
   @Mock private HospiceClaimTransformerV2 hospiceClaimTransformer;
+
+  /** The hospice claim returned in tests. */
+  @Mock HospiceClaim testHospiceClaim;
+
   /** The mock transformer for inpatient claims. */
   @Mock private InpatientClaimTransformerV2 inpatientClaimTransformer;
+
+  /** The inpatient claim returned in tests. */
+  @Mock InpatientClaim testInpatientClaim;
+
   /** The mock transformer for outpatient claims. */
   @Mock private OutpatientClaimTransformerV2 outpatientClaimTransformer;
+
+  /** The outpatient claim returned in tests. */
+  @Mock OutpatientClaim testOutpatientClaim;
+
   /** The mock transformer for part D events claims. */
   @Mock private PartDEventTransformerV2 partDEventTransformer;
+
+  /** The PDE claim returned in tests. */
+  @Mock PartDEvent testPdeClaim;
+
   /** The mock transformer for snf claims. */
-  @Mock private SNFClaimTransformerV2 snfClaimTransformerV2;
+  @Mock private SNFClaimTransformerV2 snfClaimTransformer;
+
+  /** The SNF claim returned in tests. */
+  @Mock SNFClaim testSnfClaim;
+
+  /** The re-used valid bene id value. */
+  public static String BENE_ID = "123456789";
 
   /** Sets up the test class. */
   @BeforeEach
@@ -66,15 +178,124 @@ public class R4ExplanationOfBenefitResourceProviderTest {
             metricRegistry,
             loadedFilterManager,
             samhsaMatcher,
-            carrierClaimTransformerV2,
+            carrierClaimTransformer,
             dmeClaimTransformer,
             hhaClaimTransformer,
             hospiceClaimTransformer,
             inpatientClaimTransformer,
             outpatientClaimTransformer,
             partDEventTransformer,
-            snfClaimTransformerV2);
+            snfClaimTransformer);
     lenient().when(eobId.getVersionIdPartAsLong()).thenReturn(null);
+    when(eobId.getIdPart()).thenReturn("carrier-" + BENE_ID);
+    Identifier mockId = mock(Identifier.class);
+    when(mockId.getSystem()).thenReturn("clm_id");
+    when(mockId.getValue()).thenReturn(BENE_ID);
+    when(testEob.getIdentifier()).thenReturn(List.of(mockId));
+
+    // used to get the claim type in transformer utils
+    CodeableConcept mockConcept = mock(CodeableConcept.class);
+    Coding mockCoding = mock(Coding.class);
+    when(mockCoding.getSystem()).thenReturn(TransformerConstants.CODING_SYSTEM_BBAPI_EOB_TYPE);
+    when(mockConcept.getCoding()).thenReturn(List.of(mockCoding));
+    when(mockCoding.getCode()).thenReturn("CARRIER");
+
+    when(testEob.getType()).thenReturn(mockConcept);
+    when(patientParam.getIdPart()).thenReturn(BENE_ID);
+
+    List<Object> parsedRecords =
+        ServerTestUtils.parseData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
+    testBene =
+        parsedRecords.stream()
+            .filter(r -> r instanceof Beneficiary)
+            .map(r -> (Beneficiary) r)
+            .findFirst()
+            .get();
+
+    // entity manager mocking
+    mockEntityManager();
+
+    // metrics mocking
+    when(metricRegistry.timer(any())).thenReturn(mockTimer);
+    when(mockTimer.time()).thenReturn(mockTimerContext);
+
+    // transformer mocking
+    when(carrierClaimTransformer.transform(any(), anyBoolean())).thenReturn(testEob);
+    when(inpatientClaimTransformer.transform(any())).thenReturn(testEob);
+    when(outpatientClaimTransformer.transform(any())).thenReturn(testEob);
+    when(partDEventTransformer.transform(any())).thenReturn(testEob);
+    when(hhaClaimTransformer.transform(any())).thenReturn(testEob);
+    when(snfClaimTransformer.transform(any())).thenReturn(testEob);
+    when(hospiceClaimTransformer.transform(any())).thenReturn(testEob);
+    when(dmeClaimTransformer.transform(any(), anyBoolean())).thenReturn(testEob);
+
+    setupLastUpdatedMocks();
+
+    mockHeaders();
+  }
+
+  /** Sets up the last updated mocks. */
+  private void setupLastUpdatedMocks() {
+    Meta mockMeta = mock(Meta.class);
+    when(mockMeta.getLastUpdated())
+        .thenReturn(Date.from(Instant.now().minus(1, ChronoUnit.SECONDS)));
+    when(testEob.getMeta()).thenReturn(mockMeta);
+    when(loadedFilterManager.getTransactionTime()).thenReturn(Instant.now());
+  }
+
+  /** Mocks the default header values. */
+  private void mockHeaders() {
+    when(requestDetails.getHeader(CommonHeaders.HEADER_NAME_INCLUDE_TAX_NUMBERS))
+        .thenReturn("false");
+    when(requestDetails.getHeader(CommonHeaders.HEADER_NAME_INCLUDE_ADDRESS_FIELDS))
+        .thenReturn("false");
+    // We dont use this anymore on v2, so set it to false since everything should work regardless of
+    // its value
+    when(requestDetails.getHeader(CommonHeaders.HEADER_NAME_INCLUDE_IDENTIFIERS))
+        .thenReturn("false");
+    Map<String, List<String>> headers = new HashMap<>();
+    headers.put(CommonHeaders.HEADER_NAME_INCLUDE_TAX_NUMBERS, List.of("false"));
+    headers.put(CommonHeaders.HEADER_NAME_INCLUDE_ADDRESS_FIELDS, List.of("false"));
+    headers.put(CommonHeaders.HEADER_NAME_INCLUDE_IDENTIFIERS, List.of("false"));
+    when(requestDetails.getHeaders()).thenReturn(headers);
+    when(requestDetails.getCompleteUrl()).thenReturn("test");
+  }
+
+  /** Sets up the default entity manager mocks. */
+  private void mockEntityManager() {
+    CriteriaBuilder criteriaBuilder = mock(CriteriaBuilder.class);
+    CriteriaQuery<Beneficiary> mockCriteria = mock(CriteriaQuery.class);
+    Root<Beneficiary> root = mock(Root.class);
+    Path mockPath = mock(Path.class);
+    Subquery mockSubquery = mock(Subquery.class);
+    when(entityManager.getCriteriaBuilder()).thenReturn(criteriaBuilder);
+    doReturn(mockCriteria).when(criteriaBuilder).createQuery(any());
+    when(mockCriteria.select(any())).thenReturn(mockCriteria);
+    when(mockCriteria.from(any(Class.class))).thenReturn(root);
+    when(root.get(isNull(SingularAttribute.class))).thenReturn(mockPath);
+    when(entityManager.createQuery(mockCriteria)).thenReturn(mockQuery);
+    when(mockQuery.setHint(any(), anyBoolean())).thenReturn(mockQuery);
+    when(mockQuery.setMaxResults(anyInt())).thenReturn(mockQuery);
+    when(mockQuery.getSingleResult()).thenReturn(testBene);
+    when(mockQuery.setParameter(anyString(), any())).thenReturn(mockQuery);
+    // Used for the check to see if claim data exists; needs a list of bitmask data
+    when(mockQuery.getResultList())
+        .thenReturn(
+            List.of(
+                QueryUtils.V_CARRIER_HAS_DATA
+                    + QueryUtils.V_SNF_HAS_DATA
+                    + QueryUtils.V_DME_HAS_DATA
+                    + QueryUtils.V_HHA_HAS_DATA
+                    + QueryUtils.V_HOSPICE_HAS_DATA
+                    + QueryUtils.V_INPATIENT_HAS_DATA
+                    + QueryUtils.V_OUTPATIENT_HAS_DATA
+                    + QueryUtils.V_PART_D_HAS_DATA));
+    when(mockCriteria.subquery(any())).thenReturn(mockSubquery);
+    when(mockCriteria.distinct(anyBoolean())).thenReturn(mockCriteria);
+    when(mockSubquery.select(any())).thenReturn(mockSubquery);
+    when(mockSubquery.from(any(Class.class))).thenReturn(root);
+    when(entityManager.createNativeQuery(anyString())).thenReturn(mockQuery);
+    eobProvider.setEntityManager(entityManager);
   }
 
   /**
@@ -99,6 +320,8 @@ public class R4ExplanationOfBenefitResourceProviderTest {
    */
   @Test
   public void testEobReadWhereNullIdExpectException() {
+    when(eobId.getIdPart()).thenReturn(null);
+
     InvalidRequestException exception =
         assertThrows(InvalidRequestException.class, () -> eobProvider.read(eobId, requestDetails));
     assertEquals("Missing required ExplanationOfBenefit ID", exception.getLocalizedMessage());
@@ -130,5 +353,145 @@ public class R4ExplanationOfBenefitResourceProviderTest {
         assertThrows(InvalidRequestException.class, () -> eobProvider.read(eobId, requestDetails));
     assertEquals(
         "ExplanationOfBenefit ID must not define a version", exception.getLocalizedMessage());
+  }
+
+  /**
+   * Test when reading a claim, if the claim is not found, a {@link ResourceNotFoundException} is
+   * thrown.
+   */
+  @Test
+  public void testReadWhenNoClaimsFoundExpectException() {
+    // mock no result when making JPA call
+    when(mockQuery.getSingleResult()).thenThrow(new NoResultException());
+
+    assertThrows(ResourceNotFoundException.class, () -> eobProvider.read(eobId, requestDetails));
+  }
+
+  /**
+   * Verifies that {@link ExplanationOfBenefitResourceProvider#read} works as expected for an {@link
+   * ExplanationOfBenefit} using a negative ID, which is used for synthetic data and should pass the
+   * id regex.
+   */
+  @Test
+  public void testReadWhenNegativeIdExpectEobReturned() {
+    when(eobId.getIdPart()).thenReturn("pde--123456789");
+
+    ExplanationOfBenefit eob = eobProvider.read(eobId, requestDetails);
+
+    assertEquals(testEob, eob);
+  }
+
+  /**
+   * Verifies that {@link ExplanationOfBenefitResourceProvider#read} throws an exception when the
+   * search id has an invalid id parameter.
+   */
+  @Test
+  public void testReadWhenInvalidIdExpectException() {
+    when(eobId.getIdPart()).thenReturn("-1?234");
+
+    assertThrows(InvalidRequestException.class, () -> eobProvider.read(eobId, requestDetails));
+  }
+
+  /**
+   * Verifies that {@link ExplanationOfBenefitResourceProvider#findByPatient} does not add paging
+   * values when no paging is requested.
+   */
+  @Test
+  public void testFindByPatientWithPageSizeNotProvidedExpectNoPaging() {
+
+    Bundle response =
+        eobProvider.findByPatient(patientParam, null, null, null, null, null, requestDetails);
+
+    assertNotNull(response);
+
+    assertNull(response.getLink(Constants.LINK_NEXT));
+    assertNull(response.getLink(Constants.LINK_PREVIOUS));
+    assertNull(response.getLink(Constants.LINK_FIRST));
+    assertNull(response.getLink(Constants.LINK_LAST));
+  }
+
+  /**
+   * Verifies that {@link ExplanationOfBenefitResourceProvider#findByPatient} throws an exception
+   * when using negative values for page size and start index parameters. This test expects to
+   * receive a InvalidRequestException, as negative values should result in an HTTP 400.
+   */
+  @Test
+  public void testFindByPatientWithNegativeStartIndexExpectException() {
+    // Set paging params to page size 0
+    Map<String, String[]> params = new HashMap<>();
+    params.put("startIndex", new String[] {"-1"});
+    when(requestDetails.getParameters()).thenReturn(params);
+
+    assertThrows(
+        InvalidRequestException.class,
+        () ->
+            eobProvider.findByPatient(patientParam, null, null, null, null, null, requestDetails));
+  }
+
+  /**
+   * Tests that {@link ExplanationOfBenefitResourceProvider#findByPatient} returns a bundle of size
+   * 0 if no claims are found.
+   */
+  @Test
+  public void testFindByPatientWhenNoClaimsFoundExpectEmptyBundle() {
+    // mock no result when making JPA call
+    when(mockQuery.getSingleResult()).thenThrow(NoResultException.class);
+    when(mockQuery.getResultList()).thenReturn(List.of(0));
+
+    Bundle response =
+        eobProvider.findByPatient(patientParam, null, null, null, null, null, requestDetails);
+
+    assertEquals(0, response.getTotal());
+  }
+
+  /**
+   * Verifies that {@link R4ExplanationOfBenefitResourceProvider#findByPatient} with <code>
+   * excludeSAMHSA=true</code> calls the samhsa matcher to determine if items should be removed.
+   */
+  @Test
+  public void testFindByPatientWhenExcludeSamshaTrueExpectFilterMatcherCalled() {
+
+    // the bitmask determines which claims get returned for the test, so return three
+    when(mockQuery.getResultList())
+        .thenReturn(
+            List.of(
+                QueryUtils.V_CARRIER_HAS_DATA
+                    + QueryUtils.V_SNF_HAS_DATA
+                    + QueryUtils.V_DME_HAS_DATA));
+
+    eobProvider.findByPatient(patientParam, null, null, "true", null, null, requestDetails);
+
+    // we returned three claims, so we should see three samhsa filter tests
+    verify(samhsaMatcher, times(3)).test(testEob);
+  }
+
+  /**
+   * Verifies that {@link R4ExplanationOfBenefitResourceProvider#findByPatient} with <code>
+   * excludeSAMHSA=false</code> does not call the filter for SAMHSA-related claims.
+   */
+  @Test
+  public void testFindByPatientWhenExcludeSamshaFalseExpectNoFiltering() {
+    eobProvider.findByPatient(patientParam, null, null, "false", null, null, requestDetails);
+
+    verify(samhsaMatcher, never()).test(testEob);
+  }
+
+  /**
+   * Verifies that {@link R4ExplanationOfBenefitResourceProvider#findByPatient} passes the
+   * includeTaxNumbers value to the transformer for each claim type that uses the value (currently
+   * only carrier and DME).
+   */
+  @Test
+  public void testFindByPatientIncludeTaxNumberPassedToTransformer() {
+
+    when(requestDetails.getHeader(CommonHeaders.HEADER_NAME_INCLUDE_TAX_NUMBERS))
+        .thenReturn("true");
+    when(requestDetails.getHeaders(CommonHeaders.HEADER_NAME_INCLUDE_TAX_NUMBERS))
+        .thenReturn(List.of("true"));
+
+    eobProvider.findByPatient(patientParam, null, null, null, null, null, requestDetails);
+
+    verify(carrierClaimTransformer, times(1)).transform(any(), eq(true));
+    verify(dmeClaimTransformer, times(1)).transform(any(), eq(true));
   }
 }

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/R4ExplanationOfBenefitResourceProviderTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/R4ExplanationOfBenefitResourceProviderTest.java
@@ -400,7 +400,7 @@ public class R4ExplanationOfBenefitResourceProviderTest {
   public void testFindByPatientWithPageSizeNotProvidedExpectNoPaging() {
 
     Bundle response =
-        eobProvider.findByPatient(patientParam, null, null, null, null, null, requestDetails);
+        eobProvider.findByPatient(patientParam, null, null, null, null, null, null, requestDetails);
 
     assertNotNull(response);
 
@@ -425,7 +425,8 @@ public class R4ExplanationOfBenefitResourceProviderTest {
     assertThrows(
         InvalidRequestException.class,
         () ->
-            eobProvider.findByPatient(patientParam, null, null, null, null, null, requestDetails));
+            eobProvider.findByPatient(
+                patientParam, null, null, null, null, null, null, requestDetails));
   }
 
   /**
@@ -439,7 +440,7 @@ public class R4ExplanationOfBenefitResourceProviderTest {
     when(mockQuery.getResultList()).thenReturn(List.of(0));
 
     Bundle response =
-        eobProvider.findByPatient(patientParam, null, null, null, null, null, requestDetails);
+        eobProvider.findByPatient(patientParam, null, null, null, null, null, null, requestDetails);
 
     assertEquals(0, response.getTotal());
   }
@@ -459,7 +460,7 @@ public class R4ExplanationOfBenefitResourceProviderTest {
                     + QueryUtils.V_SNF_HAS_DATA
                     + QueryUtils.V_DME_HAS_DATA));
 
-    eobProvider.findByPatient(patientParam, null, null, "true", null, null, requestDetails);
+    eobProvider.findByPatient(patientParam, null, null, "true", null, null, null, requestDetails);
 
     // we returned three claims, so we should see three samhsa filter tests
     verify(samhsaMatcher, times(3)).test(testEob);
@@ -471,7 +472,7 @@ public class R4ExplanationOfBenefitResourceProviderTest {
    */
   @Test
   public void testFindByPatientWhenExcludeSamshaFalseExpectNoFiltering() {
-    eobProvider.findByPatient(patientParam, null, null, "false", null, null, requestDetails);
+    eobProvider.findByPatient(patientParam, null, null, "false", null, null, null, requestDetails);
 
     verify(samhsaMatcher, never()).test(testEob);
   }
@@ -489,7 +490,7 @@ public class R4ExplanationOfBenefitResourceProviderTest {
     when(requestDetails.getHeaders(CommonHeaders.HEADER_NAME_INCLUDE_TAX_NUMBERS))
         .thenReturn(List.of("true"));
 
-    eobProvider.findByPatient(patientParam, null, null, null, null, null, requestDetails);
+    eobProvider.findByPatient(patientParam, null, null, null, null, null, null, requestDetails);
 
     verify(carrierClaimTransformer, times(1)).transform(any(), eq(true));
     verify(dmeClaimTransformer, times(1)).transform(any(), eq(true));


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BFD-2614](https://jira.cms.gov/browse/BFD-2614)

**User Story or Bug Summary:**
<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->
As a BFD engineer I would like the Explanation of Benefit resource provider end-to-end tests to be converted to unit/integration tests if possible so that I can more easily test the resource provider functionality in isolation.

---

### What Does This PR Do?
<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

Major:
- Renamed R4ExplanationOfBenefitResourceProviderIT to R4ExplanationOfBenefitResourceProviderE2E
- Moved some tests in the E2E to unit tests (arrows indicate being replaced by the noted unit test in the unit test class):

_readEobForMissingCarrierClaim_
_readEobForMissingDMEClaim_
_readEobForMissingHHAClaim_
_readEobForMissingHospiceClaim_
_readEobForMissingInpatientClaim_
_readEobForMissingOutpatientClaim_
_readEobForMissingPartDEvent_
_readEobForMissingSNFClaim_
-> _testReadWhenNoClaimsFoundExpectException_

_readEobForMissingNegativePartDEvent_ -> _testReadWhenNegativeIdExpectEobReturned_
_readEobForInvalidIdParamPartDEvent_ -> _testReadWhenInvalidIdExpectException_

_searchForEobsWithPagingWithNegativePagingParameters_ -> _testFindByPatientWithNegativeStartIndexExpectException_

_searchForEobsByMissingPatient_ -> _testFindByPatientWhenNoClaimsFoundExpectEmptyBundle_

_searchForNonSamhsaEobsWithExcludeSamhsaFalse_
_searchForSamhsaEobsWithExcludeSamhsaFalse_ -> _testFindByPatientWhenExcludeSamshaFalseExpectNoFiltering_
_readEobForExistingCarrierClaimForManyLines_ -> _CarrierClaimTransformerV2Test.shouldHaveCareTeamMembers_

Added the following three tests for better coverage:

_testFindByPatientWithPageSizeNotProvided_
_testFindByPatientWhenExcludeSamshaTrueExpectFilterMatcherCalled_
_testFindByPatientIncludeTaxNumberPassedToTransformer_

Minor:
- Some small documentation cleanup on E2E and unit tests where it was ambiguous/confusing
- Small cleanup in EOB resource provider where we were using a useless optional
- Small cleanup in ServerExecutor and QueryUtilsTest where we were still using Junit4 asserts, which was pulling in an unnecessary transient dependency on Junit4
- Fixed E2E test "_searchForEobsIncludeTaxNumbersHandling_" which had a TODO regarding tax numbers not being returned; added back the checks for tax numbers, but it seems the only thing wrong is care team section not being returned for DME, which I'll open a bug for. Tax numbers come back properly for carrier and DME, and care team does correctly return for Carrier.

### What Should Reviewers Watch For?
<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items to the following list here -->
* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [x] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [x] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [x] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] The data dictionary has been updated with any field mapping changes, if any were made.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    