### PR TITLE
BFD-2674: Upgrade RDS Clusters

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -229,14 +229,13 @@ try {
 				currentStage = env.STAGE_NAME
 				lock(resource: 'env_test') {
 					milestone(label: 'stage_deploy_test_common_start')
-					println "Skipping due to BFD-2673"
-					// container('bfd-cbc-build') {
-					// 	awsAuth.assumeRole()
-					// 	terraform.deployTerraservice(
-					// 		env: bfdEnv,
-					// 		directory: "ops/terraform/services/common"
-					// 	)
-					// }
+					container('bfd-cbc-build') {
+						awsAuth.assumeRole()
+						terraform.deployTerraservice(
+							env: bfdEnv,
+							directory: "ops/terraform/services/common"
+						)
+					}
 				}
 			}
 
@@ -381,14 +380,13 @@ try {
 				if (willDeployToProdEnvs) {
 					lock(resource: 'env_prod_sbx') {
 						milestone(label: 'stage_deploy_prod_sbx_common_start')
-						println "Skipping due to BFD-2673"
-						// container('bfd-cbc-build') {
-						// 	awsAuth.assumeRole()
-						// 	terraform.deployTerraservice(
-						// 		env: bfdEnv,
-						// 		directory: "ops/terraform/services/common"
-						// 	)
-						// }
+						container('bfd-cbc-build') {
+							awsAuth.assumeRole()
+							terraform.deployTerraservice(
+								env: bfdEnv,
+								directory: "ops/terraform/services/common"
+							)
+						}
 					}
 				} else {
 					org.jenkinsci.plugins.pipeline.modeldefinition.Utils.markStageSkippedForConditional('Deploy to prod-sbx')
@@ -523,14 +521,13 @@ try {
 				if (willDeployToProdEnvs) {
 					lock(resource: 'env_prod') {
 						milestone(label: 'stage_deploy_prod_common_start')
-						println "Skipping due to BFD-2673"
-						// container('bfd-cbc-build') {
-						// 	awsAuth.assumeRole()
-						// 	terraform.deployTerraservice(
-						// 		env: bfdEnv,
-						// 		directory: "ops/terraform/services/common"
-						// 	)
-						// }
+						container('bfd-cbc-build') {
+							awsAuth.assumeRole()
+							terraform.deployTerraservice(
+								env: bfdEnv,
+								directory: "ops/terraform/services/common"
+							)
+						}
 					}
 				} else {
 					org.jenkinsci.plugins.pipeline.modeldefinition.Utils.markStageSkippedForConditional('Deploy to prod')

--- a/apps/bfd-shared-test-utils/src/main/java/gov/cms/bfd/DatabaseTestUtils.java
+++ b/apps/bfd-shared-test-utils/src/main/java/gov/cms/bfd/DatabaseTestUtils.java
@@ -62,7 +62,7 @@ public final class DatabaseTestUtils {
   public static final String DEFAULT_IT_DATABASE = "jdbc:bfd-test:tc";
 
   /** The default test container image to use when nothing is provided. */
-  public static final String TEST_CONTAINER_DATABASE_IMAGE_DEFAULT = "postgres:14.6-alpine";
+  public static final String TEST_CONTAINER_DATABASE_IMAGE_DEFAULT = "postgres:14.7-alpine";
 
   /** The username used for test container database username. */
   public static final String TEST_CONTAINER_DATABASE_USERNAME = "bfd";

--- a/apps/pom.xml
+++ b/apps/pom.xml
@@ -181,7 +181,7 @@
         <its.db.url>jdbc:bfd-test:tc</its.db.url>
         <its.db.username/>
         <its.db.password/>
-        <its.testcontainer.db.image>postgres:14.6-alpine</its.testcontainer.db.image>
+        <its.testcontainer.db.image>postgres:14.7-alpine</its.testcontainer.db.image>
 
         <!-- Whether the partially adjudicated claims endpoints should be enabled -->
         <local.pac.enabled>true</local.pac.enabled>

--- a/ops/terraform/services/base/values/prod-sbx.yaml
+++ b/ops/terraform/services/base/values/prod-sbx.yaml
@@ -11,9 +11,8 @@
 /bfd/prod-sbx/common/nonsensitive/rds_aurora_family: aurora-postgresql14
 /bfd/prod-sbx/common/nonsensitive/rds_backup_retention_period: 8 # in days
 /bfd/prod-sbx/common/nonsensitive/rds_iam_database_authentication_enabled: true
-/bfd/prod-sbx/common/nonsensitive/rds_cluster_identifier: bfd-2673-prod-sbx-aurora-cluster # temporary; undo with BFD-2674
-# /bfd/prod-sbx/common/nonsensitive/rds_cluster_identifier: bfd-prod-sbx-aurora-cluster
-/bfd/prod-sbx/common/nonsensitive/rds_instance_class: db.r5.2xlarge
+/bfd/prod-sbx/common/nonsensitive/rds_cluster_identifier: bfd-prod-sbx-aurora-cluster
+/bfd/prod-sbx/common/nonsensitive/rds_instance_class: db.r6i.12xlarge
 /bfd/prod-sbx/common/nonsensitive/rds_instance_count: 2
 /bfd/prod-sbx/common/nonsensitive/rds_master_username: bfduser
 /bfd/prod-sbx/common/nonsensitive/rds_security_group: bfd-prod-sbx-aurora-cluster

--- a/ops/terraform/services/base/values/prod.yaml
+++ b/ops/terraform/services/base/values/prod.yaml
@@ -11,9 +11,8 @@
 /bfd/prod/common/nonsensitive/rds_aurora_family: aurora-postgresql14
 /bfd/prod/common/nonsensitive/rds_backup_retention_period: 8 # in days
 /bfd/prod/common/nonsensitive/rds_iam_database_authentication_enabled: true
-/bfd/prod/common/nonsensitive/rds_cluster_identifier: bfd-2673-prod-aurora-cluster # temporary override; undo with BFD-2674
-# /bfd/prod/common/nonsensitive/rds_cluster_identifier: bfd-prod-aurora-cluster
-/bfd/prod/common/nonsensitive/rds_instance_class: db.r5.12xlarge
+/bfd/prod/common/nonsensitive/rds_cluster_identifier: bfd-prod-aurora-cluster
+/bfd/prod/common/nonsensitive/rds_instance_class: db.r6i.12xlarge
 /bfd/prod/common/nonsensitive/rds_instance_count: 4
 /bfd/prod/common/nonsensitive/rds_master_username: bfduser
 /bfd/prod/common/nonsensitive/rds_security_group: bfd-prod-aurora-cluster

--- a/ops/terraform/services/base/values/test.yaml
+++ b/ops/terraform/services/base/values/test.yaml
@@ -12,7 +12,7 @@
 /bfd/test/common/nonsensitive/rds_backup_retention_period: 8 # in days
 /bfd/test/common/nonsensitive/rds_iam_database_authentication_enabled: true
 /bfd/test/common/nonsensitive/rds_cluster_identifier: bfd-test-aurora-cluster
-/bfd/test/common/nonsensitive/rds_instance_class: db.r5.12xlarge
+/bfd/test/common/nonsensitive/rds_instance_class: db.r6i.12xlarge
 /bfd/test/common/nonsensitive/rds_instance_count: 2
 /bfd/test/common/nonsensitive/rds_master_username: bfduser
 /bfd/test/common/nonsensitive/rds_security_group: bfd-test-aurora-cluster

--- a/ops/terraform/services/common/.terraform-docs.yml
+++ b/ops/terraform/services/common/.terraform-docs.yml
@@ -2,6 +2,7 @@ formatter: markdown table
 sections:
   show:
     - requirements
+    - inputs
     - resources
     - data-sources
 
@@ -13,6 +14,14 @@ content: |-
     <!-- GENERATED WITH `terraform-docs .`
          Updates to text between BEGIN_TF_DOCS and END_TFDOCS tags
          will be overwritten.
+         For more details, see the file '.terraform-docs.yml' or
+         https://terraform-docs.io/user-guide/configuration/
+    -->
+
+    {{ .Inputs }}
+
+    <!-- GENERATED WITH `terraform-docs .`
+         Manually updating the README.md will be overwritten.
          For more details, see the file '.terraform-docs.yml' or
          https://terraform-docs.io/user-guide/configuration/
     -->

--- a/ops/terraform/services/common/README.md
+++ b/ops/terraform/services/common/README.md
@@ -39,6 +39,18 @@ For more details, see the file '.terraform-docs.yml' or
 https://terraform-docs.io/user-guide/configuration/
 -->
 
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_rds_cluster_identifier_override"></a> [rds\_cluster\_identifier\_override](#input\_rds\_cluster\_identifier\_override) | RDS Cluster Identifier Override. Defaults to cluster identifier specified in centralized environmental configuration. | `string` | `null` | no |
+
+<!-- GENERATED WITH `terraform-docs .`
+Manually updating the README.md will be overwritten.
+For more details, see the file '.terraform-docs.yml' or
+https://terraform-docs.io/user-guide/configuration/
+-->
+
 ## Resources
 
 | Name | Type |

--- a/ops/terraform/services/common/app-autoscaling.tf
+++ b/ops/terraform/services/common/app-autoscaling.tf
@@ -27,8 +27,8 @@ resource "aws_appautoscaling_scheduled_action" "scale_out" {
   service_namespace  = aws_appautoscaling_target.replicas[0].service_namespace
   resource_id        = aws_appautoscaling_target.replicas[0].resource_id
   scalable_dimension = aws_appautoscaling_target.replicas[0].scalable_dimension
-  schedule = "cron(00 07 ? * MON-FRI *)"
-  timezone = "America/New_York"
+  schedule           = "cron(00 07 ? * MON-FRI *)"
+  timezone           = "America/New_York"
 
   # NOTE: min_capacity and max_capacity will count nodes that are and
   # are not managed by app-autoscaling when calculating the desired capacity.
@@ -45,8 +45,8 @@ resource "aws_appautoscaling_scheduled_action" "scale_in" {
   service_namespace  = aws_appautoscaling_target.replicas[0].service_namespace
   resource_id        = aws_appautoscaling_target.replicas[0].resource_id
   scalable_dimension = aws_appautoscaling_target.replicas[0].scalable_dimension
-  schedule = "cron(00 19 ? * MON-FRI *)"
-  timezone = "America/New_York"
+  schedule           = "cron(00 19 ? * MON-FRI *)"
+  timezone           = "America/New_York"
 
   # NOTE: min_capacity and max_capacity only impacts nodes managed by app-autoscaling
   # when this number is fewer than the number of nodes defined by the cluster

--- a/ops/terraform/services/common/aurora-cluster.tf
+++ b/ops/terraform/services/common/aurora-cluster.tf
@@ -44,7 +44,7 @@ resource "aws_rds_cluster" "aurora_cluster" {
   deletion_protection                 = !local.is_ephemeral_env # TODO: consider having this overridable in the future, especially for longer-lasting ephemeral clusters
   engine                              = "aurora-postgresql"
   engine_mode                         = "provisioned"
-  engine_version                      = "14.6"
+  engine_version                      = "14.7"
   iam_database_authentication_enabled = local.rds_iam_database_authentication_enabled
   kms_key_id                          = data.aws_kms_key.cmk.arn
   port                                = 5432

--- a/ops/terraform/services/common/main.tf
+++ b/ops/terraform/services/common/main.tf
@@ -53,7 +53,7 @@ locals {
   # RDS configuration SSM lookups
   rds_aurora_family                       = local.nonsensitive_config["rds_aurora_family"]
   rds_backup_retention_period             = local.nonsensitive_config["rds_backup_retention_period"]
-  rds_cluster_identifier                  = local.nonsensitive_config["rds_cluster_identifier"]
+  rds_cluster_identifier                  = coalesce(var.rds_cluster_identifier_override, local.nonsensitive_config["rds_cluster_identifier"])
   rds_iam_database_authentication_enabled = local.nonsensitive_config["rds_iam_database_authentication_enabled"]
   rds_instance_class                      = local.nonsensitive_config["rds_instance_class"]
   rds_instance_count                      = local.nonsensitive_config["rds_instance_count"]


### PR DESCRIPTION
**JIRA Ticket:**
[BFD-2674](https://jira.cms.gov/browse/BFD-2674)

**User Story or Bug Summary:**
This change set supports the upgrade to the 6th generation database instances and minor upgrade to Aurora PostgreSQL 14.7.

---

### What Does This PR Do?
- encode the logic for db.r6i instances for the Aurora PostgreSQL 14.7 Aurora Clusters for path-to-production environments.
- point `prod-sbx` and `prod` environments to their respective, primary data stores
- introduce a new override variable to allow for specifying alternative rds_cluster_identifier values for exceptional use cases in the `common` terraservice, useful in case of upgrades like this
- include minor fixes for formatting and documentation updates in the `common` terraservice
- re-enable `common` terraservice deployments
- update test references from 14.6 to 14.7

These changes have been supported by out-of-band operations that made necessary adjustments directly against the primary, path-to-production data stores.

### What Should Reviewers Watch For?
<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items to the following list here -->
* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [x] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [x] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [x] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] The data dictionary has been updated with any field mapping changes, if any were made.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.