### PR TITLE
BFD-2720: Fix bug with samhsa matcher class cast in RDA logic

### DIFF
--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/pac/R4ClaimSamhsaMatcher.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/pac/R4ClaimSamhsaMatcher.java
@@ -1,5 +1,7 @@
 package gov.cms.bfd.server.war.r4.providers.pac;
 
+import gov.cms.bfd.model.rda.RdaFissClaim;
+import gov.cms.bfd.model.rda.RdaMcsClaim;
 import gov.cms.bfd.server.war.adapters.CodeableConcept;
 import gov.cms.bfd.server.war.adapters.r4.ClaimAdapter;
 import gov.cms.bfd.server.war.commons.AbstractSamhsaMatcher;
@@ -20,6 +22,47 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public final class R4ClaimSamhsaMatcher extends AbstractSamhsaMatcher<Claim> {
+
+  /** The fiss claim transformer, used for converting resources to check for samhsa data. */
+  private final FissClaimTransformerV2 fissTransformer;
+
+  /** The mcs claim transformer, used for converting resources to check for samhsa data. */
+  private final McsClaimTransformerV2 mcsTransformer;
+
+  /**
+   * Instantiates a new samhsa matcher.
+   *
+   * <p>Resources should be instantiated by Spring, so this should only be directly called by tests.
+   *
+   * @param fissClaimTransformer the fiss claim transformer
+   * @param mcsClaimTransformer the mcs claim transformer
+   */
+  public R4ClaimSamhsaMatcher(
+      FissClaimTransformerV2 fissClaimTransformer, McsClaimTransformerV2 mcsClaimTransformer) {
+    this.mcsTransformer = mcsClaimTransformer;
+    this.fissTransformer = fissClaimTransformer;
+  }
+
+  /**
+   * Determines if there are no samhsa entries in the claim.
+   *
+   * @param entity the claim to check
+   * @return {@code true} if there are no samhsa entries in the claim
+   */
+  public boolean hasNoSamhsaData(Object entity) {
+    Claim claim;
+
+    if (entity instanceof RdaFissClaim) {
+      claim = fissTransformer.transform(entity, false);
+    } else if (entity instanceof RdaMcsClaim) {
+      claim = mcsTransformer.transform(entity, false);
+    } else {
+      throw new IllegalArgumentException(
+          "Unsupported entity " + entity.getClass().getCanonicalName() + " for samhsa filtering");
+    }
+
+    return !test(claim);
+  }
 
   /** {@inheritDoc} */
   @Override

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/pac/R4ClaimResponseResourceProviderE2E.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/pac/R4ClaimResponseResourceProviderE2E.java
@@ -1,5 +1,7 @@
 package gov.cms.bfd.server.war.r4.providers.pac;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.param.DateParam;
@@ -113,6 +115,33 @@ public class R4ClaimResponseResourceProviderE2E extends ServerRequiredTest {
     ignorePatterns.add("\"/entry/[0-9]+/resource/created\"");
 
     AssertUtils.assertJsonEquals(expected, actual, ignorePatterns);
+  }
+
+  /**
+   * Tests to see if the correct response is given when a search is done for {@link ClaimResponse}s
+   * using given mbi and excludeSAMHSA=true, since this does an extra check for samhsa data.
+   */
+  @Test
+  void shouldGetClaimResponseResourcesByMbiHashWithExcludeSamhsaTrue() {
+    IGenericClient fhirClient = ServerTestUtils.get().createFhirClientV2();
+
+    Bundle claimResult =
+        fhirClient
+            .search()
+            .forResource(ClaimResponse.class)
+            .where(
+                Map.of(
+                    "mbi",
+                    Collections.singletonList(new ReferenceParam(RDATestUtils.MBI_OLD_HASH)),
+                    "service-date",
+                    Arrays.asList(new DateParam("gt1970-07-18"), new DateParam("lt1970-07-25")),
+                    "excludeSAMHSA",
+                    Collections.singletonList(new ReferenceParam("true"))))
+            .returnBundle(Bundle.class)
+            .execute();
+
+    // Ensure we got a result and not an exception
+    assertNotNull(claimResult);
   }
 
   /**

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/pac/R4ClaimSamhsaMatcherTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/pac/R4ClaimSamhsaMatcherTest.java
@@ -1,0 +1,76 @@
+package gov.cms.bfd.server.war.r4.providers.pac;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import gov.cms.bfd.model.rda.RdaFissClaim;
+import gov.cms.bfd.model.rda.RdaMcsClaim;
+import java.util.ArrayList;
+import java.util.List;
+import org.hl7.fhir.r4.model.Claim;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/** Tests the methods of the {@link R4ClaimSamhsaMatcher}. */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class R4ClaimSamhsaMatcherTest {
+
+  /** The class under test. */
+  private R4ClaimSamhsaMatcher samhsaMatcher;
+
+  /** The fiss claim transformer. */
+  @Mock private FissClaimTransformerV2 mockFissTransformer;
+
+  /** The mock mcs claim transformer. */
+  @Mock private McsClaimTransformerV2 mockMcsTransformer;
+
+  /** The mock claim returned by the transformers. */
+  @Mock private Claim mockClaim;
+
+  /** Sets up the class under test and dependencies. */
+  @BeforeEach
+  public void setup() {
+    samhsaMatcher = new R4ClaimSamhsaMatcher(mockFissTransformer, mockMcsTransformer);
+    when(mockFissTransformer.transform(any(), anyBoolean())).thenReturn(mockClaim);
+    when(mockMcsTransformer.transform(any(), anyBoolean())).thenReturn(mockClaim);
+    List<Claim.ProcedureComponent> procedureComponentList = new ArrayList<>();
+    when(mockClaim.getProcedure()).thenReturn(procedureComponentList);
+  }
+
+  /**
+   * Tests that the samhsa checker is invoked and returns true when a mcs claim with no data is
+   * passed, as the matches should have nothing to match as a positive samhsa result.
+   */
+  @Test
+  public void testHasNoSamhsaDataWhenMcsClaimResponseWithNoDataExpectTrue() {
+
+    RdaMcsClaim mcsClaim = mock(RdaMcsClaim.class);
+
+    boolean hasNoSamhsa = samhsaMatcher.hasNoSamhsaData(mcsClaim);
+
+    assertTrue(hasNoSamhsa);
+  }
+
+  /**
+   * Tests that the samhsa checker is invoked and returns true when a fiss claim with no data is
+   * passed, as the matches should have nothing to match as a positive samhsa result.
+   */
+  @Test
+  public void testHasNoSamhsaDataWhenFissClaimResponseWithNoDataExpectTrue() {
+
+    RdaFissClaim fissClaim = mock(RdaFissClaim.class);
+
+    boolean hasNoSamhsa = samhsaMatcher.hasNoSamhsaData(fissClaim);
+
+    assertTrue(hasNoSamhsa);
+  }
+}

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/pac/R4ClaimSamhsaMatcherTransformerTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/pac/R4ClaimSamhsaMatcherTransformerTest.java
@@ -188,10 +188,12 @@ public class R4ClaimSamhsaMatcherTransformerTest {
 
     FissClaimTransformerV2 fissClaimTransformerV2 =
         new FissClaimTransformerV2(new MetricRegistry());
+    McsClaimTransformerV2 mcsClaimTransformerV2 = new McsClaimTransformerV2(new MetricRegistry());
 
     Claim claim = fissClaimTransformerV2.transform(entity, true);
 
-    R4ClaimSamhsaMatcher matcher = new R4ClaimSamhsaMatcher();
+    R4ClaimSamhsaMatcher matcher =
+        new R4ClaimSamhsaMatcher(fissClaimTransformerV2, mcsClaimTransformerV2);
 
     assertEquals(expectedResult, matcher.test(claim), testName + " " + errorMessagePostFix);
   }
@@ -283,11 +285,14 @@ public class R4ClaimSamhsaMatcherTransformerTest {
 
     entity.setDetails(procedures);
 
+    FissClaimTransformerV2 fissClaimTransformerV2 =
+        new FissClaimTransformerV2(new MetricRegistry());
     McsClaimTransformerV2 mcsClaimTransformerV2 = new McsClaimTransformerV2(new MetricRegistry());
 
     Claim claim = mcsClaimTransformerV2.transform(entity, true);
 
-    R4ClaimSamhsaMatcher matcher = new R4ClaimSamhsaMatcher();
+    R4ClaimSamhsaMatcher matcher =
+        new R4ClaimSamhsaMatcher(fissClaimTransformerV2, mcsClaimTransformerV2);
 
     assertEquals(expectedResult, matcher.test(claim), testName + " " + errorMessagePostFix);
   }


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BFD-2720](https://jira.cms.gov/browse/BFD-2720)

**User Story or Bug Summary:**
<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->
After a recent adjustment to the RDA code to use dependency injection, one of the side effects was a mis-cast on some logic that changed as a result of the transformer injection. This fixes that.

---

### What Does This PR Do?
<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

Root cause of this issue was injecting a single transformer based on the resource type into the resource provider. The samhsa matcher REQUIRES the resource to be transformed into a claim, so when resources were passed into the samhsa matcher of a claimResponse resource provider, it used the claimResponse transformer, attempted to cast it to a claim after, and blew up.

This fixes that by moving the samhsa determination logic into the samhsa matcher, and injects the appropriate transformers into THAT class instead of needing the resourceProvider to always have a claim transformer handy.

- Moved hasNoSamhsaData from the Abstract resource provider into the samhsa matcher class
- Inject the claim transformers needed for hasNoSamhsaData into R4ClaimSamhsaMatcher (was already an injected component, but previously had no dependencies)
- Add E2E test to make sure with excludeSamhsa=true the claimResponse endpoint does not blow up
- Add unit tests to ensure hasNoSamhsaData works with claim and claimResponse resources in its new home
- Fix the couple spots where we had instantiated the samhsa matcher to accomadate its new constructor

### What Should Reviewers Watch For?
<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items to the following list here -->
* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [x] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [x] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [x] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] The data dictionary has been updated with any field mapping changes, if any were made.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    