### PR TITLE
BFD-2731: Fix Locust test stat loading from Athena fails when trying to deserialize statistics

### DIFF
--- a/apps/utils/locust_tests/common/bfd_user_base.py
+++ b/apps/utils/locust_tests/common/bfd_user_base.py
@@ -89,7 +89,7 @@ def _(environment: Environment, **kwargs) -> None:
                 )
         except Exception as exc:
             compare_result = FinalCompareResult.FAILED
-            logger.error("Stat comparison was not able to complete; err: %s", str(exc))
+            logger.error("Stat comparison was not able to complete; err: %s", repr(exc))
 
         stats.metadata.compare_result = compare_result
         stats.metadata.validation_result = validation_result

--- a/apps/utils/locust_tests/common/stats/aggregated_stats.py
+++ b/apps/utils/locust_tests/common/stats/aggregated_stats.py
@@ -3,7 +3,7 @@ a test run as well as the representation of those statistics via dataclasses or 
 objects"""
 import hashlib
 import time
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 

--- a/apps/utils/locust_tests/common/stats/aggregated_stats.py
+++ b/apps/utils/locust_tests/common/stats/aggregated_stats.py
@@ -146,28 +146,6 @@ class TaskStats:
         )
 
     @classmethod
-    def from_list(cls, values: List[Any]) -> "TaskStats":
-        """Constructs a new instance of TaskStats given a List of values in field declaration order.
-        Used primarily to construct a TaskStats from Athena queries
-
-        Args:
-            values (List[Any]): A List of TaskStats values in field declaration order
-
-        Returns:
-            TaskStats: A TaskStats instance representing the values from the given List
-        """
-        # We assume the list is in field declaration order, otherwise we cannot
-        # create a TaskStats from it
-        inter_dict = {field.name: values[i] for i, field in enumerate(fields(cls))}
-        # response_time_percentiles will be a list as well, we need to convert it to a dict
-        inter_dict["response_time_percentiles"] = {
-            str(percentile): inter_dict["response_time_percentiles"][i]
-            for i, percentile in enumerate(PERCENTILES_TO_REPORT)
-        }
-
-        return TaskStats(**inter_dict)
-
-    @classmethod
     def __get_percentiles_dict(cls, stats_entry: StatsEntry) -> ResponseTimePercentiles:
         """Returns a dictionary of response time percentiles indicating the percentage of requests
         that completed in a particular timeframe


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BFD-2731](https://jira.cms.gov/browse/BFD-2731)

**User Story or Bug Summary:**

<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->

Locust tests that collect and compare against statistics stored in Athena, such as the Regression Suite, fail to complete stat comparison due to a recent Athena v3 engine upgrade. This new engine now properly supports returning JSON objects, in full, whereas before it would only return a list of values per object. Unfortunately, the logic for loading and deserializing stats from Athena expects the result of stats queried from Athena to be returned as JSON lists rather than as proper JSON objects. This format mismatch is causing the Regression Suite to fail.

---

### What Does This PR Do?

<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

This PR removes the special logic (`TaskStats.from_list()`) for deserializing `TaskStats` objects returned as JSON lists of values, and replaces the usages of `TaskStats.from_list()` with `dict` unpacking (as Athena now returns a full JSON object for each `TaskStats` instance, which is deserialized by Python's `json` library into a `dict`).

This resolves the deserialization issues causing Regression Suite failures.

### What Should Reviewers Watch For?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:

<!-- Add some items to the following list here -->

- Verify all PR security questions and checklists have been completed and addressed.

### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

- If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

  - Does this PR add any new software dependencies?
    - [ ] Yes
    - [x] No
  - Does this PR modify or invalidate any of our security controls?
    - [ ] Yes
    - [x] No
  - Does this PR store or transmit data that was not stored or transmitted before?
    - [ ] Yes
    - [x] No

- If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
  - Do you think this PR requires additional review of its security implications for other reasons?
    - [ ] Yes
    - [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

- N/A

### Submitter Checklist

<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

- [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
- [x] This PR is reasonably limited in scope, to help ensure that:
  1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
  2. There isn't too much of a burden on reviewers.
  3. Any problems it causes have a small "blast radius".
  4. It'll be easier to rollback if that becomes necessary.
- [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
- [x] The data dictionary has been updated with any field mapping changes, if any were made.
- [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
- [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
- [x] Reviews are requested from both:
  - At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
  - Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
- [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
  - Please review the standards every few months to ensure you're familiar with them.
