### PR TITLE
BFD-2804: Fix BFD Server scaling policies

### DIFF
--- a/ops/terraform/services/base/values/prod-sbx.yaml
+++ b/ops/terraform/services/base/values/prod-sbx.yaml
@@ -105,8 +105,8 @@
   "bfd-prod-sbx-vpc-to-dpc-test-vpc", "bfd-prod-sbx-vpc-to-dpc-dev-vpc"
   ]
 /bfd/${env}/server/nonsensitive/asg_min_instance_count: 3
-/bfd/${env}/server/nonsensitive/asg_max_instance_count: 24
-/bfd/${env}/server/nonsensitive/asg_max_warm_instance_count: 12
+/bfd/${env}/server/nonsensitive/asg_max_instance_count: 12
+/bfd/${env}/server/nonsensitive/asg_max_warm_instance_count: 9
 /bfd/${env}/server/nonsensitive/asg_desired_instance_count: 3
 # Analysis into the time required for the BFD Server to startup showed that, on average, the Server
 # starts within 30 seconds. However, we want to account for outliers and the longest time it took to

--- a/ops/terraform/services/base/values/prod-sbx.yaml
+++ b/ops/terraform/services/base/values/prod-sbx.yaml
@@ -108,7 +108,11 @@
 /bfd/${env}/server/nonsensitive/asg_max_instance_count: 24
 /bfd/${env}/server/nonsensitive/asg_max_warm_instance_count: 12
 /bfd/${env}/server/nonsensitive/asg_desired_instance_count: 3
-/bfd/${env}/server/nonsensitive/asg_instance_warmup_time: 430
+# Analysis into the time required for the BFD Server to startup showed that, on average, the Server
+# starts within 30 seconds. However, we want to account for outliers and the longest time it took to
+# start during the period analyzed was 77 seconds. So, 90 provides a decent buffer for the worst
+# cases
+/bfd/${env}/server/nonsensitive/asg_instance_warmup_time: 90
 /bfd/${env}/server/nonsensitive/launch_template_instance_type: c6i.4xlarge
 /bfd/${env}/server/nonsensitive/launch_template_volume_size_gb: 60
 # Indicates the amount of time between batched error alerts posted to Slack when 500s occur in BFD

--- a/ops/terraform/services/base/values/prod.yaml
+++ b/ops/terraform/services/base/values/prod.yaml
@@ -96,7 +96,11 @@
 /bfd/${env}/server/nonsensitive/asg_max_instance_count: 24
 /bfd/${env}/server/nonsensitive/asg_max_warm_instance_count: 12
 /bfd/${env}/server/nonsensitive/asg_desired_instance_count: 6
-/bfd/${env}/server/nonsensitive/asg_instance_warmup_time: 430
+# Analysis into the time required for the BFD Server to startup showed that, on average, the Server
+# starts within 30 seconds. However, we want to account for outliers and the longest time it took to
+# start during the period analyzed was 77 seconds. So, 90 provides a decent buffer for the worst
+# cases
+/bfd/${env}/server/nonsensitive/asg_instance_warmup_time: 90
 /bfd/${env}/server/nonsensitive/launch_template_instance_type: c6i.4xlarge
 /bfd/${env}/server/nonsensitive/launch_template_volume_size_gb: 250
 # Indicates the amount of time between batched error alerts posted to Slack when 500s occur in BFD

--- a/ops/terraform/services/base/values/prod.yaml
+++ b/ops/terraform/services/base/values/prod.yaml
@@ -92,10 +92,10 @@
   "bfd-prod-vpc-to-bcda-prod-vpc",
   "bfd-prod-to-ab2d-prod"
   ]
-/bfd/${env}/server/nonsensitive/asg_min_instance_count: 6
-/bfd/${env}/server/nonsensitive/asg_max_instance_count: 24
-/bfd/${env}/server/nonsensitive/asg_max_warm_instance_count: 12
-/bfd/${env}/server/nonsensitive/asg_desired_instance_count: 6
+/bfd/${env}/server/nonsensitive/asg_min_instance_count: 3
+/bfd/${env}/server/nonsensitive/asg_max_instance_count: 12
+/bfd/${env}/server/nonsensitive/asg_max_warm_instance_count: 9
+/bfd/${env}/server/nonsensitive/asg_desired_instance_count: 3
 # Analysis into the time required for the BFD Server to startup showed that, on average, the Server
 # starts within 30 seconds. However, we want to account for outliers and the longest time it took to
 # start during the period analyzed was 77 seconds. So, 90 provides a decent buffer for the worst

--- a/ops/terraform/services/base/values/test.yaml
+++ b/ops/terraform/services/base/values/test.yaml
@@ -90,7 +90,11 @@
 /bfd/${env}/server/nonsensitive/asg_max_instance_count: 24
 /bfd/${env}/server/nonsensitive/asg_max_warm_instance_count: 12
 /bfd/${env}/server/nonsensitive/asg_desired_instance_count: 6
-/bfd/${env}/server/nonsensitive/asg_instance_warmup_time: 430
+# Analysis into the time required for the BFD Server to startup showed that, on average, the Server
+# starts within 30 seconds. However, we want to account for outliers and the longest time it took to
+# start during the period analyzed was 77 seconds. So, 90 provides a decent buffer for the worst
+# cases
+/bfd/${env}/server/nonsensitive/asg_instance_warmup_time: 90
 /bfd/${env}/server/nonsensitive/launch_template_instance_type: c6i.4xlarge
 /bfd/${env}/server/nonsensitive/launch_template_volume_size_gb: 60
 # Indicates the amount of time between batched error alerts posted to Slack when 500s occur in BFD

--- a/ops/terraform/services/base/values/test.yaml
+++ b/ops/terraform/services/base/values/test.yaml
@@ -86,10 +86,10 @@
   [
   "bfd-test-vpc-to-bluebutton-test"
   ]
-/bfd/${env}/server/nonsensitive/asg_min_instance_count: 6
-/bfd/${env}/server/nonsensitive/asg_max_instance_count: 24
-/bfd/${env}/server/nonsensitive/asg_max_warm_instance_count: 12
-/bfd/${env}/server/nonsensitive/asg_desired_instance_count: 6
+/bfd/${env}/server/nonsensitive/asg_min_instance_count: 3
+/bfd/${env}/server/nonsensitive/asg_max_instance_count: 12
+/bfd/${env}/server/nonsensitive/asg_max_warm_instance_count: 9
+/bfd/${env}/server/nonsensitive/asg_desired_instance_count: 3
 # Analysis into the time required for the BFD Server to startup showed that, on average, the Server
 # starts within 30 seconds. However, we want to account for outliers and the longest time it took to
 # start during the period analyzed was 77 seconds. So, 90 provides a decent buffer for the worst

--- a/ops/terraform/services/server/modules/bfd_server_asg/main.tf
+++ b/ops/terraform/services/server/modules/bfd_server_asg/main.tf
@@ -237,19 +237,19 @@ resource "aws_autoscaling_policy" "filtered_networkin_low_scaling" {
 
   step_adjustment {
     metric_interval_upper_bound = "-5e+08"
-    scaling_adjustment          = -9
+    scaling_adjustment          = -(length(var.env_config.azs) * 3)
   }
 
   step_adjustment {
     metric_interval_lower_bound = "-5e+08"
     metric_interval_upper_bound = "-3e+08"
-    scaling_adjustment          = -6
+    scaling_adjustment          = -(length(var.env_config.azs) * 2)
   }
 
   step_adjustment {
     metric_interval_lower_bound = "-3e+08"
     metric_interval_upper_bound = "0"
-    scaling_adjustment          = -3
+    scaling_adjustment          = -length(var.env_config.azs)
   }
 }
 
@@ -310,19 +310,19 @@ resource "aws_autoscaling_policy" "filtered_networkin_high_scaling" {
 
   step_adjustment {
     metric_interval_lower_bound = "5e+08"
-    scaling_adjustment          = 9
+    scaling_adjustment          = length(var.env_config.azs) * 3
   }
 
   step_adjustment {
     metric_interval_lower_bound = "2e+08"
     metric_interval_upper_bound = "5e+08"
-    scaling_adjustment          = 6
+    scaling_adjustment          = length(var.env_config.azs) * 2
   }
 
   step_adjustment {
     metric_interval_lower_bound = "0"
     metric_interval_upper_bound = "2e+08"
-    scaling_adjustment          = 3
+    scaling_adjustment          = length(var.env_config.azs)
   }
 }
 ## Autoscaling Notifications

--- a/ops/terraform/services/server/modules/bfd_server_asg/main.tf
+++ b/ops/terraform/services/server/modules/bfd_server_asg/main.tf
@@ -186,7 +186,7 @@ resource "aws_cloudwatch_metric_alarm" "filtered_networkin_low" {
   comparison_operator = "LessThanThreshold"
   datapoints_to_alarm = 5
   evaluation_periods  = 5
-  threshold           = 600000000
+  threshold           = 400000000
   treat_missing_data  = "ignore"
   alarm_actions       = [aws_autoscaling_policy.filtered_networkin_low_scaling.arn]
 
@@ -236,18 +236,18 @@ resource "aws_autoscaling_policy" "filtered_networkin_low_scaling" {
   policy_type             = "StepScaling"
 
   step_adjustment {
-    metric_interval_upper_bound = "-5e+08"
+    metric_interval_upper_bound = "-3e+08"
     scaling_adjustment          = -(length(var.env_config.azs) * 3)
   }
 
   step_adjustment {
-    metric_interval_lower_bound = "-5e+08"
-    metric_interval_upper_bound = "-3e+08"
+    metric_interval_lower_bound = "-3e+08"
+    metric_interval_upper_bound = "-2e+08"
     scaling_adjustment          = -(length(var.env_config.azs) * 2)
   }
 
   step_adjustment {
-    metric_interval_lower_bound = "-3e+08"
+    metric_interval_lower_bound = "-2e+08"
     metric_interval_upper_bound = "0"
     scaling_adjustment          = -length(var.env_config.azs)
   }
@@ -309,19 +309,19 @@ resource "aws_autoscaling_policy" "filtered_networkin_high_scaling" {
   policy_type               = "StepScaling"
 
   step_adjustment {
-    metric_interval_lower_bound = "5e+08"
+    metric_interval_lower_bound = "3e+08"
     scaling_adjustment          = length(var.env_config.azs) * 3
   }
 
   step_adjustment {
-    metric_interval_lower_bound = "2e+08"
-    metric_interval_upper_bound = "5e+08"
+    metric_interval_lower_bound = "1e+08"
+    metric_interval_upper_bound = "3e+08"
     scaling_adjustment          = length(var.env_config.azs) * 2
   }
 
   step_adjustment {
     metric_interval_lower_bound = "0"
-    metric_interval_upper_bound = "2e+08"
+    metric_interval_upper_bound = "1e+08"
     scaling_adjustment          = length(var.env_config.azs)
   }
 }

--- a/ops/terraform/services/server/modules/bfd_server_asg/main.tf
+++ b/ops/terraform/services/server/modules/bfd_server_asg/main.tf
@@ -130,7 +130,7 @@ resource "aws_autoscaling_group" "main" {
   min_elb_capacity          = var.lb_config == null ? null : var.asg_config.min
   wait_for_capacity_timeout = var.lb_config == null ? null : "20m"
 
-  health_check_grace_period = var.asg_config.instance_warmup
+  health_check_grace_period = var.asg_config.instance_warmup * 2
   health_check_type         = var.lb_config == null ? "EC2" : "ELB" # Failures of ELB healthchecks are asg failures
   vpc_zone_identifier       = data.aws_subnet.app_subnets[*].id
   load_balancers            = var.lb_config == null ? [] : [var.lb_config.name]

--- a/ops/terraform/services/server/modules/bfd_server_asg/main.tf
+++ b/ops/terraform/services/server/modules/bfd_server_asg/main.tf
@@ -186,7 +186,7 @@ resource "aws_cloudwatch_metric_alarm" "filtered_networkin_low" {
   comparison_operator = "LessThanThreshold"
   datapoints_to_alarm = 5
   evaluation_periods  = 5
-  threshold           = 400000000
+  threshold           = 400 * 1000000 # 400 megabytes
   treat_missing_data  = "ignore"
   alarm_actions       = [aws_autoscaling_policy.filtered_networkin_low_scaling.arn]
 
@@ -267,7 +267,7 @@ resource "aws_cloudwatch_metric_alarm" "filtered_networkin_high" {
   comparison_operator = "GreaterThanThreshold"
   datapoints_to_alarm = 1
   evaluation_periods  = 1
-  threshold           = 100000000
+  threshold           = 100 * 1000000 # 100 megabytes
   treat_missing_data  = "ignore"
   alarm_actions       = [aws_autoscaling_policy.filtered_networkin_high_scaling.arn]
 


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BFD-2804](https://jira.cms.gov/browse/BFD-2804)

**User Story or Bug Summary:**

<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->

Current scaling policies exist to scale-out when CPU utilization increases. We found that a potentially more reliable or more realistic metric to analyze is network or traffic based.

---

### What Does This PR Do?

<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

This PR updates:
- BFD Server's scaling policies to scale based upon "filtered" `NetworkIn` (`NetworkIn` with corresponding `NetworkOut`). Essentially, BFD Server will now scale-out and scale-in depending on the amount of _incoming_ traffic to the Server ELB. These new scaling policies are tuned to be faster and more aggressive than the previous policies, opting to scale-out within a minute of heavy traffic and scale-in only after traffic has subsided for 5 minutes. 
- Capacity is now added to the ASG in multiples of the Availability Zones that BFD Server is hosted in
- The BFD Server's default desired and minimum capacity has been reduced to `3` as this new scaling policy _should_\* be aggressive enough to handle significant loads
   - This change is something I am _less_ confident in than the other changes here, and would like feedback on it. Based on historical analysis of load per-instance and network traffic, as well as the shape of typical bulk loads from our partners, I _believe_ that we should be able to reduce to 3 instances by-default. However, due to issues encountered with the Load Tests (see below), I cannot be 100% confident in this feeling. **I am open to reverting this change and revisiting this in the future**
- The ["instance warmup"](https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-default-instance-warmup.html?icmpid=docs_ec2as_help_panel) for BFD Server instances has been reduced from 430 seconds to 90 seconds, after analysis on BFD Server startup time for the past 3 months indicated that the longest time it took for an individual instance to be ready was 77 seconds.

\* Even with Cross AZ Load Balancing enabled, traffic from the Load Tests was _extremely_ sticky and load was not balanced across instances beyond the initial 3 even after scale-out. While I am still confident (based upon the analysis of historical network/CPU/etc. data) that these new Scaling Policies are _more_ appropriate than the existing policies, I am not sure if there is additional tuning necessary outside of the Scaling Policies (i.e. enabling Cross AZ balancing by-default, upgrading from the Classic Load Balancers, etc.) that would provide even more benefit

#### Scaling Policy Details

- If `NetworkIn` exceeds 100MB/min average over a minute and:
  - `NetworkIn` is _less_ than 200MB/min:
    - 1x`AvailabiltyZones` (3 as of now) instances are scaled-out, to 6 total instances
  - `NetworkIn` is _greater_ than 200MB/min but _less_ than 400MB/min:
    - 2x`AvailabiltyZones` (6 as of now) instances are scaled-out, to 9 total instances
  - `NetworkIn` is _greater_ than 400MB/min:
    - 3x`AvailabiltyZones` (9 as of now) instances are scaled-out, to 12 total instances
- If `NetworkIn` is _less_ than 400MB/min average over a 5 minute period:
  - but _greater_ than 200MB/min over 5 mins:
    - 1x`AvailabiltyZones` (3 as of now) instances are scaled-in, dropping to 9 total instances
  - but _greater_ than 100MB/min over 5 mins:
    - 2x`AvailabiltyZones` (6 as of now) instances are scaled-in, dropping to 6 total instances
  - and _less_ than 100MB/min over 5 mins:
    - 3x`AvailabiltyZones` (9 as of now) instances are scaled-in, dropping to 3 total instances

These thresholds were chosen by analyzing past bulk loads, including the load that caused this work, and finding that loads are typically indicated by `NetworkIn` exceeding 100MB/min with _large_ loads sometimes spiking above 400 MB/min.

### What Should Reviewers Watch For?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:

<!-- Add some items to the following list here -->

- Verify all PR security questions and checklists have been completed and addressed.

### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

- If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

  - Does this PR add any new software dependencies?
    - [ ] Yes
    - [x] No
  - Does this PR modify or invalidate any of our security controls?
    - [ ] Yes
    - [x] No
  - Does this PR store or transmit data that was not stored or transmitted before?
    - [ ] Yes
    - [x] No

- If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
  - Do you think this PR requires additional review of its security implications for other reasons?
    - [ ] Yes
    - [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

- N/A

### Submitter Checklist

<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

- [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
- [x] This PR is reasonably limited in scope, to help ensure that:
  1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
  2. There isn't too much of a burden on reviewers.
  3. Any problems it causes have a small "blast radius".
  4. It'll be easier to rollback if that becomes necessary.
- [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
- [x] The data dictionary has been updated with any field mapping changes, if any were made.
- [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
- [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
- [x] Reviews are requested from both:
  - At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
  - Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
- [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
  - Please review the standards every few months to ensure you're familiar with them.
