### PR TITLE
BFD-2854: Server ASG health check grace period is too low and ELB healthcheck configuration is not ideal

### DIFF
--- a/ops/terraform/services/server/modules/bfd_server_asg/main.tf
+++ b/ops/terraform/services/server/modules/bfd_server_asg/main.tf
@@ -130,7 +130,7 @@ resource "aws_autoscaling_group" "main" {
   min_elb_capacity          = var.lb_config == null ? null : var.asg_config.min
   wait_for_capacity_timeout = var.lb_config == null ? null : "20m"
 
-  health_check_grace_period = var.asg_config.instance_warmup * 2
+  health_check_grace_period = 600 # Temporary, will be lowered when/if lifecycle hooks are implemented
   health_check_type         = var.lb_config == null ? "EC2" : "ELB" # Failures of ELB healthchecks are asg failures
   vpc_zone_identifier       = data.aws_subnet.app_subnets[*].id
   load_balancers            = var.lb_config == null ? [] : [var.lb_config.name]

--- a/ops/terraform/services/server/modules/bfd_server_lb/main.tf
+++ b/ops/terraform/services/server/modules/bfd_server_lb/main.tf
@@ -32,8 +32,8 @@ resource "aws_elb" "main" {
   }
 
   health_check {
-    healthy_threshold   = 3 # Most servers are init'd within 30 seconds, so this should give enough time
-    unhealthy_threshold = 4
+    healthy_threshold   = 3 
+    unhealthy_threshold = 5 # Server, on avg, inits within 40 seconds; this gives enough time for it to do so
     target              = "TCP:${var.egress.port}"
     interval            = 10 # (seconds) Match HealthApt
     timeout             = 5  # (seconds) Match HealthApt

--- a/ops/terraform/services/server/modules/bfd_server_lb/main.tf
+++ b/ops/terraform/services/server/modules/bfd_server_lb/main.tf
@@ -32,8 +32,8 @@ resource "aws_elb" "main" {
   }
 
   health_check {
-    healthy_threshold   = 5 # Match HealthApt
-    unhealthy_threshold = 2 # Match HealthApt
+    healthy_threshold   = 3 # Most servers are init'd within 30 seconds, so this should give enough time
+    unhealthy_threshold = 4
     target              = "TCP:${var.egress.port}"
     interval            = 10 # (seconds) Match HealthApt
     timeout             = 5  # (seconds) Match HealthApt


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BFD-2584](https://jira.cms.gov/browse/BFD-2584)

**User Story or Bug Summary:**

<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->

The "health check grace period" for the Server AutoScaling Group is too low and the Elastic Load Balancer healthchecks are configured with less-than-ideal thresholds, so perfectly healthy instances are being created, quickly and erroneously being marked as `Unhealthy` before they are even _ready_ to be healthchecked, and then promptly removed from the AutoScaling Group shortly after being added even though they are truly healthy. This is causing poor behavior during scaling events.

---

### What Does This PR Do?

<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

This PR updates:

- The healthcheck grace period for the Server ASG to 600 seconds
  - This _should_ outright stop ELB healthchecks causing the erroneous removal of instances falsely identified as `Unhealthy` from the Server ASG
- The ELB healthcheck thresholds for marking instances as `Unhealthy` or `Healthy` have been changed from 2 to 5 and 5 to 3, respectively
  - This should _dramatically_ reduce the chances of a BFD Server EC2 Instance being created, set to `InService`, and then having its initial ELB healthcheck mark it as `Unhealthy` (even though we _know_ that most BFD Server instances would not be able to start in time). Due to analysis on startup times done in BFD-2804, we know that the BFD Server comes up in about 40 seconds _on average_, so the `Unhealthy` threshold being 2 (20 seconds, due to the 10-second interval on each check) essentially made it impossible for _most_ BFD Server instances to pass their initial healthcheck

Hopefully, these changes will reduce or outright eliminate the possibility of healthy instances being erroneously removed from the AutoScaling Group. The changes to the ELB healthchecks should also positively impact our performance during scaling, as instances will no longer drop from the Load Balancer after initialization because they erroneously fail their initial healthcheck.

### What Should Reviewers Watch For?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:

<!-- Add some items to the following list here -->

- Verify all PR security questions and checklists have been completed and addressed.

### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

- If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

  - Does this PR add any new software dependencies?
    - [ ] Yes
    - [x] No
  - Does this PR modify or invalidate any of our security controls?
    - [ ] Yes
    - [x] No
  - Does this PR store or transmit data that was not stored or transmitted before?
    - [ ] Yes
    - [x] No

- If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
  - Do you think this PR requires additional review of its security implications for other reasons?
    - [ ] Yes
    - [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

- N/A

### Submitter Checklist

<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

- [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
- [x] This PR is reasonably limited in scope, to help ensure that:
  1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
  2. There isn't too much of a burden on reviewers.
  3. Any problems it causes have a small "blast radius".
  4. It'll be easier to rollback if that becomes necessary.
- [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
- [x] The data dictionary has been updated with any field mapping changes, if any were made.
- [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
- [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
- [x] Reviews are requested from both:
  - At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
  - Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
- [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
  - Please review the standards every few months to ensure you're familiar with them.
