### PR TITLE
BFD-2815: Fix Inappropriate Usage of Optional

### DIFF
--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/CarrierClaimTransformerV2.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/CarrierClaimTransformerV2.java
@@ -236,7 +236,7 @@ final class CarrierClaimTransformerV2 implements ClaimTransformerInterfaceV2 {
               line.getPerformingPhysicianNpi());
 
       // Fall back to UPIN if NPI not present
-      if (!line.getPerformingPhysicianNpi().isPresent()) {
+      if (line.getPerformingPhysicianNpi().isEmpty()) {
         performing =
             TransformerUtilsV2.addCareTeamMember(
                 eob,
@@ -247,52 +247,21 @@ final class CarrierClaimTransformerV2 implements ClaimTransformerInterfaceV2 {
       }
 
       if (performing.isPresent()) {
+        CareTeamComponent careTeam = performing.get();
+
         // Update the responsible flag
-        performing.get().setResponsible(true);
+        careTeam.setResponsible(true);
         // PRVDR_SPCLTY => ExplanationOfBenefit.careTeam.qualification
-        performing
-            .get()
+        careTeam
             .setQualification(
                 TransformerUtilsV2.createCodeableConcept(
                     eob, CcwCodebookVariable.PRVDR_SPCLTY, line.getProviderSpecialityCode()));
 
-        boolean performingHasMatchingExtension =
-            TransformerUtilsV2.careTeamHasMatchingExtension(
-                performing.get(),
-                TransformerUtilsV2.getReferenceUrl(CcwCodebookVariable.CARR_LINE_PRVDR_TYPE_CD),
-                String.valueOf(line.getProviderTypeCode()));
+        // CARR_LINE_PRVDR_TYPE_CD => ExplanationOfBenefit.careTeam.extension
+        TransformerUtilsV2.addCareTeamExtension(CcwCodebookVariable.CARR_LINE_PRVDR_TYPE_CD, line.getProviderTypeCode(), careTeam, eob);
 
-        if (!performingHasMatchingExtension) {
-          // CARR_LINE_PRVDR_TYPE_CD => ExplanationOfBenefit.careTeam.extension
-          performing
-              .get()
-              .addExtension(
-                  TransformerUtilsV2.createExtensionCoding(
-                      eob,
-                      CcwCodebookVariable.CARR_LINE_PRVDR_TYPE_CD,
-                      line.getProviderTypeCode()));
-        }
-
-        performingHasMatchingExtension =
-            line.getProviderParticipatingIndCode().isPresent()
-                && TransformerUtilsV2.careTeamHasMatchingExtension(
-                    performing.get(),
-                    TransformerUtilsV2.getReferenceUrl(CcwCodebookVariable.PRTCPTNG_IND_CD),
-                    String.valueOf(line.getProviderParticipatingIndCode().get()));
-
-        // TODO - following code is wrong and needs to be fixed; this error may be
-        // for both CARRIER and DME claims, stu3 and r4.
-        // JIRA ticket: https://jira.cms.gov/browse/BFD-2815
-        if (!performingHasMatchingExtension) {
-          // PRTCPTNG_IND_CD => ExplanationOfBenefit.careTeam.extension
-          performing
-              .get()
-              .addExtension(
-                  TransformerUtilsV2.createExtensionCoding(
-                      eob,
-                      CcwCodebookVariable.PRTCPTNG_IND_CD,
-                      line.getProviderParticipatingIndCode()));
-        }
+        // PRTCPTNG_IND_CD => ExplanationOfBenefit.careTeam.extension
+        TransformerUtilsV2.addCareTeamExtension(CcwCodebookVariable.PRTCPTNG_IND_CD, line.getProviderParticipatingIndCode(), careTeam, eob);
       }
 
       if (line.getOrganizationNpi().isPresent()) {

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/CarrierClaimTransformerV2.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/CarrierClaimTransformerV2.java
@@ -252,9 +252,8 @@ final class CarrierClaimTransformerV2 implements ClaimTransformerInterfaceV2 {
         // Update the responsible flag
         careTeam.setResponsible(true);
         // PRVDR_SPCLTY => ExplanationOfBenefit.careTeam.qualification
-        careTeam.setQualification(
-            TransformerUtilsV2.createCodeableConcept(
-                eob, CcwCodebookVariable.PRVDR_SPCLTY, line.getProviderSpecialityCode()));
+        TransformerUtilsV2.addCareTeamQualification(
+            careTeam, eob, CcwCodebookVariable.PRVDR_SPCLTY, line.getProviderSpecialityCode());
 
         // CARR_LINE_PRVDR_TYPE_CD => ExplanationOfBenefit.careTeam.extension
         TransformerUtilsV2.addCareTeamExtension(

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/CarrierClaimTransformerV2.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/CarrierClaimTransformerV2.java
@@ -252,16 +252,20 @@ final class CarrierClaimTransformerV2 implements ClaimTransformerInterfaceV2 {
         // Update the responsible flag
         careTeam.setResponsible(true);
         // PRVDR_SPCLTY => ExplanationOfBenefit.careTeam.qualification
-        careTeam
-            .setQualification(
-                TransformerUtilsV2.createCodeableConcept(
-                    eob, CcwCodebookVariable.PRVDR_SPCLTY, line.getProviderSpecialityCode()));
+        careTeam.setQualification(
+            TransformerUtilsV2.createCodeableConcept(
+                eob, CcwCodebookVariable.PRVDR_SPCLTY, line.getProviderSpecialityCode()));
 
         // CARR_LINE_PRVDR_TYPE_CD => ExplanationOfBenefit.careTeam.extension
-        TransformerUtilsV2.addCareTeamExtension(CcwCodebookVariable.CARR_LINE_PRVDR_TYPE_CD, line.getProviderTypeCode(), careTeam, eob);
+        TransformerUtilsV2.addCareTeamExtension(
+            CcwCodebookVariable.CARR_LINE_PRVDR_TYPE_CD, line.getProviderTypeCode(), careTeam, eob);
 
         // PRTCPTNG_IND_CD => ExplanationOfBenefit.careTeam.extension
-        TransformerUtilsV2.addCareTeamExtension(CcwCodebookVariable.PRTCPTNG_IND_CD, line.getProviderParticipatingIndCode(), careTeam, eob);
+        TransformerUtilsV2.addCareTeamExtension(
+            CcwCodebookVariable.PRTCPTNG_IND_CD,
+            line.getProviderParticipatingIndCode(),
+            careTeam,
+            eob);
       }
 
       if (line.getOrganizationNpi().isPresent()) {

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/DMEClaimTransformerV2.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/DMEClaimTransformerV2.java
@@ -238,9 +238,8 @@ final class DMEClaimTransformerV2 implements ClaimTransformerInterfaceV2 {
         performing.get().setResponsible(true);
 
         // PRVDR_SPCLTY => ExplanationOfBenefit.careTeam.qualification
-        careTeam.setQualification(
-            TransformerUtilsV2.createCodeableConcept(
-                eob, CcwCodebookVariable.PRVDR_SPCLTY, line.getProviderSpecialityCode()));
+        TransformerUtilsV2.addCareTeamQualification(
+            careTeam, eob, CcwCodebookVariable.PRVDR_SPCLTY, line.getProviderSpecialityCode());
 
         // PRTCPTNG_IND_CD => ExplanationOfBenefit.careTeam.extension
         TransformerUtilsV2.addCareTeamExtension(

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/DMEClaimTransformerV2.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/DMEClaimTransformerV2.java
@@ -234,32 +234,14 @@ final class DMEClaimTransformerV2 implements ClaimTransformerInterfaceV2 {
 
       // Update the responsible flag
       if (performing.isPresent()) {
+        CareTeamComponent careTeam = performing.get();
         performing.get().setResponsible(true);
 
         // PRVDR_SPCLTY => ExplanationOfBenefit.careTeam.qualification
-        performing
-            .get()
-            .setQualification(
-                TransformerUtilsV2.createCodeableConcept(
-                    eob, CcwCodebookVariable.PRVDR_SPCLTY, line.getProviderSpecialityCode()));
+        careTeam.setQualification(TransformerUtilsV2.createCodeableConcept(eob, CcwCodebookVariable.PRVDR_SPCLTY, line.getProviderSpecialityCode()));
 
         // PRTCPTNG_IND_CD => ExplanationOfBenefit.careTeam.extension
-        boolean performingHasMatchingExtension =
-            line.getProviderParticipatingIndCode().isPresent()
-                && TransformerUtilsV2.careTeamHasMatchingExtension(
-                    performing.get(),
-                    TransformerUtilsV2.getReferenceUrl(CcwCodebookVariable.PRTCPTNG_IND_CD),
-                    String.valueOf(line.getProviderParticipatingIndCode().get()));
-
-        if (!performingHasMatchingExtension) {
-          performing
-              .get()
-              .addExtension(
-                  TransformerUtilsV2.createExtensionCoding(
-                      eob,
-                      CcwCodebookVariable.PRTCPTNG_IND_CD,
-                      line.getProviderParticipatingIndCode()));
-        }
+        TransformerUtilsV2.addCareTeamExtension(CcwCodebookVariable.PRTCPTNG_IND_CD, line.getProviderParticipatingIndCode(), careTeam, eob);
       }
 
       // PRVDR_STATE_CD => ExplanationOfBenefit.item.location.extension

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/DMEClaimTransformerV2.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/DMEClaimTransformerV2.java
@@ -238,10 +238,16 @@ final class DMEClaimTransformerV2 implements ClaimTransformerInterfaceV2 {
         performing.get().setResponsible(true);
 
         // PRVDR_SPCLTY => ExplanationOfBenefit.careTeam.qualification
-        careTeam.setQualification(TransformerUtilsV2.createCodeableConcept(eob, CcwCodebookVariable.PRVDR_SPCLTY, line.getProviderSpecialityCode()));
+        careTeam.setQualification(
+            TransformerUtilsV2.createCodeableConcept(
+                eob, CcwCodebookVariable.PRVDR_SPCLTY, line.getProviderSpecialityCode()));
 
         // PRTCPTNG_IND_CD => ExplanationOfBenefit.careTeam.extension
-        TransformerUtilsV2.addCareTeamExtension(CcwCodebookVariable.PRTCPTNG_IND_CD, line.getProviderParticipatingIndCode(), careTeam, eob);
+        TransformerUtilsV2.addCareTeamExtension(
+            CcwCodebookVariable.PRTCPTNG_IND_CD,
+            line.getProviderParticipatingIndCode(),
+            careTeam,
+            eob);
       }
 
       // PRVDR_STATE_CD => ExplanationOfBenefit.item.location.extension

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/InpatientClaimTransformerV2.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/InpatientClaimTransformerV2.java
@@ -194,8 +194,10 @@ final class InpatientClaimTransformerV2 implements ClaimTransformerInterfaceV2 {
         Optional.ofNullable(claimGroup.getProfessionalComponentCharge()));
 
     // CLM_TOT_PPS_CPTL_AMT => ExplanationOfBenefit.benefitBalance.financial
-    TransformerUtilsV2.addBenefitBalanceFinancialMedicalAmt(
-        eob, CcwCodebookVariable.CLM_TOT_PPS_CPTL_AMT, claimGroup.getClaimTotalPPSCapitalAmount());
+    if (claimGroup.getClaimTotalPPSCapitalAmount().isPresent()) {
+      TransformerUtilsV2.addBenefitBalanceFinancialMedicalAmt(eob, CcwCodebookVariable.CLM_TOT_PPS_CPTL_AMT,
+                                                              claimGroup.getClaimTotalPPSCapitalAmount());
+    }
 
     /*
      * add field values to the benefit balances that are common between the

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/InpatientClaimTransformerV2.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/InpatientClaimTransformerV2.java
@@ -195,8 +195,10 @@ final class InpatientClaimTransformerV2 implements ClaimTransformerInterfaceV2 {
 
     // CLM_TOT_PPS_CPTL_AMT => ExplanationOfBenefit.benefitBalance.financial
     if (claimGroup.getClaimTotalPPSCapitalAmount().isPresent()) {
-      TransformerUtilsV2.addBenefitBalanceFinancialMedicalAmt(eob, CcwCodebookVariable.CLM_TOT_PPS_CPTL_AMT,
-                                                              claimGroup.getClaimTotalPPSCapitalAmount());
+      TransformerUtilsV2.addBenefitBalanceFinancialMedicalAmt(
+          eob,
+          CcwCodebookVariable.CLM_TOT_PPS_CPTL_AMT,
+          claimGroup.getClaimTotalPPSCapitalAmount());
     }
 
     /*

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/TransformerUtilsV2.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/TransformerUtilsV2.java
@@ -60,7 +60,6 @@ import gov.cms.bfd.server.war.commons.carin.C4BBOrganizationIdentifierType;
 import gov.cms.bfd.server.war.commons.carin.C4BBPractitionerIdentifierType;
 import gov.cms.bfd.server.war.commons.carin.C4BBSupportingInfoType;
 import gov.cms.bfd.server.war.r4.providers.BeneficiaryTransformerV2.CurrencyIdentifier;
-import gov.cms.bfd.server.war.stu3.providers.TransformerUtils;
 import gov.cms.bfd.sharedutils.exceptions.BadCodeMonkeyException;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -680,17 +679,19 @@ public final class TransformerUtilsV2 {
   }
 
   /**
-   * Adds a care team extension to the supplied careTeamComponent if there is not already
-   * an extension for the supplied extensionValue and extensionValue is not empty.
+   * Adds a care team extension to the supplied careTeamComponent if there is not already an
+   * extension for the supplied extensionValue and extensionValue is not empty.
    *
    * @param codebookVariable the codebook variable to make the reference url
    * @param extensionValue the value for the extension, typically sourced from the claimLine
    * @param careTeamComponent the care team component to look for the extension in
    * @param eob the eob
    */
-  public static void addCareTeamExtension(CcwCodebookVariable codebookVariable, Optional extensionValue,
-                                          ExplanationOfBenefit.CareTeamComponent careTeamComponent,
-                                          ExplanationOfBenefit eob) {
+  public static void addCareTeamExtension(
+      CcwCodebookVariable codebookVariable,
+      Optional extensionValue,
+      ExplanationOfBenefit.CareTeamComponent careTeamComponent,
+      ExplanationOfBenefit eob) {
 
     // If our extension value is an empty optional or empty/null string, nothing to add
     if (extensionValue.isEmpty() || Strings.isNullOrEmpty(String.valueOf(extensionValue.get()))) {
@@ -703,17 +704,19 @@ public final class TransformerUtilsV2 {
   }
 
   /**
-   * Adds a care team extension to the supplied careTeamComponent if there is not already
-   * an extension for the supplied extensionValue and extensionValue is not empty.
+   * Adds a care team extension to the supplied careTeamComponent if there is not already an
+   * extension for the supplied extensionValue and extensionValue is not empty.
    *
    * @param codebookVariable the codebook variable to make the reference url
    * @param extensionValue the value for the extension, typically sourced from the claimLine
    * @param careTeamComponent the care team component to look for the extension in
    * @param eob the eob
    */
-  public static void addCareTeamExtension(CcwCodebookVariable codebookVariable, char extensionValue,
-                                          ExplanationOfBenefit.CareTeamComponent careTeamComponent,
-                                          ExplanationOfBenefit eob) {
+  public static void addCareTeamExtension(
+      CcwCodebookVariable codebookVariable,
+      char extensionValue,
+      ExplanationOfBenefit.CareTeamComponent careTeamComponent,
+      ExplanationOfBenefit eob) {
     // If our extension value is empty/null, nothing to add
     if (Strings.isNullOrEmpty(String.valueOf(extensionValue))) {
       return;
@@ -725,30 +728,32 @@ public final class TransformerUtilsV2 {
   }
 
   /**
-   * Adds a care team extension to the supplied careTeamComponent if there is not already
-   * an extension for the supplied extensionValue.
+   * Adds a care team extension to the supplied careTeamComponent if there is not already an
+   * extension for the supplied extensionValue.
    *
-   * <p>This method is kept private to dissuade the unpacking of
-   * optionals at the caller level; use the methods above for optional/char values so that we can do
-   * validation within the util method and keep it out of the calling code. If we have mandatory string
-   * values, this can be opened up, but should be noted the values should be passed in as-is from the
-   * line, not transformed prior to the call.
+   * <p>This method is kept private to dissuade the unpacking of optionals at the caller level; use
+   * the methods above for optional/char values so that we can do validation within the util method
+   * and keep it out of the calling code. If we have mandatory string values, this can be opened up,
+   * but should be noted the values should be passed in as-is from the line, not transformed prior
+   * to the call.
    *
    * @param codebookVariable the codebook variable to make the reference url
    * @param extensionValue the value for the extension, typically sourced from the claimLine
    * @param careTeamComponent the care team component to look for the extension in
    * @param eob the eob
    */
-  private static void addCareTeamExtension(CcwCodebookVariable codebookVariable, String extensionValue,
-                                          ExplanationOfBenefit.CareTeamComponent careTeamComponent,
-                                          ExplanationOfBenefit eob) {
+  private static void addCareTeamExtension(
+      CcwCodebookVariable codebookVariable,
+      String extensionValue,
+      ExplanationOfBenefit.CareTeamComponent careTeamComponent,
+      ExplanationOfBenefit eob) {
     String referenceUrl = getReferenceUrl(codebookVariable);
-    boolean hasExtension = careTeamHasMatchingExtension(careTeamComponent, referenceUrl, extensionValue);
+    boolean hasExtension =
+        careTeamHasMatchingExtension(careTeamComponent, referenceUrl, extensionValue);
 
     // If the extension doesnt exist, add it
     if (!hasExtension) {
-      careTeamComponent.addExtension(
-              createExtensionCoding(eob, codebookVariable, extensionValue));
+      careTeamComponent.addExtension(createExtensionCoding(eob, codebookVariable, extensionValue));
     }
   }
 

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/TransformerUtilsV2.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/TransformerUtilsV2.java
@@ -858,7 +858,7 @@ public final class TransformerUtilsV2 {
       CareTeamComponent careTeam,
       IAnyResource rootResource,
       CcwCodebookInterface ccwVariable,
-      Optional code) {
+      Optional<?> code) {
     // While the original code was written in such a way that implies this optional wont be empty,
     // its still an optional, so dont bother adding anything if it happens to be empty
     if (code.isEmpty()) {

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/TransformerUtilsV2.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/TransformerUtilsV2.java
@@ -831,7 +831,7 @@ public final class TransformerUtilsV2 {
    */
   static CodeableConcept createCodeableConcept(
       IAnyResource rootResource, CcwCodebookInterface ccwVariable, Optional<?> code) {
-    if (!code.isPresent()) {
+    if (code.isEmpty()) {
       throw new IllegalArgumentException();
     }
 
@@ -841,6 +841,36 @@ public final class TransformerUtilsV2 {
     concept.addCoding(coding);
 
     return concept;
+  }
+
+  /**
+   * Adds a qualification {@link CodeableConcept} to the given careTeam component, if the input code
+   * optional is not empty. If the code is empty, returns with no effect. Can safely be called to
+   * add qualification only if the value is present.
+   *
+   * @param careTeam the care team to add the
+   * @param rootResource the root resource to use for the coding
+   * @param ccwVariable the ccw variable to use for the coding
+   * @param code an optional to create the {@link CodeableConcept} from; if empty, method returns
+   *     with no action taken
+   */
+  static void addCareTeamQualification(
+      CareTeamComponent careTeam,
+      IAnyResource rootResource,
+      CcwCodebookInterface ccwVariable,
+      Optional code) {
+    // While the original code was written in such a way that implies this optional wont be empty,
+    // its still an optional, so dont bother adding anything if it happens to be empty
+    if (code.isEmpty()) {
+      return;
+    }
+
+    Coding coding = createCoding(rootResource, ccwVariable, code.get());
+
+    CodeableConcept concept = new CodeableConcept();
+    concept.addCoding(coding);
+
+    careTeam.setQualification(concept);
   }
 
   /**

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/TransformerUtilsV2.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/TransformerUtilsV2.java
@@ -689,7 +689,7 @@ public final class TransformerUtilsV2 {
    */
   public static void addCareTeamExtension(
       CcwCodebookVariable codebookVariable,
-      Optional extensionValue,
+      Optional<?> extensionValue,
       ExplanationOfBenefit.CareTeamComponent careTeamComponent,
       ExplanationOfBenefit eob) {
 

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/CarrierClaimTransformer.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/CarrierClaimTransformer.java
@@ -173,29 +173,36 @@ final class CarrierClaimTransformer implements ClaimTransformerInterface {
                 eob, CcwCodebookVariable.PRVDR_SPCLTY, claimLine.getProviderSpecialityCode()));
 
         // CARR_LINE_PRVDR_TYPE_CD => ExplanationOfBenefit.careTeam.extension
-        TransformerUtils.addCareTeamExtension(CcwCodebookVariable.CARR_LINE_PRVDR_TYPE_CD, claimLine.getProviderTypeCode(), performingCareTeamMember,
-                                              eob);
+        TransformerUtils.addCareTeamExtension(
+            CcwCodebookVariable.CARR_LINE_PRVDR_TYPE_CD,
+            claimLine.getProviderTypeCode(),
+            performingCareTeamMember,
+            eob);
 
         // PRTCPTNG_IND_CD => ExplanationOfBenefit.careTeam.extension
-        TransformerUtils.addCareTeamExtension(CcwCodebookVariable.PRTCPTNG_IND_CD, claimLine.getProviderParticipatingIndCode(), performingCareTeamMember,
-                                              eob);
+        TransformerUtils.addCareTeamExtension(
+            CcwCodebookVariable.PRTCPTNG_IND_CD,
+            claimLine.getProviderParticipatingIndCode(),
+            performingCareTeamMember,
+            eob);
 
         // addExtensionReference
-        boolean createNpiUsExtension = claimLine.getOrganizationNpi().isPresent() &&
-                !Strings.isNullOrEmpty(claimLine.getOrganizationNpi().get()) &&
-                !TransformerUtils.careTeamHasMatchingExtension(performingCareTeamMember,
-                                                               TransformerConstants.CODING_NPI_US,
-                                                               claimLine.getOrganizationNpi().get());
+        boolean createNpiUsExtension =
+            claimLine.getOrganizationNpi().isPresent()
+                && !Strings.isNullOrEmpty(claimLine.getOrganizationNpi().get())
+                && !TransformerUtils.careTeamHasMatchingExtension(
+                    performingCareTeamMember,
+                    TransformerConstants.CODING_NPI_US,
+                    claimLine.getOrganizationNpi().get());
 
-          if (createNpiUsExtension) {
-            TransformerUtils.addExtensionCoding(
-                performingCareTeamMember,
-                TransformerConstants.CODING_NPI_US,
-                TransformerConstants.CODING_NPI_US,
-                npiOrgLookup.retrieveNPIOrgDisplay(claimLine.getOrganizationNpi()),
-                claimLine.getOrganizationNpi().get());
-          }
-
+        if (createNpiUsExtension) {
+          TransformerUtils.addExtensionCoding(
+              performingCareTeamMember,
+              TransformerConstants.CODING_NPI_US,
+              TransformerConstants.CODING_NPI_US,
+              npiOrgLookup.retrieveNPIOrgDisplay(claimLine.getOrganizationNpi()),
+              claimLine.getOrganizationNpi().get());
+        }
       }
 
       /*

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/CarrierClaimTransformer.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/CarrierClaimTransformer.java
@@ -167,10 +167,11 @@ final class CarrierClaimTransformer implements ClaimTransformerInterface {
          * "specialty" codes to the `qualification` field here, and stick the "type" code into an
          * extension. TODO: suggest that the spec allows more than one `qualification` entry.
          */
-
-        performingCareTeamMember.setQualification(
-            TransformerUtils.createCodeableConcept(
-                eob, CcwCodebookVariable.PRVDR_SPCLTY, claimLine.getProviderSpecialityCode()));
+        TransformerUtils.addCareTeamQualification(
+            performingCareTeamMember,
+            eob,
+            CcwCodebookVariable.PRVDR_SPCLTY,
+            claimLine.getProviderSpecialityCode());
 
         // CARR_LINE_PRVDR_TYPE_CD => ExplanationOfBenefit.careTeam.extension
         TransformerUtils.addCareTeamExtension(

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/CarrierClaimTransformer.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/CarrierClaimTransformer.java
@@ -188,10 +188,10 @@ final class CarrierClaimTransformer implements ClaimTransformerInterface {
 
         performingHasMatchingExtension =
             claimLine.getProviderParticipatingIndCode().isPresent()
-                && TransformerUtils.careTeamHasMatchingExtension(
+                && TransformerUtils.codePresentAndCareTeamHasMatchingExtension(
                     performingCareTeamMember,
                     TransformerUtils.getReferenceUrl(CcwCodebookVariable.PRTCPTNG_IND_CD),
-                    String.valueOf(claimLine.getProviderParticipatingIndCode().get()));
+                    claimLine.getProviderParticipatingIndCode());
 
         if (!performingHasMatchingExtension) {
           performingCareTeamMember.addExtension(

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/DMEClaimTransformer.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/DMEClaimTransformer.java
@@ -181,21 +181,7 @@ final class DMEClaimTransformer implements ClaimTransformerInterface {
                 eob, CcwCodebookVariable.PRVDR_SPCLTY, claimLine.getProviderSpecialityCode()));
 
         // PRTCPTNG_IND_CD => ExplanationOfBenefit.careTeam.extension
-        boolean createCareTeamExtensionForIndCode =
-            claimLine.getProviderParticipatingIndCode().isPresent()
-                && !TransformerUtils.careTeamHasMatchingExtension(
-                    performingCareTeamMember,
-                    TransformerUtils.getReferenceUrl(CcwCodebookVariable.PRTCPTNG_IND_CD),
-                    String.valueOf(claimLine.getProviderParticipatingIndCode().get()));
-
-        // If we're missing the care team extension and this code exists, make one
-        if (createCareTeamExtensionForIndCode) {
-          performingCareTeamMember.addExtension(
-              TransformerUtils.createExtensionCoding(
-                  eob,
-                  CcwCodebookVariable.PRTCPTNG_IND_CD,
-                  claimLine.getProviderParticipatingIndCode()));
-        }
+        TransformerUtils.addCareTeamExtension(CcwCodebookVariable.PRTCPTNG_IND_CD, claimLine.getProviderParticipatingIndCode(), performingCareTeamMember, eob);
       }
 
       TransformerUtils.mapHcpcs(

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/DMEClaimTransformer.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/DMEClaimTransformer.java
@@ -176,9 +176,11 @@ final class DMEClaimTransformer implements ClaimTransformerInterface {
          * extension. TODO: suggest that the spec allows more than one
          * `qualification` entry.
          */
-        performingCareTeamMember.setQualification(
-            TransformerUtils.createCodeableConcept(
-                eob, CcwCodebookVariable.PRVDR_SPCLTY, claimLine.getProviderSpecialityCode()));
+        TransformerUtils.addCareTeamQualification(
+            performingCareTeamMember,
+            eob,
+            CcwCodebookVariable.PRVDR_SPCLTY,
+            claimLine.getProviderSpecialityCode());
 
         // PRTCPTNG_IND_CD => ExplanationOfBenefit.careTeam.extension
         TransformerUtils.addCareTeamExtension(

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/DMEClaimTransformer.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/DMEClaimTransformer.java
@@ -181,14 +181,15 @@ final class DMEClaimTransformer implements ClaimTransformerInterface {
                 eob, CcwCodebookVariable.PRVDR_SPCLTY, claimLine.getProviderSpecialityCode()));
 
         // PRTCPTNG_IND_CD => ExplanationOfBenefit.careTeam.extension
-        boolean performingHasMatchingExtension =
+        boolean createCareTeamExtensionForIndCode =
             claimLine.getProviderParticipatingIndCode().isPresent()
-                && TransformerUtils.careTeamHasMatchingExtension(
+                && !TransformerUtils.careTeamHasMatchingExtension(
                     performingCareTeamMember,
                     TransformerUtils.getReferenceUrl(CcwCodebookVariable.PRTCPTNG_IND_CD),
-                    String.valueOf(claimLine.getProviderParticipatingIndCode()));
+                    String.valueOf(claimLine.getProviderParticipatingIndCode().get()));
 
-        if (!performingHasMatchingExtension) {
+        // If we're missing the care team extension and this code exists, make one
+        if (createCareTeamExtensionForIndCode) {
           performingCareTeamMember.addExtension(
               TransformerUtils.createExtensionCoding(
                   eob,

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/DMEClaimTransformer.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/DMEClaimTransformer.java
@@ -181,7 +181,11 @@ final class DMEClaimTransformer implements ClaimTransformerInterface {
                 eob, CcwCodebookVariable.PRVDR_SPCLTY, claimLine.getProviderSpecialityCode()));
 
         // PRTCPTNG_IND_CD => ExplanationOfBenefit.careTeam.extension
-        TransformerUtils.addCareTeamExtension(CcwCodebookVariable.PRTCPTNG_IND_CD, claimLine.getProviderParticipatingIndCode(), performingCareTeamMember, eob);
+        TransformerUtils.addCareTeamExtension(
+            CcwCodebookVariable.PRTCPTNG_IND_CD,
+            claimLine.getProviderParticipatingIndCode(),
+            performingCareTeamMember,
+            eob);
       }
 
       TransformerUtils.mapHcpcs(

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/InpatientClaimTransformer.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/InpatientClaimTransformer.java
@@ -154,8 +154,7 @@ final class InpatientClaimTransformer implements ClaimTransformerInterface {
           claimGroup.getProfessionalComponentCharge());
     }
 
-    // TODO If actually nullable, should be Optional.
-    if (claimGroup.getClaimTotalPPSCapitalAmount() != null) {
+    if (claimGroup.getClaimTotalPPSCapitalAmount().isPresent()) {
       TransformerUtils.addAdjudicationTotal(
           eob,
           CcwCodebookVariable.CLM_TOT_PPS_CPTL_AMT,

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtils.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtils.java
@@ -2921,8 +2921,8 @@ public final class TransformerUtils {
   }
 
   /**
-   * Checks to see if the supplied code exists, and there is a extension that already exists in the careTeam
-   * component.
+   * Checks to see if the supplied code exists, and there is a extension that already exists in the
+   * careTeam component.
    *
    * @param careTeamComponent care team component
    * @param referenceUrl the {@link String} is the reference url to compare
@@ -2930,7 +2930,7 @@ public final class TransformerUtils {
    * @return if the code field is present and has a matching extension added already
    */
   public static boolean codePresentAndCareTeamHasMatchingExtension(
-          CareTeamComponent careTeamComponent, String referenceUrl, Optional<?> codeValue) {
+      CareTeamComponent careTeamComponent, String referenceUrl, Optional<?> codeValue) {
 
     if (codeValue.isEmpty()) {
       return false;
@@ -2940,8 +2940,8 @@ public final class TransformerUtils {
     String codeValueAsString = String.valueOf(codeValue.get());
 
     if (!Strings.isNullOrEmpty(referenceUrl)
-            && !Strings.isNullOrEmpty(codeValueAsString)
-            && careTeamComponent.getExtension().size() > 0) {
+        && !Strings.isNullOrEmpty(codeValueAsString)
+        && careTeamComponent.getExtension().size() > 0) {
 
       List<Extension> extensions = careTeamComponent.getExtensionsByUrl(referenceUrl);
 

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtils.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtils.java
@@ -3014,7 +3014,7 @@ public final class TransformerUtils {
       CareTeamComponent careTeam,
       IAnyResource rootResource,
       CcwCodebookInterface ccwVariable,
-      Optional code) {
+      Optional<?> code) {
     // While the original code was written in such a way that implies this optional wont be empty,
     // its still an optional, so dont bother adding anything if it happens to be empty
     if (code.isEmpty()) {

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtils.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtils.java
@@ -49,7 +49,6 @@ import gov.cms.bfd.server.war.commons.MedicareSegment;
 import gov.cms.bfd.server.war.commons.OffsetLinkBuilder;
 import gov.cms.bfd.server.war.commons.QueryUtils;
 import gov.cms.bfd.server.war.commons.TransformerConstants;
-import gov.cms.bfd.server.war.r4.providers.TransformerUtilsV2;
 import gov.cms.bfd.server.war.stu3.providers.BeneficiaryTransformer.CurrencyIdentifier;
 import gov.cms.bfd.sharedutils.exceptions.BadCodeMonkeyException;
 import java.io.BufferedReader;
@@ -2922,17 +2921,19 @@ public final class TransformerUtils {
   }
 
   /**
-   * Adds a care team extension to the supplied careTeamComponent if there is not already
-   * an extension for the supplied extensionValue and extensionValue is not empty.
+   * Adds a care team extension to the supplied careTeamComponent if there is not already an
+   * extension for the supplied extensionValue and extensionValue is not empty.
    *
    * @param codebookVariable the codebook variable to make the reference url
    * @param extensionValue the value for the extension, typically sourced from the claimLine
    * @param careTeamComponent the care team component to look for the extension in
    * @param eob the eob
    */
-  public static void addCareTeamExtension(CcwCodebookVariable codebookVariable, Optional extensionValue,
-                                          CareTeamComponent careTeamComponent,
-                                          ExplanationOfBenefit eob) {
+  public static void addCareTeamExtension(
+      CcwCodebookVariable codebookVariable,
+      Optional extensionValue,
+      CareTeamComponent careTeamComponent,
+      ExplanationOfBenefit eob) {
 
     // If our extension value is an empty optional or empty/null string, nothing to add
     if (extensionValue.isEmpty() || Strings.isNullOrEmpty(String.valueOf(extensionValue.get()))) {
@@ -2945,17 +2946,19 @@ public final class TransformerUtils {
   }
 
   /**
-   * Adds a care team extension to the supplied careTeamComponent if there is not already
-   * an extension for the supplied extensionValue and extensionValue is not empty.
+   * Adds a care team extension to the supplied careTeamComponent if there is not already an
+   * extension for the supplied extensionValue and extensionValue is not empty.
    *
    * @param codebookVariable the codebook variable to make the reference url
    * @param extensionValue the value for the extension, typically sourced from the claimLine
    * @param careTeamComponent the care team component to look for the extension in
    * @param eob the eob
    */
-  public static void addCareTeamExtension(CcwCodebookVariable codebookVariable, char extensionValue,
-                                          CareTeamComponent careTeamComponent,
-                                          ExplanationOfBenefit eob) {
+  public static void addCareTeamExtension(
+      CcwCodebookVariable codebookVariable,
+      char extensionValue,
+      CareTeamComponent careTeamComponent,
+      ExplanationOfBenefit eob) {
     // If our extension value is empty/null, nothing to add
     if (Strings.isNullOrEmpty(String.valueOf(extensionValue))) {
       return;
@@ -2967,30 +2970,32 @@ public final class TransformerUtils {
   }
 
   /**
-   * Adds a care team extension to the supplied careTeamComponent if there is not already
-   * an extension for the supplied extensionValue.
+   * Adds a care team extension to the supplied careTeamComponent if there is not already an
+   * extension for the supplied extensionValue.
    *
-   * <p>This method is kept private to dissuade the unpacking of
-   * optionals at the caller level; use the methods above for optional/char values so that we can do
-   * validation within the util method and keep it out of the calling code. If we have mandatory string
-   * values, this can be opened up, but should be noted the values should be passed in as-is from the
-   * line, not transformed prior to the call.
+   * <p>This method is kept private to dissuade the unpacking of optionals at the caller level; use
+   * the methods above for optional/char values so that we can do validation within the util method
+   * and keep it out of the calling code. If we have mandatory string values, this can be opened up,
+   * but should be noted the values should be passed in as-is from the line, not transformed prior
+   * to the call.
    *
    * @param codebookVariable the codebook variable to make the reference url
    * @param extensionValue the value for the extension, typically sourced from the claimLine
    * @param careTeamComponent the care team component to look for the extension in
    * @param eob the eob
    */
-  private static void addCareTeamExtension(CcwCodebookVariable codebookVariable, String extensionValue,
-                                           CareTeamComponent careTeamComponent,
-                                           ExplanationOfBenefit eob) {
+  private static void addCareTeamExtension(
+      CcwCodebookVariable codebookVariable,
+      String extensionValue,
+      CareTeamComponent careTeamComponent,
+      ExplanationOfBenefit eob) {
     String referenceUrl = getReferenceUrl(codebookVariable);
-    boolean hasExtension = careTeamHasMatchingExtension(careTeamComponent, referenceUrl, extensionValue);
+    boolean hasExtension =
+        careTeamHasMatchingExtension(careTeamComponent, referenceUrl, extensionValue);
 
     // If the extension doesnt exist, add it
     if (!hasExtension) {
-      careTeamComponent.addExtension(
-              createExtensionCoding(eob, codebookVariable, extensionValue));
+      careTeamComponent.addExtension(createExtensionCoding(eob, codebookVariable, extensionValue));
     }
   }
 

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtils.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtils.java
@@ -3000,6 +3000,36 @@ public final class TransformerUtils {
   }
 
   /**
+   * Adds a qualification {@link org.hl7.fhir.r4.model.CodeableConcept} to the given careTeam
+   * component, if the input code optional is not empty. If the code is empty, returns with no
+   * effect. Can safely be called to add qualification only if the value is present.
+   *
+   * @param careTeam the care team to add the
+   * @param rootResource the root resource to use for the coding
+   * @param ccwVariable the ccw variable to use for the coding
+   * @param code an optional to create the {@link org.hl7.fhir.r4.model.CodeableConcept} from; if
+   *     empty, method returns with no action taken
+   */
+  static void addCareTeamQualification(
+      CareTeamComponent careTeam,
+      IAnyResource rootResource,
+      CcwCodebookInterface ccwVariable,
+      Optional code) {
+    // While the original code was written in such a way that implies this optional wont be empty,
+    // its still an optional, so dont bother adding anything if it happens to be empty
+    if (code.isEmpty()) {
+      return;
+    }
+
+    Coding coding = createCoding(rootResource, ccwVariable, code.get());
+
+    CodeableConcept concept = new CodeableConcept();
+    concept.addCoding(coding);
+
+    careTeam.setQualification(concept);
+  }
+
+  /**
    * Reads ALL the NPI codes and display values from the NPI_Coded_Display_Values_Tab.txt file.
    * Refer to the README file in the src/main/resources directory.
    *

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtils.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtils.java
@@ -2931,7 +2931,7 @@ public final class TransformerUtils {
    */
   public static void addCareTeamExtension(
       CcwCodebookVariable codebookVariable,
-      Optional extensionValue,
+      Optional<?> extensionValue,
       CareTeamComponent careTeamComponent,
       ExplanationOfBenefit eob) {
 

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/CarrierClaimTransformerV2Test.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/CarrierClaimTransformerV2Test.java
@@ -1,6 +1,7 @@
 package gov.cms.bfd.server.war.r4.providers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -12,10 +13,13 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import gov.cms.bfd.data.fda.lookup.FdaDrugCodeDisplayLookup;
 import gov.cms.bfd.data.npi.lookup.NPIOrgLookup;
+import gov.cms.bfd.model.codebook.data.CcwCodebookVariable;
 import gov.cms.bfd.model.rif.entities.CarrierClaim;
+import gov.cms.bfd.model.rif.entities.CarrierClaimLine;
 import gov.cms.bfd.model.rif.samples.StaticRifResource;
 import gov.cms.bfd.model.rif.samples.StaticRifResourceGroup;
 import gov.cms.bfd.server.war.ServerTestUtils;
+import gov.cms.bfd.server.war.commons.CCWUtils;
 import gov.cms.bfd.server.war.commons.ClaimType;
 import gov.cms.bfd.server.war.commons.MedicareSegment;
 import gov.cms.bfd.server.war.commons.TransformerConstants;
@@ -698,7 +702,7 @@ public class CarrierClaimTransformerV2Test {
 
     assertTrue(compare2.equalsDeep(member2));
 
-    //     // Third member
+    // Third member
     CareTeamComponent member3 =
         TransformerTestUtilsV2.findCareTeamBySequence(3, genEob.getCareTeam());
     CareTeamComponent compare3 =
@@ -748,6 +752,42 @@ public class CarrierClaimTransformerV2Test {
     assertTrue(compare4.equalsDeep(member4));
 
     assertEquals(4, genEob.getCareTeam().size());
+  }
+
+  /**
+   * Tests that the transformer sets the expected values for the care team member extensions and
+   * does not error when only the required care team values exist.
+   */
+  @Test
+  public void testCareTeamExtensionsWhenOptionalValuesAbsent() {
+
+    List<Object> parsedRecords =
+        ServerTestUtils.parseData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
+
+    CarrierClaim loadedClaim =
+        parsedRecords.stream()
+            .filter(r -> r instanceof CarrierClaim)
+            .map(CarrierClaim.class::cast)
+            .findFirst()
+            .get();
+    loadedClaim.setLastUpdated(Instant.now());
+
+    // Set the optional care team fields to empty
+    for (CarrierClaimLine line : loadedClaim.getLines()) {
+      line.setProviderParticipatingIndCode(Optional.empty());
+      line.setProviderSpecialityCode(Optional.empty());
+    }
+
+    ExplanationOfBenefit genEob = carrierClaimTransformer.transform(loadedClaim, false);
+
+    // Ensure the extension for PRTCPTNG_IND_CD wasnt added
+    // Also the qualification coding should be empty if specialty code is not set
+    String prtIndCdUrl =
+        CCWUtils.calculateVariableReferenceUrl(CcwCodebookVariable.PRTCPTNG_IND_CD);
+    for (CareTeamComponent careTeam : genEob.getCareTeam()) {
+      assertFalse(careTeam.getExtension().stream().anyMatch(i -> i.getUrl().equals(prtIndCdUrl)));
+      assertTrue(careTeam.getQualification().getCoding().isEmpty());
+    }
   }
 
   /**

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/DMEClaimTransformerV2Test.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/DMEClaimTransformerV2Test.java
@@ -1,6 +1,7 @@
 package gov.cms.bfd.server.war.r4.providers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -11,9 +12,12 @@ import ca.uhn.fhir.parser.IParser;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import gov.cms.bfd.data.fda.lookup.FdaDrugCodeDisplayLookup;
+import gov.cms.bfd.model.codebook.data.CcwCodebookVariable;
 import gov.cms.bfd.model.rif.entities.DMEClaim;
+import gov.cms.bfd.model.rif.entities.DMEClaimLine;
 import gov.cms.bfd.model.rif.samples.StaticRifResourceGroup;
 import gov.cms.bfd.server.war.ServerTestUtils;
+import gov.cms.bfd.server.war.commons.CCWUtils;
 import gov.cms.bfd.server.war.commons.ProfileConstants;
 import gov.cms.bfd.server.war.commons.TransformerConstants;
 import java.io.IOException;
@@ -23,6 +27,7 @@ import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
@@ -200,10 +205,71 @@ public final class DMEClaimTransformerV2Test {
     // First member
     CareTeamComponent member1 = TransformerTestUtilsV2.findCareTeamBySequence(1, eob.getCareTeam());
     assertEquals("1306849450", member1.getProvider().getIdentifier().getValue());
+    assertEquals(
+        "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBClaimCareTeamRole",
+        member1.getRole().getCoding().get(0).getSystem());
+    assertEquals("referring", member1.getRole().getCoding().get(0).getCode());
 
     // Second member
     CareTeamComponent member2 = TransformerTestUtilsV2.findCareTeamBySequence(2, eob.getCareTeam());
     assertEquals("1244444444", member2.getProvider().getIdentifier().getValue());
+    assertEquals(
+        "http://hl7.org/fhir/us/carin-bb/CodeSystem/C4BBClaimCareTeamRole",
+        member2.getRole().getCoding().get(0).getSystem());
+    assertEquals("performing", member2.getRole().getCoding().get(0).getCode());
+    // Check PRTCPTNG_IND_CD extension
+    assertEquals(
+        "https://bluebutton.cms.gov/resources/variables/prtcptng_ind_cd",
+        member2.getExtension().get(0).getUrl());
+    assertEquals(
+        "https://bluebutton.cms.gov/resources/variables/prtcptng_ind_cd",
+        member2.getExtension().get(0).getUrl());
+    assertEquals("1", ((Coding) member2.getExtension().get(0).getValue()).getCode());
+    assertEquals("Participating", ((Coding) member2.getExtension().get(0).getValue()).getDisplay());
+    // Check Qualification
+    assertEquals(
+        "https://bluebutton.cms.gov/resources/variables/prvdr_spclty",
+        member2.getQualification().getCoding().get(0).getSystem());
+    assertEquals("Pharmacy (DMERC)", member2.getQualification().getCoding().get(0).getDisplay());
+    assertEquals("A5", member2.getQualification().getCoding().get(0).getCode());
+
+    assertEquals(2, eob.getCareTeam().size());
+  }
+
+  /**
+   * Tests that the transformer sets the expected values for the care team member extensions and
+   * does not error when only the required care team values exist.
+   */
+  @Test
+  public void testCareTeamExtensionsWhenOptionalValuesAbsent() {
+
+    List<Object> parsedRecords =
+        ServerTestUtils.parseData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
+
+    DMEClaim loadedClaim =
+        parsedRecords.stream()
+            .filter(r -> r instanceof DMEClaim)
+            .map(DMEClaim.class::cast)
+            .findFirst()
+            .get();
+    loadedClaim.setLastUpdated(Instant.now());
+
+    // Set the optional care team fields to empty
+    for (DMEClaimLine line : loadedClaim.getLines()) {
+      line.setProviderParticipatingIndCode(Optional.empty());
+      line.setProviderSpecialityCode(Optional.empty());
+    }
+
+    ExplanationOfBenefit genEob = dmeClaimTransformer.transform(loadedClaim, false);
+
+    // Ensure the extension for PRTCPTNG_IND_CD wasnt added
+    // Also the qualification coding should be empty if specialty code is not set
+    String prtIndCdUrl =
+        CCWUtils.calculateVariableReferenceUrl(CcwCodebookVariable.PRTCPTNG_IND_CD);
+    for (CareTeamComponent careTeam : genEob.getCareTeam()) {
+      assertFalse(careTeam.getExtension().stream().anyMatch(i -> i.getUrl().equals(prtIndCdUrl)));
+      assertTrue(careTeam.getQualification().getCoding().isEmpty());
+    }
   }
 
   /** Tests that the transformer sets the expected number of supporting info entries. */

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/TransformerUtilsV2Test.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/TransformerUtilsV2Test.java
@@ -25,6 +25,7 @@ import gov.cms.bfd.model.rif.samples.StaticRifResourceGroup;
 import gov.cms.bfd.server.sharedutils.BfdMDC;
 import gov.cms.bfd.server.war.ServerTestUtils;
 import gov.cms.bfd.server.war.commons.C4BBInstutionalClaimSubtypes;
+import gov.cms.bfd.server.war.commons.CCWUtils;
 import gov.cms.bfd.server.war.commons.ClaimType;
 import gov.cms.bfd.server.war.commons.OffsetLinkBuilder;
 import gov.cms.bfd.server.war.commons.ProfileConstants;
@@ -754,6 +755,105 @@ public class TransformerUtilsV2Test {
     assertEquals(
         "National Provider Identifier",
         careTeamEntry.getProvider().getIdentifier().getType().getCoding().get(0).getDisplay());
+  }
+
+  /**
+   * Tests that addCareTeamQualification adds a qualification if the input Optional is not empty.
+   */
+  @Test
+  public void addCareTeamQualificationWhenNotEmptyCodeExpectQualificationAdded() {
+
+    CareTeamComponent careTeam = new CareTeamComponent();
+    ExplanationOfBenefit eob = new ExplanationOfBenefit();
+    CcwCodebookVariable codebookVariable = CcwCodebookVariable.CCW_PRSCRBR_ID;
+    String expectedValue = "ABC-TESTID";
+    Optional<String> value = Optional.of(expectedValue);
+    String expectedUrl = CCWUtils.calculateVariableReferenceUrl(CcwCodebookVariable.CCW_PRSCRBR_ID);
+
+    TransformerUtilsV2.addCareTeamQualification(careTeam, eob, codebookVariable, value);
+
+    // careTeam object should have the qualification added with expected values
+    assertTrue(careTeam.hasQualification());
+    assertTrue(careTeam.getQualification().hasCoding());
+    assertEquals(expectedUrl, careTeam.getQualification().getCoding().get(0).getSystem());
+    assertEquals(expectedValue, careTeam.getQualification().getCoding().get(0).getCode());
+  }
+
+  /**
+   * Tests that addCareTeamExtension correctly adds an extension when the value Optional and its
+   * string value is not empty.
+   */
+  @Test
+  public void addCareTeamExtensionWhenNotEmptyOptionalExpectExtensionAdded() {
+
+    CareTeamComponent careTeam = new CareTeamComponent();
+    ExplanationOfBenefit eob = new ExplanationOfBenefit();
+    CcwCodebookVariable codebookVariable = CcwCodebookVariable.CCW_PRSCRBR_ID;
+    String expectedValue = "DDD-TESTID";
+    Optional<String> value = Optional.of(expectedValue);
+    String expectedUrl = CCWUtils.calculateVariableReferenceUrl(CcwCodebookVariable.CCW_PRSCRBR_ID);
+
+    TransformerUtilsV2.addCareTeamExtension(codebookVariable, value, careTeam, eob);
+
+    assertTrue(careTeam.hasExtension(expectedUrl));
+    Extension extension = careTeam.getExtensionByUrl(expectedUrl);
+    String extensionValue = ((Coding) extension.getValue()).getCode();
+    assertEquals(expectedValue, extensionValue);
+  }
+
+  /**
+   * Tests that addCareTeamExtension correctly adds an extension when the value is required and a
+   * char.
+   */
+  @Test
+  public void addCareTeamExtensionWhenRequiredCharExpectExtensionAdded() {
+
+    CareTeamComponent careTeam = new CareTeamComponent();
+    ExplanationOfBenefit eob = new ExplanationOfBenefit();
+    CcwCodebookVariable codebookVariable = CcwCodebookVariable.CCW_PRSCRBR_ID;
+    char expectedValue = 'V';
+    String expectedUrl = CCWUtils.calculateVariableReferenceUrl(CcwCodebookVariable.CCW_PRSCRBR_ID);
+
+    TransformerUtilsV2.addCareTeamExtension(codebookVariable, expectedValue, careTeam, eob);
+
+    assertTrue(careTeam.hasExtension(expectedUrl));
+    Extension extension = careTeam.getExtensionByUrl(expectedUrl);
+    String extensionValue = ((Coding) extension.getValue()).getCode();
+    assertEquals(String.valueOf(expectedValue), extensionValue);
+  }
+
+  /**
+   * Tests that addCareTeamExtension does not add an extension when the value Optional string value
+   * is empty.
+   */
+  @Test
+  public void addCareTeamExtensionWhenOptionalEmptyStringExpectNoExtensionAdded() {
+
+    CareTeamComponent careTeam = new CareTeamComponent();
+    ExplanationOfBenefit eob = new ExplanationOfBenefit();
+    CcwCodebookVariable codebookVariable = CcwCodebookVariable.CCW_PRSCRBR_ID;
+    String expectedValue = "";
+    Optional<String> value = Optional.of(expectedValue);
+    String expectedUrl = CCWUtils.calculateVariableReferenceUrl(CcwCodebookVariable.CCW_PRSCRBR_ID);
+
+    TransformerUtilsV2.addCareTeamExtension(codebookVariable, value, careTeam, eob);
+
+    assertFalse(careTeam.hasExtension(expectedUrl));
+  }
+
+  /** Tests that addCareTeamExtension does not add an extension when the value Optional is empty. */
+  @Test
+  public void addCareTeamExtensionWhenEmptyOptionalExpectNoExtensionAdded() {
+
+    CareTeamComponent careTeam = new CareTeamComponent();
+    ExplanationOfBenefit eob = new ExplanationOfBenefit();
+    CcwCodebookVariable codebookVariable = CcwCodebookVariable.CCW_PRSCRBR_ID;
+    Optional<String> value = Optional.empty();
+    String expectedUrl = CCWUtils.calculateVariableReferenceUrl(CcwCodebookVariable.CCW_PRSCRBR_ID);
+
+    TransformerUtilsV2.addCareTeamExtension(codebookVariable, value, careTeam, eob);
+
+    assertFalse(careTeam.hasExtension(expectedUrl));
   }
 
   /** Verifies that {@link TransformerUtilsV2#createBundle} sets bundle size of 2 correctly. */

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/CarrierClaimTransformerTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/CarrierClaimTransformerTest.java
@@ -1,8 +1,10 @@
 package gov.cms.bfd.server.war.stu3.providers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
@@ -17,6 +19,7 @@ import gov.cms.bfd.model.rif.entities.CarrierClaimLine;
 import gov.cms.bfd.model.rif.samples.StaticRifResource;
 import gov.cms.bfd.model.rif.samples.StaticRifResourceGroup;
 import gov.cms.bfd.server.war.ServerTestUtils;
+import gov.cms.bfd.server.war.commons.CCWUtils;
 import gov.cms.bfd.server.war.commons.ClaimType;
 import gov.cms.bfd.server.war.commons.MedicareSegment;
 import gov.cms.bfd.server.war.commons.TransformerConstants;
@@ -127,6 +130,47 @@ public final class CarrierClaimTransformerTest {
   }
 
   /**
+   * Tests that the transformer sets the expected values for the care team member extensions and
+   * does not error when only the required care team values exist.
+   */
+  @Test
+  public void testCareTeamExtensionsWhenOptionalValuesAbsent() {
+
+    List<Object> parsedRecords =
+        ServerTestUtils.parseData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
+
+    CarrierClaim loadedClaim =
+        parsedRecords.stream()
+            .filter(r -> r instanceof CarrierClaim)
+            .map(CarrierClaim.class::cast)
+            .findFirst()
+            .get();
+    loadedClaim.setLastUpdated(Instant.now());
+
+    // Set the optional care team fields to empty
+    for (CarrierClaimLine line : loadedClaim.getLines()) {
+      line.setProviderParticipatingIndCode(Optional.empty());
+      line.setProviderSpecialityCode(Optional.empty());
+      line.setOrganizationNpi(Optional.empty());
+    }
+
+    ExplanationOfBenefit genEob = carrierClaimTransformer.transform(loadedClaim, false);
+
+    // Ensure the extension for PRTCPTNG_IND_CD wasnt added
+    // Also the qualification coding should be empty if specialty code is not set
+    // organization npi should also not be added if its optional is empty
+    String prtIndCdUrl =
+        CCWUtils.calculateVariableReferenceUrl(CcwCodebookVariable.PRTCPTNG_IND_CD);
+    for (ExplanationOfBenefit.CareTeamComponent careTeam : genEob.getCareTeam()) {
+      assertFalse(careTeam.getExtension().stream().anyMatch(i -> i.getUrl().equals(prtIndCdUrl)));
+      assertFalse(
+          careTeam.getExtension().stream()
+              .anyMatch(i -> i.getUrl().equals(TransformerConstants.CODING_NPI_US)));
+      assertTrue(careTeam.getQualification().getCoding().isEmpty());
+    }
+  }
+
+  /**
    * Verifies that {@link gov.cms.bfd.server.war.stu3.providers.CarrierClaimTransformer#transform}
    * works as expected when run against the {@link StaticRifResource#SAMPLE_U_CARRIER} {@link
    * CarrierClaim}.
@@ -223,7 +267,7 @@ public final class CarrierClaimTransformerTest {
         performingCareTeamEntry,
         TransformerConstants.CODING_NPI_US,
         TransformerConstants.CODING_NPI_US,
-        "" + claimLine1.getOrganizationNpi().get());
+        claimLine1.getOrganizationNpi().get());
 
     CareTeamComponent taxNumberCareTeamEntry =
         TransformerTestUtils.findCareTeamEntryForProviderTaxNumber(

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/DMEClaimTransformerTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/DMEClaimTransformerTest.java
@@ -1,8 +1,10 @@
 package gov.cms.bfd.server.war.stu3.providers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
@@ -16,10 +18,12 @@ import gov.cms.bfd.model.rif.entities.DMEClaimLine;
 import gov.cms.bfd.model.rif.samples.StaticRifResource;
 import gov.cms.bfd.model.rif.samples.StaticRifResourceGroup;
 import gov.cms.bfd.server.war.ServerTestUtils;
+import gov.cms.bfd.server.war.commons.CCWUtils;
 import gov.cms.bfd.server.war.commons.ClaimType;
 import gov.cms.bfd.server.war.commons.MedicareSegment;
 import gov.cms.bfd.server.war.commons.TransformerConstants;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -81,6 +85,42 @@ public final class DMEClaimTransformerTest {
 
     ExplanationOfBenefit eob = dmeClaimTransformer.transform(claim, true);
     assertMatches(claim, eob, true);
+  }
+
+  /**
+   * Tests that the transformer sets the expected values for the care team member extensions and
+   * does not error when only the required care team values exist.
+   */
+  @Test
+  public void testCareTeamExtensionsWhenOptionalValuesAbsent() {
+
+    List<Object> parsedRecords =
+        ServerTestUtils.parseData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
+
+    DMEClaim loadedClaim =
+        parsedRecords.stream()
+            .filter(r -> r instanceof DMEClaim)
+            .map(DMEClaim.class::cast)
+            .findFirst()
+            .get();
+    loadedClaim.setLastUpdated(Instant.now());
+
+    // Set the optional care team fields to empty
+    for (DMEClaimLine line : loadedClaim.getLines()) {
+      line.setProviderParticipatingIndCode(Optional.empty());
+      line.setProviderSpecialityCode(Optional.empty());
+    }
+
+    ExplanationOfBenefit genEob = dmeClaimTransformer.transform(loadedClaim, false);
+
+    // Ensure the extension for PRTCPTNG_IND_CD wasnt added
+    // Also the qualification coding should be empty if specialty code is not set
+    String prtIndCdUrl =
+        CCWUtils.calculateVariableReferenceUrl(CcwCodebookVariable.PRTCPTNG_IND_CD);
+    for (ExplanationOfBenefit.CareTeamComponent careTeam : genEob.getCareTeam()) {
+      assertFalse(careTeam.getExtension().stream().anyMatch(i -> i.getUrl().equals(prtIndCdUrl)));
+      assertTrue(careTeam.getQualification().getCoding().isEmpty());
+    }
   }
 
   /**

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtilsTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtilsTest.java
@@ -23,6 +23,7 @@ import gov.cms.bfd.model.rif.entities.InpatientClaim;
 import gov.cms.bfd.model.rif.samples.StaticRifResourceGroup;
 import gov.cms.bfd.server.sharedutils.BfdMDC;
 import gov.cms.bfd.server.war.ServerTestUtils;
+import gov.cms.bfd.server.war.commons.CCWUtils;
 import gov.cms.bfd.server.war.commons.ClaimType;
 import gov.cms.bfd.server.war.commons.IdentifierType;
 import gov.cms.bfd.server.war.commons.OffsetLinkBuilder;
@@ -36,6 +37,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.CodeableConcept;
 import org.hl7.fhir.dstu3.model.Coding;
@@ -248,6 +250,124 @@ public final class TransformerUtilsTest {
         TransformerUtils.careTeamHasMatchingExtension(careTeamComponent, referenceUrl, codeValue);
 
     assertFalse(returnResult);
+  }
+
+  /**
+   * Tests that addCareTeamQualification does not add a qualification if the input Optional is
+   * empty.
+   */
+  @Test
+  public void addCareTeamQualificationWhenEmptyCodeExpectNoQualificationCodeAdded() {
+
+    CareTeamComponent careTeam = new CareTeamComponent();
+    ExplanationOfBenefit eob = new ExplanationOfBenefit();
+    CcwCodebookVariable codebookVariable = CcwCodebookVariable.CCW_PRSCRBR_ID;
+    Optional<String> value = Optional.empty();
+
+    TransformerUtils.addCareTeamQualification(careTeam, eob, codebookVariable, value);
+
+    // ensure careteam qualification isnt populated
+    // (hasQualification does some checks on coding and text existing)
+    assertFalse(careTeam.hasQualification());
+  }
+
+  /**
+   * Tests that addCareTeamQualification adds a qualification if the input Optional is not empty.
+   */
+  @Test
+  public void addCareTeamQualificationWhenNotEmptyCodeExpectQualificationAdded() {
+
+    CareTeamComponent careTeam = new CareTeamComponent();
+    ExplanationOfBenefit eob = new ExplanationOfBenefit();
+    CcwCodebookVariable codebookVariable = CcwCodebookVariable.CCW_PRSCRBR_ID;
+    String expectedValue = "ABC-TESTID";
+    Optional<String> value = Optional.of(expectedValue);
+    String expectedUrl = CCWUtils.calculateVariableReferenceUrl(CcwCodebookVariable.CCW_PRSCRBR_ID);
+
+    TransformerUtils.addCareTeamQualification(careTeam, eob, codebookVariable, value);
+
+    // careTeam object should have the qualification added with expected values
+    assertTrue(careTeam.hasQualification());
+    assertTrue(careTeam.getQualification().hasCoding());
+    assertEquals(expectedUrl, careTeam.getQualification().getCoding().get(0).getSystem());
+    assertEquals(expectedValue, careTeam.getQualification().getCoding().get(0).getCode());
+  }
+
+  /**
+   * Tests that addCareTeamExtension correctly adds an extension when the value Optional and its
+   * string value is not empty.
+   */
+  @Test
+  public void addCareTeamExtensionWhenNotEmptyOptionalExpectExtensionAdded() {
+
+    CareTeamComponent careTeam = new CareTeamComponent();
+    ExplanationOfBenefit eob = new ExplanationOfBenefit();
+    CcwCodebookVariable codebookVariable = CcwCodebookVariable.CCW_PRSCRBR_ID;
+    String expectedValue = "DDD-TESTID";
+    Optional<String> value = Optional.of(expectedValue);
+    String expectedUrl = CCWUtils.calculateVariableReferenceUrl(CcwCodebookVariable.CCW_PRSCRBR_ID);
+
+    TransformerUtils.addCareTeamExtension(codebookVariable, value, careTeam, eob);
+
+    assertTrue(careTeam.hasExtension(expectedUrl));
+    Extension extension = careTeam.getExtensionByUrl(expectedUrl);
+    String extensionValue = ((Coding) extension.getValue()).getCode();
+    assertEquals(expectedValue, extensionValue);
+  }
+
+  /**
+   * Tests that addCareTeamExtension correctly adds an extension when the value is required and a
+   * char.
+   */
+  @Test
+  public void addCareTeamExtensionWhenRequiredCharExpectExtensionAdded() {
+
+    CareTeamComponent careTeam = new CareTeamComponent();
+    ExplanationOfBenefit eob = new ExplanationOfBenefit();
+    CcwCodebookVariable codebookVariable = CcwCodebookVariable.CCW_PRSCRBR_ID;
+    char expectedValue = 'V';
+    String expectedUrl = CCWUtils.calculateVariableReferenceUrl(CcwCodebookVariable.CCW_PRSCRBR_ID);
+
+    TransformerUtils.addCareTeamExtension(codebookVariable, expectedValue, careTeam, eob);
+
+    assertTrue(careTeam.hasExtension(expectedUrl));
+    Extension extension = careTeam.getExtensionByUrl(expectedUrl);
+    String extensionValue = ((Coding) extension.getValue()).getCode();
+    assertEquals(String.valueOf(expectedValue), extensionValue);
+  }
+
+  /**
+   * Tests that addCareTeamExtension does not add an extension when the value Optional string value
+   * is empty.
+   */
+  @Test
+  public void addCareTeamExtensionWhenOptionalEmptyStringExpectNoExtensionAdded() {
+
+    CareTeamComponent careTeam = new CareTeamComponent();
+    ExplanationOfBenefit eob = new ExplanationOfBenefit();
+    CcwCodebookVariable codebookVariable = CcwCodebookVariable.CCW_PRSCRBR_ID;
+    String expectedValue = "";
+    Optional<String> value = Optional.of(expectedValue);
+    String expectedUrl = CCWUtils.calculateVariableReferenceUrl(CcwCodebookVariable.CCW_PRSCRBR_ID);
+
+    TransformerUtils.addCareTeamExtension(codebookVariable, value, careTeam, eob);
+
+    assertFalse(careTeam.hasExtension(expectedUrl));
+  }
+
+  /** Tests that addCareTeamExtension does not add an extension when the value Optional is empty. */
+  @Test
+  public void addCareTeamExtensionWhenEmptyOptionalExpectNoExtensionAdded() {
+
+    CareTeamComponent careTeam = new CareTeamComponent();
+    ExplanationOfBenefit eob = new ExplanationOfBenefit();
+    CcwCodebookVariable codebookVariable = CcwCodebookVariable.CCW_PRSCRBR_ID;
+    Optional<String> value = Optional.empty();
+    String expectedUrl = CCWUtils.calculateVariableReferenceUrl(CcwCodebookVariable.CCW_PRSCRBR_ID);
+
+    TransformerUtils.addCareTeamExtension(codebookVariable, value, careTeam, eob);
+
+    assertFalse(careTeam.hasExtension(expectedUrl));
   }
 
   /**


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BFD-2815](https://jira.cms.gov/browse/BFD-2815)

**User Story or Bug Summary:**
<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->
Fixes a couple issues where Optional was misused, causing potential issues in the event that the optional fields were not present.

---

### What Does This PR Do?
<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

Major:
- Simplifies some code in v1 and v2 DME+Carrier transformers where careTeam extensions were added, using Optionals
    - Adds the optional check code to a util method, which is reused. Takes no action if the optional is empty instead of causing an exception
- Fixes a bug in InpatientClaimTransformer (v1) where an optional was checked against null instead of using isPresent
    - Fixes a similar bug in InpatientClaimTransformerV2, where the optional was not even being checked at all before calling get() for the same field
- Add unit tests for the transformers adjusted and the new methods in the utils added

Minor:
- Fixes some cases where there were inverted isPresent() checks instead of just using isEmpty() for optionals

### What Should Reviewers Watch For?
<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items to the following list here -->
* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [x] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [x] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [x] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] The data dictionary has been updated with any field mapping changes, if any were made.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    