### PR TITLE
BFD-2813: Clean up DOS Attack vector regexes in BFD Server code

### DIFF
--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/commons/RequestHeaders.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/commons/RequestHeaders.java
@@ -1,5 +1,7 @@
 package gov.cms.bfd.server.war.commons;
 
+import static gov.cms.bfd.server.war.commons.StringUtils.splitOnCommas;
+
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import java.util.Arrays;
@@ -239,7 +241,7 @@ public class RequestHeaders {
     else {
       // Return values split on a comma with any whitespace, valid, distict, and sort
       return Arrays.asList(
-              headerValues.trim().replaceAll("^\\[|\\]$", "").toLowerCase().split("\\s*,\\s*"))
+              splitOnCommas(headerValues.trim().replaceAll("^\\[|\\]$", "").toLowerCase()))
           .stream()
           .peek(
               c -> {

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/commons/StringUtils.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/commons/StringUtils.java
@@ -1,0 +1,34 @@
+package gov.cms.bfd.server.war.commons;
+
+import com.google.common.collect.ImmutableList;
+
+/** Helper Utils class for Functions shared across. multiple classes. */
+public class StringUtils {
+
+  /**
+   * Custom Split Function to replace.
+   *
+   * @param input a String that needs to remove whitespace and commas.
+   * @return Split Array.
+   */
+  public static String[] splitOnCommas(String input) {
+    final ImmutableList.Builder<String> builder = ImmutableList.builder();
+    StringBuilder curr = new StringBuilder();
+
+    for (char c : input.toCharArray()) {
+      if (c == ',') {
+        if (curr.length() > 0) {
+          builder.add(curr.toString().trim());
+          curr = new StringBuilder();
+        }
+      } else {
+        curr.append(c);
+      }
+    }
+
+    if (curr.length() > 0) {
+      builder.add(curr.toString().trim());
+    }
+    return builder.build().toArray(new String[0]);
+  }
+}

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/R4PatientResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/R4PatientResourceProvider.java
@@ -1,5 +1,6 @@
 package gov.cms.bfd.server.war.r4.providers;
 
+import static gov.cms.bfd.server.war.commons.StringUtils.splitOnCommas;
 import static java.util.Objects.requireNonNull;
 
 import ca.uhn.fhir.model.api.annotation.Description;
@@ -980,7 +981,7 @@ public final class R4PatientResourceProvider implements IResourceProvider, Commo
       return Arrays.asList("");
     } else
       // Return values split on a comma with any whitespace, valid, distict, and sort
-      return Arrays.asList(headerValues.toLowerCase().split("\\s*,\\s*")).stream()
+      return Arrays.asList(splitOnCommas(headerValues.toLowerCase())).stream()
           .peek(
               c -> {
                 if (!VALID_HEADER_VALUES_INCLUDE_IDENTIFIERS.contains(c))

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/PatientResourceProvider.java
@@ -1,5 +1,6 @@
 package gov.cms.bfd.server.war.stu3.providers;
 
+import static gov.cms.bfd.server.war.commons.StringUtils.splitOnCommas;
 import static java.util.Objects.requireNonNull;
 
 import ca.uhn.fhir.model.api.annotation.Description;
@@ -1031,7 +1032,7 @@ public final class PatientResourceProvider implements IResourceProvider, CommonH
     if (Strings.isNullOrEmpty(headerValues)) return Arrays.asList("");
     else
       // Return values split on a comma with any whitespace, valid, distict, and sort
-      return Arrays.asList(headerValues.toLowerCase().split("\\s*,\\s*")).stream()
+      return Arrays.asList(splitOnCommas(headerValues.toLowerCase())).stream()
           .peek(
               c -> {
                 if (!VALID_HEADER_VALUES_INCLUDE_IDENTIFIERS.contains(c))

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/commons/StringUtilsTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/commons/StringUtilsTest.java
@@ -1,0 +1,18 @@
+package gov.cms.bfd.server.war.commons;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import org.junit.Test;
+
+/** Unit tests for {@link StringUtils}. */
+public class StringUtilsTest {
+
+  /** Test to verify veracity. of customSplit function. */
+  @Test
+  public void testCustomSplit() {
+    final String inputString = " header1, header2 ,  header3 , header4 ";
+    String[] expected = {"header1", "header2", "header3", "header4"};
+    String[] response = StringUtils.splitOnCommas(inputString);
+    assertArrayEquals(expected, response);
+  }
+}


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BFD-2813](https://jira.cms.gov/browse/BFD-2813)

**User Story or Bug Summary:**

<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->

As a BFD engineer I would like to reduce the attack vector for denial of service attacks on BFD so that the application is more secure.


### What Does This PR Do?
<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

This change brings in the following:
- A `RegexUtils` class with a customSplit utility function that is used across the 3 classes where the regex was used.
-  A RegexUtilsTest class that test the veracity of the customSplit function.
- Updates the requestHeaders, R4PatientResourceProvider and PatientResourceProvider classes to import and use the customSplit class.


### What Should Reviewers Watch For?
<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items to the following list here -->
* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [X] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [X] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [X] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [X] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [X] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [X] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [X] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [X] The data dictionary has been updated with any field mapping changes, if any were made.
* [X] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [X] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [X] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [X] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    