### PR TITLE
BFD-2863: Introduce Launch Lifecycle Hooks to BFD Server Instances

### DIFF
--- a/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
+++ b/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
@@ -65,6 +65,9 @@ export NEW_RELIC_METRIC_PERIOD='{{ data_server_new_relic_metric_period }}'
 STARTUP_TESTING_REQ_TIMEOUT='15'
 STARTUP_TESTING_REQ_BACKOFF_TIMEOUT='1'
 STARTUP_TESTING_BENE_ID='-88888888888888'
+# Lifecycle hook name, used to signal to the ASG that this instance has warmed-up and is ready for
+# traffic
+LAUNCH_LIFECYCLE_HOOK="{{ launch_lifecycle_hook }}"
 
 ##
 # Prints out the specified message.
@@ -125,6 +128,33 @@ service_startup_check() {
       # Effectively allow traffic from external sources to reach service port
       sudo iptables -D INPUT -p tcp ! -i lo --dport "$BFD_PORT" -j REJECT
       log "Server started properly"
+
+      instance_id="$(
+        TOKEN="$(
+          curl -X PUT "http://169.254.169.254/latest/api/token" \
+            -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" \
+            --max-time 1 2>/dev/null
+        )" && curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id
+      )"
+      if [[ -n "$instance_id" ]]; then
+        # Capturing the ASG name from Terraform -> User Data Init -> Ansible is not possible, as the
+        # ASG name (as of writing) is based upon the Launch Template name and latest version. Trying
+        # to pass this data within the launch template's Terraform resource definition would result
+        # in a circular reference. Instead, we rely on AWS's default tagging behavior to get the
+        # ASG's name
+        asg_name="$(
+          aws ec2 describe-tags \
+            --filters "Name=resource-id,Values=$instance_id" "Name=key,Values=aws:autoscaling:groupName" |
+            jq -r '.Tags | .[] | .Value'
+        )"
+        if [[ -n "$asg_name" ]]; then
+          log "Completing Lifecycle Action for Hook $LAUNCH_LIFECYCLE_HOOK..."
+          aws autoscaling complete-lifecycle-action --lifecycle-action-result CONTINUE \
+            --instance-id $instance_id --lifecycle-hook-name $LAUNCH_LIFECYCLE_HOOK \
+            --auto-scaling-group-name $asg_name 1> /dev/null 2> /dev/null &&
+            log "Lifecycle Action completed with result CONTINUE for hook $LAUNCH_LIFECYCLE_HOOK"
+        fi
+      fi
       return 0
     else
       log "Server failed to start properly, retrying..."

--- a/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
+++ b/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
@@ -67,7 +67,9 @@ STARTUP_TESTING_REQ_BACKOFF_TIMEOUT='1'
 STARTUP_TESTING_BENE_ID='-88888888888888'
 # Lifecycle hook name, used to signal to the ASG that this instance has warmed-up and is ready for
 # traffic
+{% if launch_lifecycle_hook is defined %}
 LAUNCH_LIFECYCLE_HOOK="{{ launch_lifecycle_hook }}"
+{% endif %}
 
 ##
 # Prints out the specified message.
@@ -129,6 +131,11 @@ service_startup_check() {
       sudo iptables -D INPUT -p tcp ! -i lo --dport "$BFD_PORT" -j REJECT
       log "Server started properly"
 
+      if [[ -z "$LAUNCH_LIFECYCLE_HOOK" ]]; then
+        return 0
+      fi
+      
+      log "Launch Lifecycle Hook $LAUNCH_LIFECYCLE_HOOK is enabled"
       instance_id="$(
         TOKEN="$(
           curl -X PUT "http://169.254.169.254/latest/api/token" \
@@ -136,25 +143,32 @@ service_startup_check() {
             --max-time 1 2>/dev/null
         )" && curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id
       )"
-      if [[ -n "$instance_id" ]]; then
-        # Capturing the ASG name from Terraform -> User Data Init -> Ansible is not possible, as the
-        # ASG name (as of writing) is based upon the Launch Template name and latest version. Trying
-        # to pass this data within the launch template's Terraform resource definition would result
-        # in a circular reference. Instead, we rely on AWS's default tagging behavior to get the
-        # ASG's name
-        asg_name="$(
-          aws ec2 describe-tags \
-            --filters "Name=resource-id,Values=$instance_id" "Name=key,Values=aws:autoscaling:groupName" |
-            jq -r '.Tags | .[] | .Value'
-        )"
-        if [[ -n "$asg_name" ]]; then
-          log "Completing Lifecycle Action for Hook $LAUNCH_LIFECYCLE_HOOK..."
-          aws autoscaling complete-lifecycle-action --lifecycle-action-result CONTINUE \
-            --instance-id $instance_id --lifecycle-hook-name $LAUNCH_LIFECYCLE_HOOK \
-            --auto-scaling-group-name $asg_name 1> /dev/null 2> /dev/null &&
-            log "Lifecycle Action completed with result CONTINUE for hook $LAUNCH_LIFECYCLE_HOOK"
-        fi
+      if [[ -z "$instance_id" ]]; then
+        log "Instance ID not found from IMDS; is BFD Server running on an EC2 Instance?"
+        return 0
       fi
+
+      # Capturing the ASG name from Terraform -> User Data Init -> Ansible is not possible, as the
+      # ASG name (as of writing) is based upon the Launch Template name and latest version. Trying
+      # to pass this data within the launch template's Terraform resource definition would result in
+      # a circular reference. Instead, we rely on AWS's default tagging behavior to get the ASG's
+      # name
+      asg_name="$(
+        aws ec2 describe-tags \
+          --filters "Name=resource-id,Values=$instance_id" "Name=key,Values=aws:autoscaling:groupName" |
+          jq -r '.Tags | .[] | .Value'
+      )"
+      if [[ -z "$asg_name" ]]; then
+        log "ASG name not found in instance tags; was instance launched within an ASG?"
+        return 0
+      fi
+
+      log "ASG Name: $asg_name; Instance ID: $instance_id"
+      log "Completing Lifecycle Action for Hook $LAUNCH_LIFECYCLE_HOOK..."
+      aws autoscaling complete-lifecycle-action --lifecycle-action-result CONTINUE \
+        --instance-id $instance_id --lifecycle-hook-name $LAUNCH_LIFECYCLE_HOOK \
+        --auto-scaling-group-name $asg_name 1> /dev/null 2> /dev/null &&
+        log "Lifecycle Action completed with result CONTINUE for hook $LAUNCH_LIFECYCLE_HOOK"
       return 0
     else
       log "Server failed to start properly, retrying..."

--- a/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
+++ b/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
@@ -134,17 +134,12 @@ service_startup_check() {
       if [[ -z "$LAUNCH_LIFECYCLE_HOOK" ]]; then
         return 0
       fi
-      
+
       log "Launch Lifecycle Hook $LAUNCH_LIFECYCLE_HOOK is enabled"
-      instance_id="$(
-        TOKEN="$(
-          curl -X PUT "http://169.254.169.254/latest/api/token" \
-            -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" \
-            --max-time 1 2>/dev/null
-        )" && curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id
-      )"
-      if [[ -z "$instance_id" ]]; then
-        log "Instance ID not found from IMDS; is BFD Server running on an EC2 Instance?"
+      instance_id="$(ec2-metadata --instance-id | sed 's/instance-id: \(.*\)$/\1/')"
+      region="$(ec2-metadata --availability-zone | sed 's/placement: \(.*\).$/\1/')"
+      if [[ -z "$instance_id" || -z "$region" ]]; then
+        log "Instance ID or region not found from IMDS; is BFD Server running on an EC2 Instance?"
         return 0
       fi
 
@@ -155,7 +150,8 @@ service_startup_check() {
       # name
       asg_name="$(
         aws ec2 describe-tags \
-          --filters "Name=resource-id,Values=$instance_id" "Name=key,Values=aws:autoscaling:groupName" |
+          --filters "Name=resource-id,Values=$instance_id" "Name=key,Values=aws:autoscaling:groupName" \
+          --region "$region" |
           jq -r '.Tags | .[] | .Value'
       )"
       if [[ -z "$asg_name" ]]; then
@@ -165,10 +161,14 @@ service_startup_check() {
 
       log "ASG Name: $asg_name; Instance ID: $instance_id"
       log "Completing Lifecycle Action for Hook $LAUNCH_LIFECYCLE_HOOK..."
-      aws autoscaling complete-lifecycle-action --lifecycle-action-result CONTINUE \
-        --instance-id $instance_id --lifecycle-hook-name $LAUNCH_LIFECYCLE_HOOK \
-        --auto-scaling-group-name $asg_name 1> /dev/null 2> /dev/null &&
-        log "Lifecycle Action completed with result CONTINUE for hook $LAUNCH_LIFECYCLE_HOOK"
+      aws autoscaling complete-lifecycle-action \
+        --lifecycle-action-result CONTINUE \
+        --instance-id "$instance_id" \
+        --lifecycle-hook-name "$LAUNCH_LIFECYCLE_HOOK" \
+        --auto-scaling-group-name "$asg_name" \
+        --region "$region" 1>/dev/null 2>/dev/null &&
+        log "Lifecycle Action completed with result CONTINUE for hook $LAUNCH_LIFECYCLE_HOOK" ||
+        log "Failed to complete Lifecycle Action for hook $LAUNCH_LIFECYCLE_HOOK"
       return 0
     else
       log "Server failed to start properly, retrying..."

--- a/ops/terraform/services/server/modules/bfd_server_asg/templates/fhir_server.tpl
+++ b/ops/terraform/services/server/modules/bfd_server_asg/templates/fhir_server.tpl
@@ -36,7 +36,8 @@ cat <<EOF > extra_vars.json
   "data_server_tmp_dir": "{{ data_server_dir }}/tmp",
   "data_server_war": "bfd-server-war-1.0.0-SNAPSHOT.war",
   "data_server_db_url": "${data_server_db_url}",
-  "env": "${env}"
+  "env": "${env}",
+  "launch_lifecycle_hook": "${launch_lifecycle_hook}"
 }
 EOF
 

--- a/ops/terraform/services/server/modules/bfd_server_iam/data-sources.tf
+++ b/ops/terraform/services/server/modules/bfd_server_iam/data-sources.tf
@@ -1,3 +1,5 @@
+data "aws_region" "current" {}
+
 data "aws_caller_identity" "current" {}
 
 data "aws_kms_key" "master_key" {

--- a/ops/terraform/services/server/modules/bfd_server_iam/main.tf
+++ b/ops/terraform/services/server/modules/bfd_server_iam/main.tf
@@ -151,7 +151,8 @@ resource "aws_iam_role_policy_attachment" "kms_mgmt" {
 # allow Server instances to complete lifecycle actions on their ASG
 resource "aws_iam_policy" "asg" {
   description = join("", [
-    "Policy granting BFD Server in ${local.env} environment access to complete Lifecycle Actions on "
+    "Policy granting BFD Server in ${local.env} environment access to complete Lifecycle Actions ",
+    "on the ${local.env} AutoScaling Group"
   ])
   name = "bfd-${local.env}-${var.service}-asg"
   path = "/"


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BFD-2863](https://jira.cms.gov/browse/BFD-2863)

**User Story or Bug Summary:**

<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->
As a BFD Engineer, I want BFD Server instances to be able to signal when they have warmed-up so that they are not added prematurely to the Load Balancer and made reachable before they should be

---

### What Does This PR Do?

<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

This PR adds a [Launch Lifecycle Hook](https://docs.aws.amazon.com/autoscaling/ec2/userguide/lifecycle-hooks.html) to the BFD Server AutoScaling Group that is automatically completed when an instance has fully warmed-up. Now, BFD Server EC2 Instances will enter the `Pending:Wait` lifecycle state on scale-out _until_ the instances signals, through completing the Lifecycle Action corresponding to the Launch Lifecycle Hook, that the BFD Server application is ready to receive traffic. Only then will instances transition to `InService` and be added to the Load Balancer. This differs greatly from the current behavior where BFD Server instances transition immediately from `Pending` to `InService`, well before even Ansible has time to complete its launch tasks or the BFD Server application has time to warm up.

With this change we should almost _never_ see false-positive `Unhealthy` instances from ELB healthchecks, as BFD Server instances will only be made reachable (and thus healthcheck-able) when they are ready to receive traffic. This should also resolve the corresponding false-positive `HealthyHost` alerts. With Lifecycle Hooks, we can be confident that an `Unhealthy` host is truly _unhealthy_, and any corresponding alerting on that metric indicates something is _actually_ wrong. We can also be confident that BFD API requests are only ever routed to healthy instances during scale-out.

This PR has been validated by:

- `terraform apply`ing the changes to the `server` Terraservice in workspace `2863-test`, verifying that it `apply`s successfully
- using the AWS CLI to `watch`, in real-time, instances in `2863-test`'s ASG, verifying that they transition from `Pending` to `Pending:Wait` to `InService` as expected
- using the AWS CLI to `watch`, in real-time, instances in `2863-test`'s **Load Balancer**, verifying that instances are added _only_ once they transition to `InService` and that instances do not enter the `Unhealthy` state erroneously
- manually scaling the `2863-test` ASG to 6 instances, verifying that the above behavior holds

### What Should Reviewers Watch For?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:

<!-- Add some items to the following list here -->

- Verify all PR security questions and checklists have been completed and addressed.

### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

- If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

  - Does this PR add any new software dependencies?
    - [ ] Yes
    - [x] No
  - Does this PR modify or invalidate any of our security controls?
    - [ ] Yes
    - [x] No
  - Does this PR store or transmit data that was not stored or transmitted before?
    - [ ] Yes
    - [x] No

- If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
  - Do you think this PR requires additional review of its security implications for other reasons?
    - [ ] Yes
    - [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

- N/A

### Submitter Checklist

<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

- [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
- [x] This PR is reasonably limited in scope, to help ensure that:
  1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
  2. There isn't too much of a burden on reviewers.
  3. Any problems it causes have a small "blast radius".
  4. It'll be easier to rollback if that becomes necessary.
- [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
- [x] The data dictionary has been updated with any field mapping changes, if any were made.
- [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
- [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
- [x] Reviews are requested from both:
  - At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
  - Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
- [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
  - Please review the standards every few months to ensure you're familiar with them.
