### PR TITLE
BFD-2849: Adjust case where startIndex >= maxResults to throw 400 instead of 500

### DIFF
--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/R4ExplanationOfBenefitResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/R4ExplanationOfBenefitResourceProvider.java
@@ -46,7 +46,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
 import javax.persistence.PersistenceContext;
@@ -335,16 +334,17 @@ public final class R4ExplanationOfBenefitResourceProvider extends AbstractResour
     boolean filterSamhsa = Boolean.parseBoolean(excludeSamhsa);
     CanonicalOperation operation = new CanonicalOperation(CanonicalOperation.Endpoint.V2_EOB);
     operation.setOption("by", "patient");
-    operation.setOption("IncludeTaxNumbers", "" + includeTaxNumbers);
+    operation.setOption("IncludeTaxNumbers", String.valueOf(includeTaxNumbers));
     operation.setOption(
         "types",
         (claimTypesRequested.size() == ClaimType.values().length)
             ? "*"
             : claimTypesRequested.stream()
                 .sorted(Comparator.comparing(ClaimType::name))
-                .collect(Collectors.toList())
+                .toList()
                 .toString());
-    operation.setOption("pageSize", paging.isPagingRequested() ? "" + paging.getPageSize() : "*");
+    operation.setOption(
+        "pageSize", paging.isPagingRequested() ? String.valueOf(paging.getPageSize()) : "*");
     operation.setOption(
         "_lastUpdated", Boolean.toString(lastUpdated != null && !lastUpdated.isEmpty()));
     operation.setOption(
@@ -377,6 +377,9 @@ public final class R4ExplanationOfBenefitResourceProvider extends AbstractResour
                 Optional.ofNullable(serviceDate),
                 filterSamhsa,
                 includeTaxNumbers);
+      } catch (InvalidRequestException e) {
+        // If we're throwing a 400, pass it back up
+        throw e;
       } catch (Exception e) {
         LOGGER.error(e.getMessage(), e);
       }

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/TransformerUtilsV2.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/TransformerUtilsV2.java
@@ -1765,9 +1765,9 @@ public final class TransformerUtilsV2 {
        * TODO: Above bug should be fixed as of 1/1/20; re-investigate this
        */
       int endIndex = Math.min(paging.getStartIndex() + paging.getPageSize(), resources.size());
-      resourcesSubList = resources.subList(paging.getStartIndex(), endIndex);
       // Throw a 400 if startIndex >= results, since we cant sublist with these values
       validateStartIndexSize(paging.getStartIndex(), resources.size());
+      resourcesSubList = resources.subList(paging.getStartIndex(), endIndex);
       bundle = TransformerUtilsV2.addResourcesToBundle(bundle, resourcesSubList);
       paging.setTotal(resources.size()).addLinks(bundle);
       // Add number of paginated resources to MDC logs

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/TransformerUtilsV2.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/TransformerUtilsV2.java
@@ -1766,6 +1766,8 @@ public final class TransformerUtilsV2 {
        */
       int endIndex = Math.min(paging.getStartIndex() + paging.getPageSize(), resources.size());
       resourcesSubList = resources.subList(paging.getStartIndex(), endIndex);
+      // Throw a 400 if startIndex >= results, since we cant sublist with these values
+      validateStartIndexSize(paging.getStartIndex(), resources.size());
       bundle = TransformerUtilsV2.addResourcesToBundle(bundle, resourcesSubList);
       paging.setTotal(resources.size()).addLinks(bundle);
       // Add number of paginated resources to MDC logs
@@ -1797,6 +1799,24 @@ public final class TransformerUtilsV2 {
                 : Date.from(maxBundleDate));
     bundle.setTotal(resources.size());
     return bundle;
+  }
+
+  /**
+   * Validate the start index size is less than the total number of resources. If startIndex is
+   * greater than or equal to the number of resources, throws an InvalidRequestException which will
+   * bubble up and create a 400 error at the REST level via HAPI-FHIR.
+   *
+   * @param startIndex the start index from the paging
+   * @param numResources the number of resources in the response
+   */
+  public static void validateStartIndexSize(int startIndex, int numResources) {
+    // Throw a 400 if startIndex >= results, since we cant sublist with these values
+    if (startIndex >= numResources) {
+      throw new InvalidRequestException(
+          String.format(
+              "Value for startIndex (%d) must be less than than result size (%d)",
+              startIndex, numResources));
+    }
   }
 
   /**

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/pac/AbstractR4ResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/pac/AbstractR4ResourceProvider.java
@@ -438,6 +438,8 @@ public abstract class AbstractR4ResourceProvider<T extends IBaseResource>
     if (paging.isPagingRequested()) {
       paging.setTotal(resources.size()).addLinks(bundle);
       int endIndex = Math.min(paging.getStartIndex() + paging.getPageSize(), resources.size());
+      // Throw a 400 if startIndex >= results, since we cant sublist with these values
+      TransformerUtilsV2.validateStartIndexSize(paging.getStartIndex(), resources.size());
       resources = resources.subList(paging.getStartIndex(), endIndex);
     }
 

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/ExplanationOfBenefitResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/ExplanationOfBenefitResourceProvider.java
@@ -375,6 +375,9 @@ public final class ExplanationOfBenefitResourceProvider extends AbstractResource
                 Optional.ofNullable(serviceDate),
                 filterSamhsa,
                 includeTaxNumbers);
+      } catch (InvalidRequestException e) {
+        // If we're throwing a 400, pass it back up
+        throw e;
       } catch (Exception e) {
         LOGGER.error(e.getMessage(), e);
       }

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtils.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtils.java
@@ -3180,6 +3180,14 @@ public final class TransformerUtils {
        * correctly.
        */
       int endIndex = Math.min(paging.getStartIndex() + paging.getPageSize(), resources.size());
+      // Throw a 400 if startIndex >= results, since we cant sublist with these values
+      if (paging.getStartIndex() >= resources.size()) {
+        throw new InvalidRequestException(
+            String.format(
+                "Value for startIndex (%s) must be less than than result size (%s)",
+                paging.getStartIndex(), resources.size()));
+      }
+
       List<IBaseResource> resourcesSubList = resources.subList(paging.getStartIndex(), endIndex);
       bundle = TransformerUtils.addResourcesToBundle(bundle, resourcesSubList);
       paging.setTotal(resources.size()).addLinks(bundle);

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/ServerRequiredTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/ServerRequiredTest.java
@@ -45,6 +45,9 @@ public class ServerRequiredTest {
   @GuardedBy("class synchronized")
   protected static RequestSpecification requestAuth;
 
+  /** The Server test utils instance, for convenience and brevity. */
+  protected ServerTestUtils testUtils = ServerTestUtils.get();
+
   /** Sets up the test server (and required datasource) if the server is not already running. */
   @BeforeAll
   protected static synchronized void setup() throws IOException {

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/commons/OffsetLinkBuilderTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/commons/OffsetLinkBuilderTest.java
@@ -74,7 +74,7 @@ public class OffsetLinkBuilderTest {
     assertThrows(
         InvalidRequestException.class,
         () -> {
-          OffsetLinkBuilder linkBuilder = new OffsetLinkBuilder(requestDetails, "");
+          new OffsetLinkBuilder(requestDetails, "");
         },
         "Value for startIndex cannot be negative: -1");
   }
@@ -92,12 +92,11 @@ public class OffsetLinkBuilderTest {
     String[] value = {"-1"};
     params.put(Constants.PARAM_COUNT, value);
     when(requestDetails.getParameters()).thenReturn(params);
-    OffsetLinkBuilder linkBuilder = new OffsetLinkBuilder(requestDetails, "");
 
     assertThrows(
         InvalidRequestException.class,
         () -> {
-          linkBuilder.getPageSize();
+          new OffsetLinkBuilder(requestDetails, "");
         },
         "Value for pageSize cannot be negative: -1");
   }

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/CoverageE2E.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/CoverageE2E.java
@@ -1,0 +1,101 @@
+package gov.cms.bfd.server.war.r4.providers;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+
+import gov.cms.bfd.server.war.ServerRequiredTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Endpoint end-to-end test for the V2 Coverage endpoint. */
+public class CoverageE2E extends ServerRequiredTest {
+
+  /** The base coverage endpoint. */
+  private static String coverageEndpoint;
+
+  /** Sets up the test resources. */
+  @BeforeEach
+  public void setupTest() {
+    // Set this up once, after the server has run
+    if (coverageEndpoint == null) {
+      coverageEndpoint = baseServerUrl + "/v2/fhir/Coverage/";
+    }
+  }
+
+  /**
+   * Verify that Coverage throws a 400 error when the paging start (startIndex) is set higher than
+   * the maximum number of results.
+   */
+  @Test
+  public void testCoverageSearchByBeneWithPagingStartBeyondMaxExpect400() {
+    String beneficiaryId =
+        String.valueOf(
+            testUtils.getFirstBeneficiary(testUtils.loadSampleAData()).getBeneficiaryId());
+    String requestString =
+        coverageEndpoint + "?beneficiary=" + beneficiaryId + "&_count=2&startIndex=12";
+
+    given()
+        .spec(requestAuth)
+        .expect()
+        .body("issue.severity", hasItem("error"))
+        .body(
+            "issue.diagnostics",
+            hasItem("Value for startIndex (12) must be less than than result size (4)"))
+        .statusCode(400)
+        .when()
+        .get(requestString);
+  }
+
+  /**
+   * Verify that Coverage throws a 400 error when the paging start (startIndex) is set to the
+   * maximum number of results, since the highest index must be less than the number of results as a
+   * 0-based index.
+   */
+  @Test
+  public void testCoverageSearchByBeneWithPagingStartSetToMaxResultsExpect400() {
+    String beneficiaryId =
+        String.valueOf(
+            testUtils.getFirstBeneficiary(testUtils.loadSampleAData()).getBeneficiaryId());
+    String requestString =
+        coverageEndpoint + "?beneficiary=" + beneficiaryId + "&_count=2&startIndex=4";
+
+    given()
+        .spec(requestAuth)
+        .expect()
+        .log()
+        .ifError()
+        .body("issue.severity", hasItem("error"))
+        .body(
+            "issue.diagnostics",
+            hasItem("Value for startIndex (4) must be less than than result size (4)"))
+        .statusCode(400)
+        .when()
+        .get(requestString);
+  }
+
+  /**
+   * Verify that Coverage does not error when the paging start (startIndex) is set to be equal to
+   * one less than the maximum number of results.
+   */
+  @Test
+  public void testCoverageSearchByBeneWithPagingStartOneLessThanMaxExpect200() {
+    String beneficiaryId =
+        String.valueOf(
+            testUtils.getFirstBeneficiary(testUtils.loadSampleAData()).getBeneficiaryId());
+    String requestString =
+        coverageEndpoint + "?beneficiary=" + beneficiaryId + "&_count=2&startIndex=3";
+
+    given()
+        .spec(requestAuth)
+        .expect()
+        .log()
+        .ifError()
+        .body("resourceType", equalTo("Bundle"))
+        .body("entry.size()", equalTo(1))
+        .body("total", equalTo(4))
+        .statusCode(200)
+        .when()
+        .get(requestString);
+  }
+}

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/ExplanationOfBenefitE2E.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/ExplanationOfBenefitE2E.java
@@ -36,7 +36,6 @@ import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.apache.commons.lang3.tuple.Triple;
 import org.hl7.fhir.r4.model.Patient;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /** Endpoint end-to-end test for the V2 explanation of benefits endpoint. */

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/PatientE2E.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/PatientE2E.java
@@ -1,0 +1,92 @@
+package gov.cms.bfd.server.war.r4.providers;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+
+import gov.cms.bfd.server.war.ServerRequiredTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Endpoint end-to-end test for the V2 Patient endpoint. */
+public class PatientE2E extends ServerRequiredTest {
+
+  /** The base patient endpoint. */
+  private static String patientEndpoint;
+
+  /** Sets up the test resources. */
+  @BeforeEach
+  public void setupTest() {
+    // Set this up once, after the server has run
+    if (patientEndpoint == null) {
+      patientEndpoint = baseServerUrl + "/v2/fhir/Patient/";
+    }
+  }
+
+  /**
+   * Verify that Patient throws a 400 error when the paging start (startIndex) is set higher than
+   * the maximum number of results.
+   */
+  @Test
+  public void testPatientByLogicalIdWithPagingStartBeyondMaxExpect400() {
+    String patientId = testUtils.getPatientId(testUtils.loadSampleAData());
+    String requestString = patientEndpoint + "?_id=" + patientId + "&_count=2&startIndex=12";
+
+    given()
+        .spec(requestAuth)
+        .expect()
+        .body("issue.severity", hasItem("error"))
+        .body(
+            "issue.diagnostics",
+            hasItem("Value for startIndex (12) must be less than than result size (1)"))
+        .statusCode(400)
+        .when()
+        .get(requestString);
+  }
+
+  /**
+   * Verify that Patient throws a 400 error when the paging start (startIndex) is set to the maximum
+   * number of results, since the highest index must be less than the number of results as a 0-based
+   * index.
+   */
+  @Test
+  public void testPatientByLogicalIdWithPagingStartSetToMaxResultsExpect400() {
+    String patientId = testUtils.getPatientId(testUtils.loadSampleAData());
+    String requestString = patientEndpoint + "?_id=" + patientId + "&_count=1&startIndex=1";
+
+    given()
+        .spec(requestAuth)
+        .expect()
+        .log()
+        .ifError()
+        .body("issue.severity", hasItem("error"))
+        .body(
+            "issue.diagnostics",
+            hasItem("Value for startIndex (1) must be less than than result size (1)"))
+        .statusCode(400)
+        .when()
+        .get(requestString);
+  }
+
+  /**
+   * Verify that Patient does not error when the paging start (startIndex) is set to be equal to one
+   * less than the maximum number of results.
+   */
+  @Test
+  public void testPatientByLogicalIdWithPagingStartOneLessThanMaxExpect200() {
+    String patientId = testUtils.getPatientId(testUtils.loadSampleAData());
+    String requestString = patientEndpoint + "?_id=" + patientId + "&_count=1&startIndex=0";
+
+    given()
+        .spec(requestAuth)
+        .expect()
+        .log()
+        .ifError()
+        .body("resourceType", equalTo("Bundle"))
+        .body("entry.size()", equalTo(1))
+        .body("total", equalTo(1))
+        .statusCode(200)
+        .when()
+        .get(requestString);
+  }
+}

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/TransformerUtilsV2Test.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/TransformerUtilsV2Test.java
@@ -13,6 +13,7 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
 import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import com.codahale.metrics.MetricRegistry;
 import gov.cms.bfd.data.fda.lookup.FdaDrugCodeDisplayLookup;
 import gov.cms.bfd.data.npi.lookup.NPIOrgLookup;
@@ -938,6 +939,64 @@ public class TransformerUtilsV2Test {
     Bundle bundle = TransformerUtilsV2.createBundle(paging, eobs, Instant.now());
     assertEquals(4, bundle.getTotal());
     assertEquals(2, Integer.parseInt(BfdMDC.get("resources_returned_count")));
+  }
+
+  /**
+   * Verifies that creating a bundle with a start index greater than the resource count throws a
+   * {@link InvalidRequestException}.
+   */
+  @Test
+  public void createBundleWithStartIndexGreaterThanResourceCountExpectException() {
+
+    RequestDetails requestDetails = mock(RequestDetails.class);
+    Map<String, String[]> pagingParams = new HashMap<>();
+    pagingParams.put(Constants.PARAM_COUNT, new String[] {"2"});
+    pagingParams.put("startIndex", new String[] {"12"});
+    when(requestDetails.getParameters()).thenReturn(pagingParams);
+    OffsetLinkBuilder paging = new OffsetLinkBuilder(requestDetails, "/ExplanationOfBenefit?");
+
+    List<IBaseResource> eobs = new ArrayList<>();
+    // Add three resources
+    eobs.add(new ExplanationOfBenefit());
+    eobs.add(new ExplanationOfBenefit());
+    eobs.add(new ExplanationOfBenefit());
+
+    InvalidRequestException expectedException =
+        assertThrows(
+            InvalidRequestException.class,
+            () -> TransformerUtilsV2.createBundle(paging, eobs, Instant.now()));
+    assertEquals(
+        "Value for startIndex (12) must be less than than result size (3)",
+        expectedException.getMessage());
+  }
+
+  /**
+   * Verifies that creating a bundle with a start index equal to the resource count throws a {@link
+   * InvalidRequestException} (its 0-indexed).
+   */
+  @Test
+  public void createBundleWithStartIndexEqualsResourceCountExpectException() {
+
+    RequestDetails requestDetails = mock(RequestDetails.class);
+    Map<String, String[]> pagingParams = new HashMap<>();
+    pagingParams.put(Constants.PARAM_COUNT, new String[] {"2"});
+    pagingParams.put("startIndex", new String[] {"3"});
+    when(requestDetails.getParameters()).thenReturn(pagingParams);
+    OffsetLinkBuilder paging = new OffsetLinkBuilder(requestDetails, "/ExplanationOfBenefit?");
+
+    List<IBaseResource> eobs = new ArrayList<>();
+    // Add three resources
+    eobs.add(new ExplanationOfBenefit());
+    eobs.add(new ExplanationOfBenefit());
+    eobs.add(new ExplanationOfBenefit());
+
+    InvalidRequestException expectedException =
+        assertThrows(
+            InvalidRequestException.class,
+            () -> TransformerUtilsV2.createBundle(paging, eobs, Instant.now()));
+    assertEquals(
+        "Value for startIndex (3) must be less than than result size (3)",
+        expectedException.getMessage());
   }
 
   /** Verifies that {@link TransformerUtilsV2#createBundle} sets bundle size correctly. */

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/pac/ClaimE2E.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/pac/ClaimE2E.java
@@ -1,0 +1,106 @@
+package gov.cms.bfd.server.war.r4.providers.pac;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+
+import gov.cms.bfd.server.war.ServerRequiredTest;
+import gov.cms.bfd.server.war.utils.RDATestUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Endpoint end-to-end test for the Claim endpoint. */
+public class ClaimE2E extends ServerRequiredTest {
+
+  /** Test utils. */
+  private static final RDATestUtils rdaTestUtils = new RDATestUtils();
+
+  /** The base claim endpoint. */
+  private static String claimEndpoint;
+
+  /** Sets up the test resources. */
+  @BeforeEach
+  public void setupTest() {
+    // Set this up once, after the server has run
+    if (claimEndpoint == null) {
+      rdaTestUtils.init();
+      rdaTestUtils.seedData(true);
+      claimEndpoint = baseServerUrl + "/v2/fhir/Claim/";
+    }
+  }
+
+  /** Cleans up the test data. */
+  @AfterAll
+  public static void tearDown() {
+    rdaTestUtils.truncateTables();
+    rdaTestUtils.destroy();
+  }
+
+  /**
+   * Verify that Claim throws a 400 error when the paging start (startIndex) is set higher than the
+   * maximum number of results.
+   */
+  @Test
+  public void testClaimFindByPatientWithPagingStartBeyondMaxExpect400() {
+    String requestString =
+        claimEndpoint + "?mbi=" + RDATestUtils.MBI_OLD_HASH + "&_count=2&startIndex=12";
+
+    given()
+        .spec(requestAuth)
+        .expect()
+        .body("issue.severity", hasItem("error"))
+        .body(
+            "issue.diagnostics",
+            hasItem("Value for startIndex (12) must be less than than result size (4)"))
+        .statusCode(400)
+        .when()
+        .get(requestString);
+  }
+
+  /**
+   * Verify that Claim throws a 400 error when the paging start (startIndex) is set to the maximum
+   * number of results, since the highest index must be less than the number of results as a 0-based
+   * index.
+   */
+  @Test
+  public void testClaimFindByPatientWithPagingStartSetToMaxResultsExpect400() {
+    String requestString =
+        claimEndpoint + "?mbi=" + RDATestUtils.MBI_OLD_HASH + "&_count=2&startIndex=4";
+
+    given()
+        .spec(requestAuth)
+        .expect()
+        .body("issue.severity", hasItem("error"))
+        .body(
+            "issue.diagnostics",
+            hasItem("Value for startIndex (4) must be less than than result size (4)"))
+        .statusCode(400)
+        .when()
+        .get(requestString);
+  }
+
+  /**
+   * Verify that Claim does not error when the paging start (startIndex) is set to be equal to one
+   * less than the maximum number of results.
+   */
+  @Test
+  public void testClaimFindByPatientWithPagingStartOneLessThanMaxExpect200() {
+    String requestString =
+        claimEndpoint + "?mbi=" + RDATestUtils.MBI_OLD_HASH + "&_count=2&startIndex=3";
+
+    given()
+        .spec(requestAuth)
+        .expect()
+        .log()
+        .body()
+        .body("resourceType", equalTo("Bundle"))
+        // sine we start on the last item's index with 2 items per page, 1 item returned
+        .body("entry.size()", equalTo(1))
+        // 4 items total reported on all pages
+        .body("total", equalTo(4))
+        .statusCode(200)
+        .when()
+        .get(requestString);
+  }
+}

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/pac/ClaimResponseE2E.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/pac/ClaimResponseE2E.java
@@ -1,0 +1,106 @@
+package gov.cms.bfd.server.war.r4.providers.pac;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+
+import gov.cms.bfd.server.war.ServerRequiredTest;
+import gov.cms.bfd.server.war.utils.RDATestUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Endpoint end-to-end test for the ClaimResponse endpoint. */
+public class ClaimResponseE2E extends ServerRequiredTest {
+
+  /** Test utils. */
+  private static final RDATestUtils rdaTestUtils = new RDATestUtils();
+
+  /** The base claim response endpoint. */
+  private static String claimResponseEndpoint;
+
+  /** Sets up the test resources. */
+  @BeforeEach
+  public void setupTest() {
+    // Set this up once, after the server has run
+    if (claimResponseEndpoint == null) {
+      rdaTestUtils.init();
+      rdaTestUtils.seedData(true);
+      claimResponseEndpoint = baseServerUrl + "/v2/fhir/ClaimResponse/";
+    }
+  }
+
+  /** Cleans up the test data. */
+  @AfterAll
+  public static void tearDown() {
+    rdaTestUtils.truncateTables();
+    rdaTestUtils.destroy();
+  }
+
+  /**
+   * Verify that ClaimResponse throws a 400 error when the paging start (startIndex) is set higher
+   * than the maximum number of results.
+   */
+  @Test
+  public void testClaimResponseFindByPatientWithPagingStartBeyondMaxExpect400() {
+    String requestString =
+        claimResponseEndpoint + "?mbi=" + RDATestUtils.MBI_OLD_HASH + "&_count=2&startIndex=12";
+
+    given()
+        .spec(requestAuth)
+        .expect()
+        .body("issue.severity", hasItem("error"))
+        .body(
+            "issue.diagnostics",
+            hasItem("Value for startIndex (12) must be less than than result size (4)"))
+        .statusCode(400)
+        .when()
+        .get(requestString);
+  }
+
+  /**
+   * Verify that ClaimResponse throws a 400 error when the paging start (startIndex) is set to the
+   * maximum number of results, since the highest index must be less than the number of results as a
+   * 0-based index.
+   */
+  @Test
+  public void testClaimResponseFindByPatientWithPagingStartSetToMaxResultsExpect400() {
+    String requestString =
+        claimResponseEndpoint + "?mbi=" + RDATestUtils.MBI_OLD_HASH + "&_count=2&startIndex=4";
+
+    given()
+        .spec(requestAuth)
+        .expect()
+        .body("issue.severity", hasItem("error"))
+        .body(
+            "issue.diagnostics",
+            hasItem("Value for startIndex (4) must be less than than result size (4)"))
+        .statusCode(400)
+        .when()
+        .get(requestString);
+  }
+
+  /**
+   * Verify that ClaimResponse does not error when the paging start (startIndex) is set to be equal
+   * to one less than the maximum number of results.
+   */
+  @Test
+  public void testClaimResponseFindByPatientWithPagingStartOneLessThanMaxExpect200() {
+    String requestString =
+        claimResponseEndpoint + "?mbi=" + RDATestUtils.MBI_OLD_HASH + "&_count=2&startIndex=3";
+
+    given()
+        .spec(requestAuth)
+        .expect()
+        .log()
+        .body()
+        .body("resourceType", equalTo("Bundle"))
+        // sine we start on the last item's index with 2 items per page, 1 item returned
+        .body("entry.size()", equalTo(1))
+        // 4 items total reported on all pages
+        .body("total", equalTo(4))
+        .statusCode(200)
+        .when()
+        .get(requestString);
+  }
+}

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/CoverageE2E.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/CoverageE2E.java
@@ -1,0 +1,101 @@
+package gov.cms.bfd.server.war.stu3.providers;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+
+import gov.cms.bfd.server.war.ServerRequiredTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Endpoint end-to-end test for the V1 Coverage endpoint. */
+public class CoverageE2E extends ServerRequiredTest {
+
+  /** The base coverage endpoint. */
+  private static String coverageEndpoint;
+
+  /** Sets up the test resources. */
+  @BeforeEach
+  public void setupTest() {
+    // Set this up once, after the server has run
+    if (coverageEndpoint == null) {
+      coverageEndpoint = baseServerUrl + "/v1/fhir/Coverage/";
+    }
+  }
+
+  /**
+   * Verify that Coverage throws a 400 error when the paging start (startIndex) is set higher than
+   * the maximum number of results.
+   */
+  @Test
+  public void testCoverageSearchByBeneWithPagingStartBeyondMaxExpect400() {
+    String beneficiaryId =
+        String.valueOf(
+            testUtils.getFirstBeneficiary(testUtils.loadSampleAData()).getBeneficiaryId());
+    String requestString =
+        coverageEndpoint + "?beneficiary=" + beneficiaryId + "&_count=2&startIndex=12";
+
+    given()
+        .spec(requestAuth)
+        .expect()
+        .body("issue.severity", hasItem("error"))
+        .body(
+            "issue.diagnostics",
+            hasItem("Value for startIndex (12) must be less than than result size (4)"))
+        .statusCode(400)
+        .when()
+        .get(requestString);
+  }
+
+  /**
+   * Verify that Coverage throws a 400 error when the paging start (startIndex) is set to the
+   * maximum number of results, since the highest index must be less than the number of results as a
+   * 0-based index.
+   */
+  @Test
+  public void testCoverageSearchByBeneWithPagingStartSetToMaxResultsExpect400() {
+    String beneficiaryId =
+        String.valueOf(
+            testUtils.getFirstBeneficiary(testUtils.loadSampleAData()).getBeneficiaryId());
+    String requestString =
+        coverageEndpoint + "?beneficiary=" + beneficiaryId + "&_count=2&startIndex=4";
+
+    given()
+        .spec(requestAuth)
+        .expect()
+        .log()
+        .ifError()
+        .body("issue.severity", hasItem("error"))
+        .body(
+            "issue.diagnostics",
+            hasItem("Value for startIndex (4) must be less than than result size (4)"))
+        .statusCode(400)
+        .when()
+        .get(requestString);
+  }
+
+  /**
+   * Verify that Coverage does not error when the paging start (startIndex) is set to be equal to
+   * one less than the maximum number of results.
+   */
+  @Test
+  public void testCoverageSearchByBeneWithPagingStartOneLessThanMaxExpect200() {
+    String beneficiaryId =
+        String.valueOf(
+            testUtils.getFirstBeneficiary(testUtils.loadSampleAData()).getBeneficiaryId());
+    String requestString =
+        coverageEndpoint + "?beneficiary=" + beneficiaryId + "&_count=2&startIndex=3";
+
+    given()
+        .spec(requestAuth)
+        .expect()
+        .log()
+        .ifError()
+        .body("resourceType", equalTo("Bundle"))
+        .body("entry.size()", equalTo(1))
+        .body("total", equalTo(4))
+        .statusCode(200)
+        .when()
+        .get(requestString);
+  }
+}

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/PatientE2E.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/PatientE2E.java
@@ -1,0 +1,92 @@
+package gov.cms.bfd.server.war.stu3.providers;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+
+import gov.cms.bfd.server.war.ServerRequiredTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Endpoint end-to-end test for the V1 Patient endpoint. */
+public class PatientE2E extends ServerRequiredTest {
+
+  /** The base patient endpoint. */
+  private static String patientEndpoint;
+
+  /** Sets up the test resources. */
+  @BeforeEach
+  public void setupTest() {
+    // Set this up once, after the server has run
+    if (patientEndpoint == null) {
+      patientEndpoint = baseServerUrl + "/v1/fhir/Patient/";
+    }
+  }
+
+  /**
+   * Verify that Patient throws a 400 error when the paging start (startIndex) is set higher than
+   * the maximum number of results.
+   */
+  @Test
+  public void testPatientByLogicalIdWithPagingStartBeyondMaxExpect400() {
+    String patientId = testUtils.getPatientId(testUtils.loadSampleAData());
+    String requestString = patientEndpoint + "?_id=" + patientId + "&_count=2&startIndex=12";
+
+    given()
+        .spec(requestAuth)
+        .expect()
+        .body("issue.severity", hasItem("error"))
+        .body(
+            "issue.diagnostics",
+            hasItem("Value for startIndex (12) must be less than than result size (1)"))
+        .statusCode(400)
+        .when()
+        .get(requestString);
+  }
+
+  /**
+   * Verify that Patient throws a 400 error when the paging start (startIndex) is set to the maximum
+   * number of results, since the highest index must be less than the number of results as a 0-based
+   * index.
+   */
+  @Test
+  public void testPatientByLogicalIdWithPagingStartSetToMaxResultsExpect400() {
+    String patientId = testUtils.getPatientId(testUtils.loadSampleAData());
+    String requestString = patientEndpoint + "?_id=" + patientId + "&_count=1&startIndex=1";
+
+    given()
+        .spec(requestAuth)
+        .expect()
+        .log()
+        .ifError()
+        .body("issue.severity", hasItem("error"))
+        .body(
+            "issue.diagnostics",
+            hasItem("Value for startIndex (1) must be less than than result size (1)"))
+        .statusCode(400)
+        .when()
+        .get(requestString);
+  }
+
+  /**
+   * Verify that Patient does not error when the paging start (startIndex) is set to be equal to one
+   * less than the maximum number of results.
+   */
+  @Test
+  public void testPatientByLogicalIdWithPagingStartOneLessThanMaxExpect200() {
+    String patientId = testUtils.getPatientId(testUtils.loadSampleAData());
+    String requestString = patientEndpoint + "?_id=" + patientId + "&_count=1&startIndex=0";
+
+    given()
+        .spec(requestAuth)
+        .expect()
+        .log()
+        .ifError()
+        .body("resourceType", equalTo("Bundle"))
+        .body("entry.size()", equalTo(1))
+        .body("total", equalTo(1))
+        .statusCode(200)
+        .when()
+        .get(requestString);
+  }
+}


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BFD-2849](https://jira.cms.gov/browse/BFD-2849)

**User Story or Bug Summary:**
<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->
Calling the EOB (and probably other) endpoints with a startIndex greater than the number of entries in the response returns a 500; the response should be a 400, since this is a user input error and can be corrected by adjusting the request.

---

### What Does This PR Do?
<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

For every endpoint (via adjusting the bundling logic when pagination is request in the TransformerUtils) we will throw an InvalidRequestException with a useful error message when the `startIndex >= totalResources.size()` which will cause a 400 at the response layer in HAPI-FHIR.

While many restAssured tests were added to cover this case for each endpoint (including PAC endpoints), 99% of the tests are just copy/pasted from the newly added EOB tests with minor alterations for the endpoint, number of results expected, and version (between v1/v2), so much of this is the same code. 

For each endpoint, only tests that were related to the bug were added. One exception is v1 EOB, where all the tests that existed for v2 worked so figured I might as well copy them all over.

For v1 restAssured E2Es, I just copied exactly what was in the V2 tests, and changed it to v1. (Only exception being the EOB tests where the paths for taxNum were different and a couple asserts had to have their path adjusted).

Major Adjustments:
- Adjusts EOB resource provider in both v1 and v2 to not swallow InvalidRequestExceptions when creating the bundle, since this would prevent throwing a 400 during the bundling
- Adds logic to throw an InvalidRequestException while creating bundles for all endpoints (including PAC endpoints) if the startIndex >= max number of resources returned
- Adds RestAssured test classes for every endpoint, both v1 and v2
   - Tests added for each endpoint were to cover this bugfix only, but add a nice framework for future test additions

Minor Adjustments:
- Cleanup in OffsetLinkBuilder to move the validations of the field sizes into a method instead of being spread between constructor, getters, and elsewhere. This lines up with how fields were validated in PatientLinkBuilder.
    - Fixed a couple tests as a result of the validation changes, since some validation checks were done in getters before
- Fixes some spots near code I was changing which were using string concatenation to make strings instead of String.Valueof
- Adds some common restAssured test methods to ServerTestUtils so they can be shared



### What Should Reviewers Watch For?
<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items to the following list here -->
* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [x] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [x] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [x] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

Signoff from the various peering partners, noted in this confluence document:
https://confluence.cms.gov/pages/viewpage.action?pageId=896217997


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] The data dictionary has been updated with any field mapping changes, if any were made.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    