### PR TITLE
BFD-2850: Bug fix to count being ignored when using lastUpdated ranges: V1

### DIFF
--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtils.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/stu3/providers/TransformerUtils.java
@@ -3213,9 +3213,8 @@ public final class TransformerUtils {
      * manager's version of
      * the timestamp.
      */
-    // FUTURE: Fix this to use sublist similar to V2 to fix bug
     Instant maxBundleDate =
-        resources.stream()
+        resourcesSubList.stream()
             .map(r -> r.getMeta().getLastUpdated().toInstant())
             .filter(Objects::nonNull)
             .max(Instant::compareTo)

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/ExplanationOfBenefitE2E.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/ExplanationOfBenefitE2E.java
@@ -723,8 +723,6 @@ public class ExplanationOfBenefitE2E extends ServerRequiredTest {
         given()
             .spec(requestAuth)
             .expect()
-            .log()
-            .body()
             .body("entry.size()", equalTo(expectedCount))
             .body("total", equalTo(expectedTotal))
             .statusCode(200)

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/ExplanationOfBenefitE2E.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/ExplanationOfBenefitE2E.java
@@ -34,7 +34,6 @@ import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.apache.commons.lang3.tuple.Triple;
 import org.hl7.fhir.r4.model.Patient;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /** Endpoint end-to-end test for the V1 explanation of benefits endpoint. */
@@ -695,15 +694,13 @@ public class ExplanationOfBenefitE2E extends ServerRequiredTest {
   /**
    * Verifies that {@link ExplanationOfBenefitResourceProvider#findByPatient} works as with a
    * lastUpdated parameter after yesterday and pagination links work and contain lastUpdated.
-   *
-   * <p>FIXME: Fix up like v2, should work now
    */
   @Test
-  @Disabled("Should be fixed, needs adjustment like v2")
   public void searchEobByPatientIdWithLastUpdatedAndPagination() {
 
     String patientId = testUtils.getPatientId(testUtils.loadSampleAData());
     int expectedCount = 5;
+    int expectedTotal = 8;
     String yesterday =
         new DateTimeDt(Date.from(Instant.now().minus(1, ChronoUnit.DAYS))).getValueAsString();
     String now = new DateTimeDt(new Date()).getValueAsString();
@@ -721,7 +718,7 @@ public class ExplanationOfBenefitE2E extends ServerRequiredTest {
             .spec(requestAuth)
             .expect()
             .body("entry.size()", equalTo(expectedCount))
-            .body("total", equalTo(expectedCount))
+            .body("total", equalTo(expectedTotal))
             .statusCode(200)
             .when()
             .get(requestString);
@@ -744,7 +741,7 @@ public class ExplanationOfBenefitE2E extends ServerRequiredTest {
         .spec(requestAuth)
         .expect()
         .body("entry.size()", equalTo(3))
-        .body("total", equalTo(3))
+        .body("total", equalTo(expectedTotal))
         .statusCode(200)
         .when()
         .get(URLDecoder.decode(nextLink));


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BFD-2850](https://jira.cms.gov/browse/BFD-2850)


**User Story or Bug Summary:**
<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->


---
When using an EOB request with lastUpdated AND pagination (using _count) the _count parameter seems to be ignored.  This change was fixed in #1922. This change is specific to adding the test for version 1 (Stu3) providers. 
Note: This change updates the E2E for both R4 to remove  `log().body()` which was used for debugging as well as 
updating the E2E for both Stu3 to enabled the test and fix certain aspects of the test for version 1. 

### What Does This PR Do?
<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

These changes update the `searchEobByPatientIdWithLastUpdatedAndPagination()` for both the R4 and Stu3 providers which were disabled in stu3. The r4 update removes .log().body() which was used for debugging. 


- Updates `TransformerUtils.java` to reference r`esourcesSubList` for uniformity with V2 version
-  Updates `searchEobByPatientIdWithLastUpdatedAndPagination()` test in ExplanationOfBenefitE2E.java`  in `gov.cms.bfd.server.war.r4.providers`
-  Updates `searchEobByPatientIdWithLastUpdatedAndPagination()` test in ExplanationOfBenefitE2E.java`  in `gov.cms.bfd.server.war.stu3.providers`


### What Should Reviewers Watch For?
<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items to the following list here -->
* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [X] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [X] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [X] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [X] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [X] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [X] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [X] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [X] The data dictionary has been updated with any field mapping changes, if any were made.
* [X] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [X] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [X] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [X] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    