### PR TITLE
BFD-2706 Update performance SLO alarms for claim and claimresponse resources

### DIFF
--- a/ops/terraform/modules/resources/bfd_server_slo_alarms/main.tf
+++ b/ops/terraform/modules/resources/bfd_server_slo_alarms/main.tf
@@ -908,8 +908,8 @@ resource "aws_cloudwatch_metric_alarm" "slo_claim_no_resources_latency_mean_15m_
   metric_name = local.metrics.claim_no_resources_latency
   namespace   = local.namespace
 
-  alarm_actions = [data.aws_sns_topic.bfd_test_sns.arn]
-  ok_actions    = null
+  alarm_actions = local.alert_arn
+  ok_actions    = local.alert_ok_arn
 
   datapoints_to_alarm = "1"
   treat_missing_data  = "notBreaching"
@@ -932,8 +932,8 @@ resource "aws_cloudwatch_metric_alarm" "slo_claim_no_resources_latency_mean_15m_
   metric_name = local.metrics.claim_no_resources_latency
   namespace   = local.namespace
 
-  alarm_actions = [data.aws_sns_topic.bfd_test_sns.arn]
-  ok_actions    = null
+  alarm_actions = local.warning_arn
+  ok_actions    = local.warning_ok_arn
 
   datapoints_to_alarm = "1"
   treat_missing_data  = "notBreaching"
@@ -966,8 +966,8 @@ resource "aws_cloudwatch_metric_alarm" "slo_claim_with_resources_bulk_latency_99
     client_ssl = data.external.client_ssls_by_partner["claim_resources_latency"].result[each.key]
   }
 
-  alarm_actions = [data.aws_sns_topic.bfd_test_sns.arn]
-  ok_actions    = null
+  alarm_actions = local.alert_arn
+  ok_actions    = local.alert_ok_arn
 
   datapoints_to_alarm = "1"
   treat_missing_data  = "notBreaching"
@@ -990,8 +990,8 @@ resource "aws_cloudwatch_metric_alarm" "slo_claimresponse_no_resources_latency_m
   metric_name = local.metrics.claimresponse_no_resources_latency
   namespace   = local.namespace
 
-  alarm_actions = [data.aws_sns_topic.bfd_test_sns.arn]
-  ok_actions    = null
+  alarm_actions = local.alert_arn
+  ok_actions    = local.alert_ok_arn
 
   datapoints_to_alarm = "1"
   treat_missing_data  = "notBreaching"
@@ -1003,7 +1003,7 @@ resource "aws_cloudwatch_metric_alarm" "slo_claimresponse_no_resources_latency_m
   evaluation_periods  = "1"
   period              = "900"
   statistic           = "Average"
-  threshold           = "1000"
+  threshold           = "950"
 
   alarm_description = join("", [
     "/v*/fhir/ClaimResponse response with no resources returned mean 15 minute latency ",
@@ -1014,8 +1014,8 @@ resource "aws_cloudwatch_metric_alarm" "slo_claimresponse_no_resources_latency_m
   metric_name = local.metrics.claimresponse_no_resources_latency
   namespace   = local.namespace
 
-  alarm_actions = [data.aws_sns_topic.bfd_test_sns.arn]
-  ok_actions    = null
+  alarm_actions = local.warning_arn
+  ok_actions    = local.warning_ok_arn
 
   datapoints_to_alarm = "1"
   treat_missing_data  = "notBreaching"
@@ -1048,8 +1048,8 @@ resource "aws_cloudwatch_metric_alarm" "slo_claimresponse_with_resources_bulk_la
     client_ssl = data.external.client_ssls_by_partner["claimresponse_resources_latency"].result[each.key]
   }
 
-  alarm_actions = [data.aws_sns_topic.bfd_test_sns.arn]
-  ok_actions    = null
+  alarm_actions = local.alert_arn
+  ok_actions    = local.alert_ok_arn
 
   datapoints_to_alarm = "1"
   treat_missing_data  = "notBreaching"

--- a/ops/terraform/modules/resources/bfd_server_slo_alarms/main.tf
+++ b/ops/terraform/modules/resources/bfd_server_slo_alarms/main.tf
@@ -908,8 +908,8 @@ resource "aws_cloudwatch_metric_alarm" "slo_claim_no_resources_latency_mean_15m_
   metric_name = local.metrics.claim_no_resources_latency
   namespace   = local.namespace
 
-  alarm_actions = local.alert_arn
-  ok_actions    = local.alert_ok_arn
+  alarm_actions = [data.aws_sns_topic.bfd_test_sns.arn]
+  ok_actions    = null
 
   datapoints_to_alarm = "1"
   treat_missing_data  = "notBreaching"
@@ -932,8 +932,8 @@ resource "aws_cloudwatch_metric_alarm" "slo_claim_no_resources_latency_mean_15m_
   metric_name = local.metrics.claim_no_resources_latency
   namespace   = local.namespace
 
-  alarm_actions = local.warning_arn
-  ok_actions    = local.warning_ok_arn
+  alarm_actions = [data.aws_sns_topic.bfd_test_sns.arn]
+  ok_actions    = null
 
   datapoints_to_alarm = "1"
   treat_missing_data  = "notBreaching"
@@ -966,8 +966,8 @@ resource "aws_cloudwatch_metric_alarm" "slo_claim_with_resources_bulk_latency_99
     client_ssl = data.external.client_ssls_by_partner["claim_resources_latency"].result[each.key]
   }
 
-  alarm_actions = local.alert_arn
-  ok_actions    = local.alert_ok_arn
+  alarm_actions = [data.aws_sns_topic.bfd_test_sns.arn]
+  ok_actions    = null
 
   datapoints_to_alarm = "1"
   treat_missing_data  = "notBreaching"
@@ -990,8 +990,8 @@ resource "aws_cloudwatch_metric_alarm" "slo_claimresponse_no_resources_latency_m
   metric_name = local.metrics.claimresponse_no_resources_latency
   namespace   = local.namespace
 
-  alarm_actions = local.alert_arn
-  ok_actions    = local.alert_ok_arn
+  alarm_actions = [data.aws_sns_topic.bfd_test_sns.arn]
+  ok_actions    = null
 
   datapoints_to_alarm = "1"
   treat_missing_data  = "notBreaching"
@@ -1003,7 +1003,7 @@ resource "aws_cloudwatch_metric_alarm" "slo_claimresponse_no_resources_latency_m
   evaluation_periods  = "1"
   period              = "900"
   statistic           = "Average"
-  threshold           = "950"
+  threshold           = "1000"
 
   alarm_description = join("", [
     "/v*/fhir/ClaimResponse response with no resources returned mean 15 minute latency ",
@@ -1014,8 +1014,8 @@ resource "aws_cloudwatch_metric_alarm" "slo_claimresponse_no_resources_latency_m
   metric_name = local.metrics.claimresponse_no_resources_latency
   namespace   = local.namespace
 
-  alarm_actions = local.warning_arn
-  ok_actions    = local.warning_ok_arn
+  alarm_actions = [data.aws_sns_topic.bfd_test_sns.arn]
+  ok_actions    = null
 
   datapoints_to_alarm = "1"
   treat_missing_data  = "notBreaching"
@@ -1048,8 +1048,8 @@ resource "aws_cloudwatch_metric_alarm" "slo_claimresponse_with_resources_bulk_la
     client_ssl = data.external.client_ssls_by_partner["claimresponse_resources_latency"].result[each.key]
   }
 
-  alarm_actions = local.alert_arn
-  ok_actions    = local.alert_ok_arn
+  alarm_actions = [data.aws_sns_topic.bfd_test_sns.arn]
+  ok_actions    = null
 
   datapoints_to_alarm = "1"
   treat_missing_data  = "notBreaching"

--- a/ops/terraform/services/server/modules/bfd_server_slo_alarms/main.tf
+++ b/ops/terraform/services/server/modules/bfd_server_slo_alarms/main.tf
@@ -910,8 +910,8 @@ resource "aws_cloudwatch_metric_alarm" "slo_claim_no_resources_latency_mean_15m_
   metric_name = local.metrics.claim_no_resources_latency
   namespace   = local.namespace
 
-  alarm_actions = [data.aws_sns_topic.bfd_test_sns.arn]
-  ok_actions    = null
+  alarm_actions = local.alert_arn
+  ok_actions    = local.alert_ok_arn
 
   datapoints_to_alarm = "1"
   treat_missing_data  = "notBreaching"
@@ -934,8 +934,8 @@ resource "aws_cloudwatch_metric_alarm" "slo_claim_no_resources_latency_mean_15m_
   metric_name = local.metrics.claim_no_resources_latency
   namespace   = local.namespace
 
-  alarm_actions = [data.aws_sns_topic.bfd_test_sns.arn]
-  ok_actions    = null
+  alarm_actions = local.warning_arn
+  ok_actions    = local.warning_ok_arn
 
   datapoints_to_alarm = "1"
   treat_missing_data  = "notBreaching"
@@ -968,8 +968,8 @@ resource "aws_cloudwatch_metric_alarm" "slo_claim_with_resources_bulk_latency_99
     client_ssl = data.external.client_ssls_by_partner["claim_resources_latency"].result[each.key]
   }
 
-  alarm_actions = [data.aws_sns_topic.bfd_test_sns.arn]
-  ok_actions    = null
+  alarm_actions = local.alert_arn
+  ok_actions    = local.alert_ok_arn
 
   datapoints_to_alarm = "1"
   treat_missing_data  = "notBreaching"
@@ -992,8 +992,8 @@ resource "aws_cloudwatch_metric_alarm" "slo_claimresponse_no_resources_latency_m
   metric_name = local.metrics.claimresponse_no_resources_latency
   namespace   = local.namespace
 
-  alarm_actions = [data.aws_sns_topic.bfd_test_sns.arn]
-  ok_actions    = null
+  alarm_actions = local.alert_arn
+  ok_actions    = local.alert_ok_arn
 
   datapoints_to_alarm = "1"
   treat_missing_data  = "notBreaching"
@@ -1005,7 +1005,7 @@ resource "aws_cloudwatch_metric_alarm" "slo_claimresponse_no_resources_latency_m
   evaluation_periods  = "1"
   period              = "900"
   statistic           = "Average"
-  threshold           = "1000"
+  threshold           = "950"
 
   alarm_description = join("", [
     "/v*/fhir/ClaimResponse response with no resources returned mean 15 minute latency ",
@@ -1016,8 +1016,8 @@ resource "aws_cloudwatch_metric_alarm" "slo_claimresponse_no_resources_latency_m
   metric_name = local.metrics.claimresponse_no_resources_latency
   namespace   = local.namespace
 
-  alarm_actions = [data.aws_sns_topic.bfd_test_sns.arn]
-  ok_actions    = null
+  alarm_actions = local.warning_arn
+  ok_actions    = local.warning_ok_arn
 
   datapoints_to_alarm = "1"
   treat_missing_data  = "notBreaching"
@@ -1050,8 +1050,8 @@ resource "aws_cloudwatch_metric_alarm" "slo_claimresponse_with_resources_bulk_la
     client_ssl = data.external.client_ssls_by_partner["claimresponse_resources_latency"].result[each.key]
   }
 
-  alarm_actions = [data.aws_sns_topic.bfd_test_sns.arn]
-  ok_actions    = null
+  alarm_actions = local.alert_arn
+  ok_actions    = local.alert_ok_arn
 
   datapoints_to_alarm = "1"
   treat_missing_data  = "notBreaching"


### PR DESCRIPTION
**JIRA Ticket:**
[BFD-2706](https://jira.cms.gov/browse/BFD-2706)

**User Story or Bug Summary:**
Purpose:
- The BFD team will need to update PACA-related SLOs (Claim / ClaimResponse) 6-8 weeks after Full Launch

Notes:
- After observing normal traffic patterns we need to define the SLOs further in Cloudwatch
- We also need to move from Splunk to Cloudwatch alerts for those SLOs

AC:
- update Claim / ClaimResponse SLOs
- move to CloudWatch alerts from Splunk

Resources:
- https://confluence.cms.gov/pages/viewpage.action?spaceKey=BFD&title=BFD+SLOs

Addendum:
- after discussing this topic w/ mitch and burling it was decided that these SLOs need to be researched the "BFD way"
- BFD captures a lot of query information via its "data lake service" called AWS Athena
- we need to break this tix up in 2 parts
    1.  research how to use Athena, query the parts that are related to performance
    2. use those queried numbers to update our performance SLOs in production.

---

### What Does This PR Do?

Updates the Cloudwatch alarms for the claim/claimresponse SLOs
- Updated the following Cloudwatch metric alarms to use the same `alert_action` and `ok_action` as the other production SLO alarms.  Previously, all alerts/warnings were directed to the `bfd-test` Slack channel.

1. `slo_claim_no_resources_latency_mean_15m_alert`
2. `slo_claim_no_resources_latency_mean_15m_warning`
3. `slo_claim_with_resources_bulk_latency_99p_15m_alert`
4. `slo_claimresponse_no_resources_latency_mean_15m_alert`
5. `slo_claimresponse_no_resources_latency_mean_15m_warning`
6. `slo_claimresponse_with_resources_bulk_latency_99p_15m_alert`

- Per recommendations in Daryll's research summary [(bfd-2810_notes.txt)](https://jira.cms.gov/secure/attachment/1452422/bfd-2810_notes.txt), the SLO for the "warn" level of the claim response latency (`slo_claimresponse_no_resources_latency_mean_15m_warning`) has been lowered from 1000ms to 950ms.

- [BFD-2810](https://jira.cms.gov/browse/BFD-2810) is related.
 
### What Should Reviewers Watch For?

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items to the following list here -->
* All the `alert_action` and `ok_action` are appropriate for the alarms they reference.
* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [X] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [X] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [X] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [X] No

### What Needs to Be Merged and Deployed Before this PR?
* N/A

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [X] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [X] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [X] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [X] The data dictionary has been updated with any field mapping changes, if any were made.
* [X] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [X] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [X] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [X] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    
### Addendum
-  output of terraform plan (prod) [not applied]
```
Terraform will perform the following actions:

  # module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_claim_no_resources_latency_mean_15m_alert will be updated in-place
  ~ resource "aws_cloudwatch_metric_alarm" "slo_claim_no_resources_latency_mean_15m_alert" {
      ~ alarm_actions             = [
          - "arn:aws:sns:us-east-1:577373831711:bfd-prod-cloudwatch-alarms-slack-bfd-test",
          + "arn:aws:sns:us-east-1:577373831711:bfd-prod-cloudwatch-alarms",
        ]
        id                        = "bfd-server-prod-slo-claim-no-resources-latency-mean-15m-alert"
      ~ ok_actions                = [
          + "arn:aws:sns:us-east-1:577373831711:bfd-prod-cloudwatch-ok",
        ]
        tags                      = {}
        # (16 unchanged attributes hidden)
    }

  # module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_claim_no_resources_latency_mean_15m_warning will be updated in-place
  ~ resource "aws_cloudwatch_metric_alarm" "slo_claim_no_resources_latency_mean_15m_warning" {
      ~ alarm_actions             = [
          - "arn:aws:sns:us-east-1:577373831711:bfd-prod-cloudwatch-alarms-slack-bfd-test",
          + "arn:aws:sns:us-east-1:577373831711:bfd-prod-cloudwatch-alarms-slack-bfd-warnings",
        ]
        id                        = "bfd-server-prod-slo-claim-no-resources-latency-mean-15m-warning"
        tags                      = {}
        # (17 unchanged attributes hidden)
    }

  # module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_claimresponse_no_resources_latency_mean_15m_alert will be updated in-place
  ~ resource "aws_cloudwatch_metric_alarm" "slo_claimresponse_no_resources_latency_mean_15m_alert" {
      ~ alarm_actions             = [
          - "arn:aws:sns:us-east-1:577373831711:bfd-prod-cloudwatch-alarms-slack-bfd-test",
          + "arn:aws:sns:us-east-1:577373831711:bfd-prod-cloudwatch-alarms",
        ]
        id                        = "bfd-server-prod-slo-claimresponse-no-resources-latency-mean-15m-alert"
      ~ ok_actions                = [
          + "arn:aws:sns:us-east-1:577373831711:bfd-prod-cloudwatch-ok",
        ]
        tags                      = {}
        # (16 unchanged attributes hidden)
    }

  # module.bfd_server_slo_alarms[0].aws_cloudwatch_metric_alarm.slo_claimresponse_no_resources_latency_mean_15m_warning will be updated in-place
  ~ resource "aws_cloudwatch_metric_alarm" "slo_claimresponse_no_resources_latency_mean_15m_warning" {
      ~ alarm_actions             = [
          - "arn:aws:sns:us-east-1:577373831711:bfd-prod-cloudwatch-alarms-slack-bfd-test",
          + "arn:aws:sns:us-east-1:577373831711:bfd-prod-cloudwatch-alarms-slack-bfd-warnings",
        ]
        id                        = "bfd-server-prod-slo-claimresponse-no-resources-latency-mean-15m-warning"
        tags                      = {}
      ~ threshold                 = 1000 -> 950
        # (16 unchanged attributes hidden)
    }

  # module.disk_usage_alarms[0].aws_autoscaling_notification.this will be updated in-place
  ~ resource "aws_autoscaling_notification" "this" {
      ~ group_names   = [
          + "bfd-prod-fhir-384",
        ]
        id            = "arn:aws:sns:us-east-1:577373831711:bfd-server-prod-instance-launch-terminate"
      ~ notifications = [
          + "autoscaling:EC2_INSTANCE_LAUNCH",
          + "autoscaling:EC2_INSTANCE_TERMINATE",
        ]
        # (1 unchanged attribute hidden)
    }

  # module.disk_usage_alarms[0].aws_lambda_function.this will be updated in-place
  ~ resource "aws_lambda_function" "this" {
        id                             = "bfd-prod-manage-disk-usage-alarms"
      ~ last_modified                  = "2023-05-18T22:12:24.000+0000" -> (known after apply)
      ~ source_code_hash               = "tc6yCEiE1cAcljHg0b8R2Aa259etaxK9B0Y4dL5kuOc=" -> "/y5GG0NjnSYev5cITg4AVwjPhazn/j0YC8rpZ7OP34g="
        tags                           = {
            "Name" = "bfd-prod-manage-disk-usage-alarms"
        }
        # (21 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

Plan: 0 to add, 6 to change, 0 to destroy.
```