### PR TITLE
BFD-2883: Fix pagination url encoding issue in RestAssured test

### DIFF
--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/ServerRequiredTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/ServerRequiredTest.java
@@ -103,8 +103,14 @@ public class ServerRequiredTest {
                 .keyStoreType(keystoreType)
                 .trustStoreType(keystoreType)
                 .allowAllHostnames());
+    /* RestAssured will url encode urls by default, and we use pre-encoded urls during pagination, so turn it off
+     * since it will double-encode the lastUpdated field otherwise. */
     requestAuth =
-        new RequestSpecBuilder().setBaseUri(baseServerUrl).setAuth(testCertificate).build();
+        new RequestSpecBuilder()
+            .setBaseUri(baseServerUrl)
+            .setAuth(testCertificate)
+            .setUrlEncodingEnabled(false)
+            .build();
   }
 
   /**

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/ServerRequiredTest.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/ServerRequiredTest.java
@@ -103,14 +103,8 @@ public class ServerRequiredTest {
                 .keyStoreType(keystoreType)
                 .trustStoreType(keystoreType)
                 .allowAllHostnames());
-    /* RestAssured will url encode urls by default, and we use pre-encoded urls during pagination, so turn it off
-     * since it will double-encode the lastUpdated field otherwise. */
     requestAuth =
-        new RequestSpecBuilder()
-            .setBaseUri(baseServerUrl)
-            .setAuth(testCertificate)
-            .setUrlEncodingEnabled(false)
-            .build();
+        new RequestSpecBuilder().setBaseUri(baseServerUrl).setAuth(testCertificate).build();
   }
 
   /**

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/ExplanationOfBenefitE2E.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/ExplanationOfBenefitE2E.java
@@ -26,6 +26,7 @@ import gov.cms.bfd.server.war.commons.TransformerConstants;
 import gov.cms.bfd.server.war.stu3.providers.ExplanationOfBenefitResourceProvider;
 import gov.cms.bfd.server.war.stu3.providers.Stu3EobSamhsaMatcherTest;
 import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
@@ -741,9 +742,13 @@ public class ExplanationOfBenefitE2E extends ServerRequiredTest {
     String firstLink = testUtils.getPaginationLink(response, "first");
     assertTrue(firstLink.contains("_lastUpdated"));
 
+    /* RestAssured will url encode urls by default, and we use pre-encoded urls during pagination, so turn it off
+     * since it will double-encode the lastUpdated field otherwise. */
+    RequestSpecification requestAuthNoEncode = given().spec(requestAuth).urlEncodingEnabled(false);
+
     // Ensure using the next link works appropriately and returns the last 3 results
     given()
-        .spec(requestAuth)
+        .spec(requestAuthNoEncode)
         .expect()
         .body("entry.size()", equalTo(3))
         .body("total", equalTo(expectedTotal))

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/ExplanationOfBenefitE2E.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/ExplanationOfBenefitE2E.java
@@ -750,8 +750,7 @@ public class ExplanationOfBenefitE2E extends ServerRequiredTest {
         .body("total", equalTo(expectedTotal))
         .statusCode(200)
         .when()
-        .get(URLDecoder.decode(nextLink));
-    // FUTURE: Decoder is a workaround, fix in https://jira.cms.gov/browse/BFD-2883
+        .get(nextLink);
   }
 
   /**

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/ExplanationOfBenefitE2E.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/ExplanationOfBenefitE2E.java
@@ -26,7 +26,6 @@ import gov.cms.bfd.server.war.commons.TransformerConstants;
 import gov.cms.bfd.server.war.stu3.providers.ExplanationOfBenefitResourceProvider;
 import gov.cms.bfd.server.war.stu3.providers.Stu3EobSamhsaMatcherTest;
 import io.restassured.response.Response;
-import io.restassured.specification.RequestSpecification;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
@@ -742,13 +741,12 @@ public class ExplanationOfBenefitE2E extends ServerRequiredTest {
     String firstLink = testUtils.getPaginationLink(response, "first");
     assertTrue(firstLink.contains("_lastUpdated"));
 
-    /* RestAssured will url encode urls by default, and we use pre-encoded urls during pagination, so turn it off
-     * since it will double-encode the lastUpdated field otherwise. */
-    RequestSpecification requestAuthNoEncode = given().spec(requestAuth).urlEncodingEnabled(false);
-
     // Ensure using the next link works appropriately and returns the last 3 results
     given()
-        .spec(requestAuthNoEncode)
+        .spec(requestAuth)
+        /* RestAssured will url encode urls by default, and we use pre-encoded urls during pagination, so turn it off
+         * since it will double-encode the lastUpdated field otherwise. */
+        .urlEncodingEnabled(false)
         .expect()
         .body("entry.size()", equalTo(3))
         .body("total", equalTo(expectedTotal))

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/ExplanationOfBenefitE2E.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/ExplanationOfBenefitE2E.java
@@ -26,7 +26,6 @@ import gov.cms.bfd.server.war.commons.TransformerConstants;
 import gov.cms.bfd.server.war.stu3.providers.ExplanationOfBenefitResourceProvider;
 import gov.cms.bfd.server.war.stu3.providers.Stu3EobSamhsaMatcherTest;
 import io.restassured.response.Response;
-import java.net.URLDecoder;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/ExplanationOfBenefitE2E.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/ExplanationOfBenefitE2E.java
@@ -24,7 +24,7 @@ import gov.cms.bfd.server.war.commons.ClaimType;
 import gov.cms.bfd.server.war.commons.CommonHeaders;
 import gov.cms.bfd.server.war.commons.TransformerConstants;
 import io.restassured.response.Response;
-import java.net.URLDecoder;
+import io.restassured.specification.RequestSpecification;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
@@ -736,15 +736,19 @@ public class ExplanationOfBenefitE2E extends ServerRequiredTest {
     String firstLink = testUtils.getPaginationLink(response, "first");
     assertTrue(firstLink.contains("_lastUpdated"));
 
+    /* RestAssured will url encode urls by default, and we use pre-encoded urls during pagination, so turn it off
+     * since it will double-encode the lastUpdated field otherwise. */
+    RequestSpecification requestAuthNoEncode = given().spec(requestAuth).urlEncodingEnabled(false);
+
     // Ensure using the next link works appropriately and returns the last 3 results
     given()
-        .spec(requestAuth)
+        .spec(requestAuthNoEncode)
         .expect()
         .body("entry.size()", equalTo(3))
         .body("total", equalTo(expectedTotal))
         .statusCode(200)
         .when()
-        .get(URLDecoder.decode(nextLink));
+        .get(nextLink);
   }
 
   /**

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/ExplanationOfBenefitE2E.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/ExplanationOfBenefitE2E.java
@@ -24,7 +24,6 @@ import gov.cms.bfd.server.war.commons.ClaimType;
 import gov.cms.bfd.server.war.commons.CommonHeaders;
 import gov.cms.bfd.server.war.commons.TransformerConstants;
 import io.restassured.response.Response;
-import io.restassured.specification.RequestSpecification;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/ExplanationOfBenefitE2E.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/ExplanationOfBenefitE2E.java
@@ -736,13 +736,12 @@ public class ExplanationOfBenefitE2E extends ServerRequiredTest {
     String firstLink = testUtils.getPaginationLink(response, "first");
     assertTrue(firstLink.contains("_lastUpdated"));
 
-    /* RestAssured will url encode urls by default, and we use pre-encoded urls during pagination, so turn it off
-     * since it will double-encode the lastUpdated field otherwise. */
-    RequestSpecification requestAuthNoEncode = given().spec(requestAuth).urlEncodingEnabled(false);
-
     // Ensure using the next link works appropriately and returns the last 3 results
     given()
-        .spec(requestAuthNoEncode)
+        .spec(requestAuth)
+        /* RestAssured will url encode urls by default, and we use pre-encoded urls during pagination, so turn it off
+         * since it will double-encode the lastUpdated field otherwise. */
+        .urlEncodingEnabled(false)
         .expect()
         .body("entry.size()", equalTo(3))
         .body("total", equalTo(expectedTotal))


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BFD-2883](https://jira.cms.gov/browse/BFD-2883)

**User Story or Bug Summary:**
<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->
Fixes an issue where a restAssured test was failing when calling a pagination url.

---

### What Does This PR Do?
<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

Originally this was a bugfix due to a pagination link failing when calling it via RestAssured, leading to the incorrect assumption the server could not read the url-encoded pagination link (as opposed to the non-encoded first response link) when lastUpdated was present and the timestamp was part of the request. 

After much fiddling with HAPI interceptors and various debugging, it turns out this is an issue with RestAssured; it automatically url-encodes requests, leading to issues when the url is _already_ encoded, as is the case with our pagination "next" links. For other tests this wasnt an issue because the only real time we encode anything is when lastUpdated is present and we use timestamps. However in one test where we test lastUpdated paginated links, it wasnt working due to double-encoding.

- Adjusts the request auth to disable url encoding for the pagination request where it was causing issues
    - We still need/want to urlEncode for most url cases, so this will need to be done case by case for tests that use lastUpdated (or service-date) in their request Urls


### What Should Reviewers Watch For?
<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items to the following list here -->
* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [x] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [x] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [x] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] The data dictionary has been updated with any field mapping changes, if any were made.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    