### PR TITLE
BFD-2862: BFD Server ASG scale-in policy is evaluating too soon after scale-out causing premature scale-in

### DIFF
--- a/ops/terraform/services/server/modules/bfd_server_asg/main.tf
+++ b/ops/terraform/services/server/modules/bfd_server_asg/main.tf
@@ -295,7 +295,7 @@ resource "aws_cloudwatch_metric_alarm" "filtered_networkin_low" {
     id    = "e2"
     label = "Set to ${each.value.desired_capacity} capacity units"
     expression = "IF(${join(" && ", compact([
-      each.value.begin > 0 ? "networkin > ${each.value.begin}" : null,
+      each.value.begin != null ? "networkin > ${each.value.begin}" : null,
       each.value.end != null ? "networkin <= ${each.value.end}" : null,
       "m3 > ${each.value.desired_capacity}"
     ]))}, 1)"
@@ -384,7 +384,7 @@ resource "aws_cloudwatch_metric_alarm" "filtered_networkin_high" {
       id    = "e${metric_query.key}"
       label = "Set to ${metric_query.value.desired_capacity} capacity units"
       expression = "IF(${join(" && ", compact([
-        "networkin > ${metric_query.value.begin}",
+        metric_query.value.begin != null ? "networkin > ${metric_query.value.begin}" : null,
         metric_query.value.end != null ? "networkin <= ${metric_query.value.end}" : null,
         "m3 < ${metric_query.value.desired_capacity}"
       ]))}, ${metric_query.key + 1})"

--- a/ops/terraform/services/server/modules/bfd_server_asg/main.tf
+++ b/ops/terraform/services/server/modules/bfd_server_asg/main.tf
@@ -25,14 +25,19 @@ locals {
       consecutive_periods_to_alarm = 15
     }
   }
+  # begin is inclusive, end is exclusive
   scaling_stages = [
-    # Between 0 MB/min and 100 MB/min we want to be at 3 instances
-    { begin = 0, end = 1 * var.scaling_networkin_interval_mb, desired_capacity = local.scaling_capacity_step * 1 },
-    # Between 100 MB/min and 200 MB/min we want to be at 6 instances
+    # If NetworkIn is less than 1 * var.scaling_networkin_interval_mb MB/min, exclusive, we want to
+    # be at 3 instances
+    { begin = null, end = 1 * var.scaling_networkin_interval_mb, desired_capacity = local.scaling_capacity_step * 1 },
+    # If NetworkIn is greater than or equal to 1 * var.scaling_networkin_interval_mb MB/min, but
+    # less than 2 * var.scaling_networkin_interval_mb MB/min we want to be at 6 instances
     { begin = 1 * var.scaling_networkin_interval_mb, end = 2 * var.scaling_networkin_interval_mb, desired_capacity = local.scaling_capacity_step * 2 },
-    # Between 200 MB/min and 400 MB/min we want to be at 9 instances
+    # If NetworkIn is greater than or equal to 2 * var.scaling_networkin_interval_mb MB/min, but
+    # less than 4 * var.scaling_networkin_interval_mb MB/min we want to be at 9 instances
     { begin = 2 * var.scaling_networkin_interval_mb, end = 4 * var.scaling_networkin_interval_mb, desired_capacity = local.scaling_capacity_step * 3 },
-    # Whenever traffic exceeds 400 MB/min we want to be at 12 instances
+    # Whenever traffic is greater than or equal to 4 * var.scaling_networkin_interval_mb MB/min we
+    # want to be at 12 instances
     { begin = 4 * var.scaling_networkin_interval_mb, end = null, desired_capacity = local.scaling_capacity_step * 4 },
   ]
   scalein_config  = slice(local.scaling_stages, 0, length(local.scaling_stages) - 1)


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BFD-2862](https://jira.cms.gov/browse/BFD-2862)

**User Story or Bug Summary:**

<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->

The BFD Server scale-in policy will immediately scale-in instances when NetworkIn drops beneath a particular scale-in threshold range, unless prior to scale-in the BFD Server ASG scaled-out to 12 instances. The expected behavior is that scale-in does not occur until 10 minutes after scale-out, but the current scale-in policy allows for near immediate scale-in after scale-out.

---

### What Does This PR Do?

<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

This PR updates the scaling "configuration" such that:
- scale-in should no longer be able to immediately, erroneously activate and scale-in the Server after a scale-out.
- the period of time that must pass before scale-in can occur has been increased to 15 minutes from 10 minutes to ensure the Server remains scaled-out during our typical "bursty" bulk loads. 
- the [instance warmup](https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-default-instance-warmup.html?icmpid=docs_ec2as_help_panel) has been removed entirely, as [BFD-2863](https://jira.cms.gov/browse/BFD-2863) introduced Lifecycle Hooks that are only completed once a given instance is warmed-up, so an arbitrary instance warmup is unnecessary.

This PR has been validated by:

- `terraform apply`ing the changes to the `test` environment's `server`, verifiying that the changes apply successfully and as expected
- manually setting the desired capacity of the `test` environment's `server` ASG to capacities greater than 3 (thus simulating scale-out), verifying that the ASG scales-in after 15 minutes to the appropriate number of instances

#### Context

The original scale-in implementation used a single CloudWatch Alarm with a single, corresponding scale-in policy attached to the ASG. The scale-in alarm would ALARM if, over a _consecutive_ period of 10 minutes, the `NetworkIn` was beneath 400 MB/min. Therefore, if at any point the `NetworkIn` exceeded 400 MB/min, the alarm would transition to `OK`. After such a transition, the alarm would only ever transition back to `ALARM` after 10 consecutive minutes of network traffic less than 400 MB/min.

If the scale-in policy's corresponding alarm is _ever_ in the `ALARM` state, that means the scale-in policy is active and its thresholds are evaluated to determine which scaling action to take. Because 400 MB/min was the _end_ of the range of scaling stages configured for the server and network traffic only ever exceeds 400 MB/min when we get larger loads, the scale-in alarm was practically _always_ in `ALARM`. This meant that the scale-in policy could almost always _evaluate_. So, there was often a scenario where the Server would get enough traffic to scale-out but because the traffic did not quite exceed 400 MB/min, the scale-in alarm never stopped `ALARM`ing and the scale-in policy would be able to evaluate immediately afterwards. This would usually result in scaling oscillation, where the Server would scale at one minute and then immediately scale-in the next minute.

This has been resolved by splitting the scale-in to `n - 1` scale-in policies and `n - 1` scale-in alarms, where `n` is the number of scaling stages that are defined within code. We have 4 stages, so this implementation will create 3 distinct scale-in alarms and corresponding policies. Each scale-in policy and alarm evaluates a particular stage of scaling (ranges of network traffic). By moving the threshold evaluation to CloudWatch Metric Math, only returning a value if the number of instances exceed the scale-in policy's desired capacity target, and configuring each alarm to treat missing data as `OK`, the alarms will now transition to `OK` whenever a scaling event occurs. This "breaks" the consecutive periods of evaluation, forcing each alarm to re-evaluate after scale-out over the _full_ 15 minute period before transitioning to a new state, thus ensuring the scale-in policies cannot evaluate immediately after scale-out.

### What Should Reviewers Watch For?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:

<!-- Add some items to the following list here -->

- Verify all PR security questions and checklists have been completed and addressed.

### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

- If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

  - Does this PR add any new software dependencies?
    - [ ] Yes
    - [x] No
  - Does this PR modify or invalidate any of our security controls?
    - [ ] Yes
    - [x] No
  - Does this PR store or transmit data that was not stored or transmitted before?
    - [ ] Yes
    - [x] No

- If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
  - Do you think this PR requires additional review of its security implications for other reasons?
    - [ ] Yes
    - [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

- N/A

### Submitter Checklist

<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

- [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
- [x] This PR is reasonably limited in scope, to help ensure that:
  1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
  2. There isn't too much of a burden on reviewers.
  3. Any problems it causes have a small "blast radius".
  4. It'll be easier to rollback if that becomes necessary.
- [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
- [x] The data dictionary has been updated with any field mapping changes, if any were made.
- [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
- [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
- [x] Reviews are requested from both:
  - At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
  - Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
- [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
  - Please review the standards every few months to ensure you're familiar with them.
