### PR TITLE
BFD-2691: Fix minor test issue with tax num test

### DIFF
--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/R4ExplanationOfBenefitResourceProviderE2E.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/R4ExplanationOfBenefitResourceProviderE2E.java
@@ -1034,6 +1034,7 @@ public final class R4ExplanationOfBenefitResourceProviderE2E extends ServerRequi
     // Verify that tax numbers are present for carrier claims.
     carrierEob = filterToClaimType(searchResults, ClaimType.CARRIER).get(0);
     assertNotNull(carrierClaim.getLines().get(0).getProviderTaxNumber());
+    // Ensure old v1 mapping for tax num using careteam is not present
     assertNull(
         TransformerTestUtilsV2.findCareTeamEntryForProviderTaxNumber(
             carrierClaim.getLines().get(0).getProviderTaxNumber(), carrierEob.getCareTeam()));
@@ -1041,10 +1042,10 @@ public final class R4ExplanationOfBenefitResourceProviderE2E extends ServerRequi
     // Verify that tax numbers are present for DME claims.
     dmeEob = filterToClaimType(searchResults, ClaimType.DME).get(0);
     assertNotNull(dmeClaim.getLines().get(0).getProviderTaxNumber());
-    // FIXME: investigate this, careTeam for tax number doesnt seem to be added correctly for DME?
-    /*assertNotNull(
-    TransformerTestUtilsV2.findCareTeamEntryForProviderTaxNumber(
-        dmeClaim.getLines().get(0).getProviderTaxNumber(), dmeEob.getCareTeam()));*/
+    // Ensure old v1 mapping for tax num using careteam is not present
+    assertNull(
+        TransformerTestUtilsV2.findCareTeamEntryForProviderTaxNumber(
+            dmeClaim.getLines().get(0).getProviderTaxNumber(), dmeEob.getCareTeam()));
   }
 
   /**


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BFD-2691](https://jira.cms.gov/browse/BFD-2691)

**User Story or Bug Summary:**
<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->
Fixes a typo with the tax num test which was causing a check to fail.

---

### What Does This PR Do?
<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

The test `searchForEobsIncludeTaxNumbersHandling` (v2) had, in the recent past, been missing some tests relating to ensuring the tax number values were present and correct. I added additional assertions for this, but noticed one of them was not working and marked it for later review.

In v1, taxNumber on DME and carrier claims was checked via the careteam component and not the current location, in the line items. The extra checks ensured that the old v1 careteam mapping was not filled for v2, however I accidentally used `assertNotNull` for DME, leading to thinking there was a functionality issue. Thankfully it was just a typo and works fine when corrected.

- Fixed typo with test on assertion
- Added comments to help clarify why the assertion is there

### What Should Reviewers Watch For?
<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items to the following list here -->
* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [x] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [x] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [x] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] The data dictionary has been updated with any field mapping changes, if any were made.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    