### PR TITLE
BFD-2877 - Omit @Builder.Default annotation for entities with GT 99 fields

### DIFF
--- a/apps/bfd-model/bfd-model-dsl-codegen/bfd-model-dsl-codegen-plugin/src/main/java/gov/cms/model/dsl/codegen/plugin/GenerateEntitiesFromDslMojo.java
+++ b/apps/bfd-model/bfd-model-dsl-codegen/bfd-model-dsl-codegen-plugin/src/main/java/gov/cms/model/dsl/codegen/plugin/GenerateEntitiesFromDslMojo.java
@@ -443,8 +443,14 @@ public class GenerateEntitiesFromDslMojo extends AbstractMojo {
           .addAnnotation(
               AnnotationSpec.builder(BatchSize.class)
                   .addMember("size", "$L", BATCH_SIZE_FOR_ARRAY_FIELDS)
-                  .build())
-          .addAnnotation(Builder.Default.class);
+                  .build());
+      // We previously skipped adding the @Builder annotation to an entity that
+      // has a 100 or more fields; the check here is to prevent spurious Lombok
+      // warnings that correctly point out that since we are not adding the
+      // @Builder annotation, we should also not add a @Builder.Default annotation.
+      if (mapping.getTable().getColumns().size() < 100) {
+        fieldSpec.addAnnotation(Builder.Default.class);
+      }
     }
     final var accessorSpec =
         AccessorSpec.builder()


### PR DESCRIPTION
**JIRA Ticket:**
[BFD-2877](https://jira.cms.gov/browse/BFD-2877)

**User Story or Bug Summary:**

Disable adding @Builder.Default annotation to entity field(s) for which the plugin has decided it can’t add the @Builder annotation to the entity class.

---

### What Does This PR Do?

Current DSL plugin behavior does not add the @Builder annotation to an entity if the mapping spec determines that there are more than 99 fields (entity column) in the entity. However, when defining a linked entity field to another entity, the @Builder.Default annotation was being added which Lombok correctly points out that since we not adding @Builder annotation, we should should not add @Builder.Default annotation.

This PR introduces code to correctly omit adding the @Builder.Default annotation for an entity that has more than 99 fields.

### What Should Reviewers Watch For?

This is a minor code change to supplement previous entity construction logic to address Lombok warnings.

If you're reviewing this PR, please check for these things in particular:

* Verify all PR security questions and checklists have been completed and addressed.

### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [X] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [X] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [X] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [X] No

### What Needs to Be Merged and Deployed Before this PR?

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist

I have gone through and verified that...:

* [X] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [X] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [X] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [X] The data dictionary has been updated with any field mapping changes, if any were made.
* [X] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [X] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [X] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [X] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    