### PR TITLE
BFD-2935: Update BFD Server to use default RDS reader endpoint

### DIFF
--- a/ops/terraform/services/common/aurora-cluster.tf
+++ b/ops/terraform/services/common/aurora-cluster.tf
@@ -145,6 +145,11 @@ resource "aws_rds_cluster_endpoint" "readers" {
   cluster_identifier          = aws_rds_cluster.aurora_cluster.id
   cluster_endpoint_identifier = "bfd-${local.env}-ro"
   custom_endpoint_type        = "READER"
+
+  # EXCLUDED_MEMBERS assigns ALL but the last reader to the custom endpoint
+  excluded_members = [
+    element(local.reader_nodes, length(local.reader_nodes) - 1).id
+  ]
 }
 
 # This is the reserved synthea reader endpoint in production

--- a/ops/terraform/services/common/aurora-cluster.tf
+++ b/ops/terraform/services/common/aurora-cluster.tf
@@ -145,11 +145,6 @@ resource "aws_rds_cluster_endpoint" "readers" {
   cluster_identifier          = aws_rds_cluster.aurora_cluster.id
   cluster_endpoint_identifier = "bfd-${local.env}-ro"
   custom_endpoint_type        = "READER"
-
-  # EXCLUDED_MEMBERS assigns ALL but the last reader to the custom endpoint
-  excluded_members = [
-    element(local.reader_nodes, length(local.reader_nodes) - 1).id
-  ]
 }
 
 # This is the reserved synthea reader endpoint in production

--- a/ops/terraform/services/server/modules/bfd_server_asg/main.tf
+++ b/ops/terraform/services/server/modules/bfd_server_asg/main.tf
@@ -2,7 +2,7 @@ locals {
   env = terraform.workspace
 
   # When the CustomEndpoint is empty, fall back to the ReaderEndpoint
-  rds_reader_endpoint = data.external.rds.result["CustomEndpoint"] == "" ? data.external.rds.result["ReaderEndpoint"] : data.external.rds.result["CustomEndpoint"]
+  rds_reader_endpoint = data.external.rds.result["ReaderEndpoint"]
 
   additional_tags = { Layer = var.layer, role = var.role }
 


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BFD-2935](https://jira.cms.gov/browse/BFD-2935)

**User Story or Bug Summary:**

<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->

As a BFD Engineer I want the BFD Server to be able to query all of the available reader endpoint nodes such that no one reader node is overwhelmed with traffic resulting in poor BFD Server performance

---

### What Does This PR Do?

<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

This PR updates the `server` Terraservice such that BFD Server instances will be created with their database URLs pointing to the default reader endpoint, thus allowing the BFD Server to take advantage of all available reader nodes

This PR has been validated by:

- `terraform apply`ing it to `prod` (in response to the most recent incident), verifying that it `apply`s as expected and that all reader nodes were being used by the BFD Server

The changes remain in `prod` in order to manage further load.

### What Should Reviewers Watch For?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:

<!-- Add some items to the following list here -->

- Verify all PR security questions and checklists have been completed and addressed.

### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

- If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

  - Does this PR add any new software dependencies?
    - [ ] Yes
    - [x] No
  - Does this PR modify or invalidate any of our security controls?
    - [ ] Yes
    - [x] No
  - Does this PR store or transmit data that was not stored or transmitted before?
    - [ ] Yes
    - [x] No

- If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
  - Do you think this PR requires additional review of its security implications for other reasons?
    - [ ] Yes
    - [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

- N/A

### Submitter Checklist

<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

- [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
- [x] This PR is reasonably limited in scope, to help ensure that:
  1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
  2. There isn't too much of a burden on reviewers.
  3. Any problems it causes have a small "blast radius".
  4. It'll be easier to rollback if that becomes necessary.
- [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
- [x] The data dictionary has been updated with any field mapping changes, if any were made.
- [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
- [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
- [x] Reviews are requested from both:
  - At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
  - Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
- [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
  - Please review the standards every few months to ensure you're familiar with them.
