### PR TITLE
BFD-2969: PAC endpoint metric filters still do not filter URI correctly due to inconsistent trailing slash

### DIFF
--- a/ops/terraform/services/server/modules/bfd_server_metrics/main.tf
+++ b/ops/terraform/services/server/modules/bfd_server_metrics/main.tf
@@ -18,7 +18,7 @@ locals {
 
   endpoint_patterns = {
     for name, patterns in local.endpoints :
-    replace(name, "_", "-") => "(${join(" || ", [for pattern in patterns : "$.mdc.http_access_request_uri = \"${pattern}\""])})"
+    name => "(${join(" || ", [for pattern in patterns : "$.mdc.http_access_request_uri = \"${pattern}\""])})"
   }
 
   client_ssl_pattern = "$.mdc.http_access_request_clientSSL_DN = \"*\""
@@ -39,8 +39,8 @@ locals {
   endpoint_filters_config = merge([
     for endpoint_key, endpoint_pattern in local.endpoint_patterns : {
       for variation, variation_config in local.filter_variations :
-      "${replace(endpoint_key, "-", "_")}_${variation}" => {
-        "resource_name"    = endpoint_key
+      "${endpoint_key}_${variation}" => {
+        "resource_name"    = replace(endpoint_key, "_", "-")
         "endpoint_pattern" = endpoint_pattern
         "name_suffix"      = variation_config.name_suffix
         "dimensions"       = variation_config.dimensions
@@ -143,7 +143,7 @@ resource "aws_cloudwatch_log_metric_filter" "http_requests_latency_patient_not_b
   # Terraform HCL has no support for breaking long strings, so the join() function is used as a
   # poor, but functional, substitute. Otherwise this pattern would be far too long
   pattern = join("", [
-    "{$.mdc.http_access_request_uri = \"${local.endpoints.patient_all}\" && ",
+    "{${local.endpoint_patterns.patient_all} && ",
     "$.mdc.http_access_request_operation != \"*by=*contract*\" && ",
     "$.mdc.http_access_request_operation != \"*by=*Contract*\" && ",
     "${local.client_ssl_pattern} && ",
@@ -168,7 +168,7 @@ resource "aws_cloudwatch_log_metric_filter" "http_requests_latency_patient_by_co
   log_group_name = local.log_groups.access
 
   pattern = join("", [
-    "{$.mdc.http_access_request_uri = \"${local.endpoints.patient_all}\" && ",
+    "{${local.endpoint_patterns.patient_all} && ",
     "$.mdc.http_access_request_query_string = \"*_count=4000*\" && ",
     "($.mdc.http_access_request_operation = \"*by=*contract*\" || ",
     "$.mdc.http_access_request_operation = \"*by=*Contract*\") && ",
@@ -193,7 +193,7 @@ resource "aws_cloudwatch_log_metric_filter" "http_requests_latency_by_kb_eob_all
   log_group_name = local.log_groups.access
 
   pattern = join("", [
-    "{$.mdc.http_access_request_uri = \"${local.endpoints.eob_all}\" && ",
+    "{${local.endpoint_patterns.eob_all} && ",
     "${local.client_ssl_pattern} && ",
     "$.mdc.http_access_response_duration_per_kb = *}"
   ])
@@ -215,7 +215,7 @@ resource "aws_cloudwatch_log_metric_filter" "http_requests_latency_eob_all_with_
   log_group_name = local.log_groups.access
 
   pattern = join("", [
-    "{$.mdc.http_access_request_uri = \"${local.endpoints.eob_all}\" && ",
+    "{${local.endpoint_patterns.eob_all} && ",
     "${local.client_ssl_pattern} && ",
     "$.mdc.resources_returned_count != 0 && ",
     "$.mdc.http_access_response_duration_milliseconds = *}"
@@ -238,7 +238,7 @@ resource "aws_cloudwatch_log_metric_filter" "http_requests_latency_by_kb_eob_all
   log_group_name = local.log_groups.access
 
   pattern = join("", [
-    "{$.mdc.http_access_request_uri = \"${local.endpoints.eob_all}\" && ",
+    "{${local.endpoint_patterns.eob_all} && ",
     "${local.client_ssl_pattern} && ",
     "$.mdc.resources_returned_count != 0 && ",
     "$.mdc.http_access_response_duration_per_kb = *}"
@@ -262,7 +262,7 @@ resource "aws_cloudwatch_log_metric_filter" "http_requests_latency_eob_all_no_re
   log_group_name = local.log_groups.access
 
   pattern = join("", [
-    "{$.mdc.http_access_request_uri = \"${local.endpoints.eob_all}\" && ",
+    "{${local.endpoint_patterns.eob_all} && ",
     "$.mdc.resources_returned_count = 0 && ",
     "${local.client_ssl_pattern} && ",
     "$.mdc.http_access_response_duration_milliseconds = *}"
@@ -285,7 +285,7 @@ resource "aws_cloudwatch_log_metric_filter" "http_requests_latency_by_kb_claim_a
   log_group_name = local.log_groups.access
 
   pattern = join("", [
-    "{$.mdc.http_access_request_uri = \"${local.endpoints.claim_all}\" && ",
+    "{${local.endpoint_patterns.claim_all} && ",
     "${local.client_ssl_pattern} && ",
     "$.mdc.resources_returned_count != 0 && ",
     "$.mdc.http_access_response_duration_per_kb = *}"
@@ -309,7 +309,7 @@ resource "aws_cloudwatch_log_metric_filter" "http_requests_latency_claim_all_no_
   log_group_name = local.log_groups.access
 
   pattern = join("", [
-    "{$.mdc.http_access_request_uri = \"${local.endpoints.claim_all}\" && ",
+    "{${local.endpoint_patterns.claim_all} && ",
     "$.mdc.resources_returned_count = 0 && ",
     "${local.client_ssl_pattern} && ",
     "$.mdc.http_access_response_duration_milliseconds = *}"
@@ -332,7 +332,7 @@ resource "aws_cloudwatch_log_metric_filter" "http_requests_latency_claim_all_wit
   log_group_name = local.log_groups.access
 
   pattern = join("", [
-    "{$.mdc.http_access_request_uri = \"${local.endpoints.claim_all}\" && ",
+    "{${local.endpoint_patterns.claim_all} && ",
     "${local.client_ssl_pattern} && ",
     "$.mdc.resources_returned_count != 0 && ",
     "$.mdc.http_access_response_duration_milliseconds = *}"
@@ -355,7 +355,7 @@ resource "aws_cloudwatch_log_metric_filter" "http_requests_latency_by_kb_claimre
   log_group_name = local.log_groups.access
 
   pattern = join("", [
-    "{$.mdc.http_access_request_uri = \"${local.endpoints.claim_response_all}\" && ",
+    "{${local.endpoint_patterns.claim_response_all} && ",
     "${local.client_ssl_pattern} && ",
     "$.mdc.resources_returned_count != 0 && ",
     "$.mdc.http_access_response_duration_per_kb = *}"
@@ -379,7 +379,7 @@ resource "aws_cloudwatch_log_metric_filter" "http_requests_latency_claimresponse
   log_group_name = local.log_groups.access
 
   pattern = join("", [
-    "{$.mdc.http_access_request_uri = \"${local.endpoints.claim_response_all}\" && ",
+    "{${local.endpoint_patterns.claim_response_all} && ",
     "$.mdc.resources_returned_count = 0 && ",
     "${local.client_ssl_pattern} && ",
     "$.mdc.http_access_response_duration_milliseconds = *}"
@@ -402,7 +402,7 @@ resource "aws_cloudwatch_log_metric_filter" "http_requests_latency_claimresponse
   log_group_name = local.log_groups.access
 
   pattern = join("", [
-    "{$.mdc.http_access_request_uri = \"${local.endpoints.claim_response_all}\" && ",
+    "{${local.endpoint_patterns.claim_response_all} && ",
     "${local.client_ssl_pattern} && ",
     "$.mdc.resources_returned_count != 0 && ",
     "$.mdc.http_access_response_duration_milliseconds = *}"

--- a/ops/terraform/services/server/modules/bfd_server_metrics/main.tf
+++ b/ops/terraform/services/server/modules/bfd_server_metrics/main.tf
@@ -7,18 +7,18 @@ locals {
   }
   namespace = "bfd-${local.env}/bfd-server"
   endpoints = {
-    all                = "*/fhir/*"
-    metadata           = "*/fhir/metadata*"
-    coverage_all       = "*/fhir/Coverage*"
-    patient_all        = "*/fhir/Patient*"
-    eob_all            = "*/fhir/ExplanationOfBenefit*"
-    claim_all          = "*/fhir/Claim"
-    claim_response_all = "*/fhir/ClaimResponse"
+    all                = ["*/fhir/*"]
+    metadata           = ["*/fhir/metadata*"]
+    coverage_all       = ["*/fhir/Coverage*"]
+    patient_all        = ["*/fhir/Patient*"]
+    eob_all            = ["*/fhir/ExplanationOfBenefit*"]
+    claim_all          = ["*/fhir/Claim", "*/fhir/Claim/"]
+    claim_response_all = ["*/fhir/ClaimResponse", "*/fhir/ClaimResponse/"]
   }
 
   endpoint_patterns = {
-    for name, pattern in local.endpoints :
-    replace(name, "_", "-") => "$.mdc.http_access_request_uri = \"${pattern}\""
+    for name, patterns in local.endpoints :
+    replace(name, "_", "-") => "(${join(" || ", [for pattern in patterns : "$.mdc.http_access_request_uri = \"${pattern}\""])})"
   }
 
   client_ssl_pattern = "$.mdc.http_access_request_clientSSL_DN = \"*\""


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BFD-2969](https://jira.cms.gov/browse/BFD-2969)

**User Story or Bug Summary:**

<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->

Recent usage of BFD Server CloudWatch Dashboards uncovered a discrepancy between the number of total requests reported by metrics and per-endpoint metric counts. It was discovered that `Claim` and `ClaimResponse` `access.json` Metric Filter pattern definitions are incorrectly assuming that their corresponding log entries cannot have a trailing slash (`/`). This is resulting in a fraction of the total metrics being collected for `Claim` and `ClaimResponse` endpoints.

---

### What Does This PR Do?

<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

This PR:

- Updates filter generation for URI filtering such that mutliple patterns can be specified for a given endpoint
- Updates `Claim` and `ClaimResponse` endpoint definitions such that all variations of corresponding URIs (with or without trailing slash) are captured by corresponding Metric Filters
- Updates endpoint-specific Metric Filters to use generated URI patterns

This PR has been verified by:

- `terraform plan`ning the changes to `server`, verifying that the plan changes the Metric Filter as expected
- copying a generated Metric Filter for `Claim` into the AWS Console's Metric Filter tester with actual `access.json` logs, verifying that the Metric Filter captures _all_ `Claim` endpoints regardless of trailing slash and ignores entries for other endpoints (like `ClaimResponse` or `Coverage`)

### What Should Reviewers Watch For?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:

<!-- Add some items to the following list here -->

- Verify all PR security questions and checklists have been completed and addressed.

### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

- If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

  - Does this PR add any new software dependencies?
    - [ ] Yes
    - [x] No
  - Does this PR modify or invalidate any of our security controls?
    - [ ] Yes
    - [x] No
  - Does this PR store or transmit data that was not stored or transmitted before?
    - [ ] Yes
    - [x] No

- If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
  - Do you think this PR requires additional review of its security implications for other reasons?
    - [ ] Yes
    - [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

- N/A

### Submitter Checklist

<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

- [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
- [x] This PR is reasonably limited in scope, to help ensure that:
  1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
  2. There isn't too much of a burden on reviewers.
  3. Any problems it causes have a small "blast radius".
  4. It'll be easier to rollback if that becomes necessary.
- [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
- [x] The data dictionary has been updated with any field mapping changes, if any were made.
- [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
- [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
- [x] Reviews are requested from both:
  - At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
  - Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
- [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
  - Please review the standards every few months to ensure you're familiar with them.
