### PR TITLE
BFD-2971: CloudWatch Alarms for Pipeline SLOs are alerting incorrectly

### DIFF
--- a/ops/terraform/services/base/values/prod-sbx.yaml
+++ b/ops/terraform/services/base/values/prod-sbx.yaml
@@ -47,7 +47,7 @@
 /bfd/${env}/pipeline/ccw/nonsensitive/rif_job_batch_size_claims: 100
 /bfd/${env}/pipeline/ccw/nonsensitive/rif_job_queue_size_multiple_claims: 10
 /bfd/${env}/pipeline/ccw/nonsensitive/rif_thread_multiple_claims: 25
-/bfd/${env}/pipeline/ccw/nonsensitive/slis_repeater_lambda_invoke_rate: 15 minutes
+/bfd/${env}/pipeline/ccw/nonsensitive/slis_repeater_lambda_invoke_rate: 1 minutes
 ## PIPELINE+RDA
 /bfd/${env}/pipeline/rda/nonsensitive/data_pipeline_ccw_rif_job_enabled: false # CCW Jobs are disabled by default on RDA Pipelines
 /bfd/${env}/pipeline/rda/nonsensitive/data_pipeline_rda_grpc_inproc_server_mode: 'S3'

--- a/ops/terraform/services/base/values/prod.yaml
+++ b/ops/terraform/services/base/values/prod.yaml
@@ -47,7 +47,7 @@
 /bfd/${env}/pipeline/ccw/nonsensitive/rif_job_batch_size_claims: 100
 /bfd/${env}/pipeline/ccw/nonsensitive/rif_job_queue_size_multiple_claims: 10
 /bfd/${env}/pipeline/ccw/nonsensitive/rif_thread_multiple_claims: 25
-/bfd/${env}/pipeline/ccw/nonsensitive/slis_repeater_lambda_invoke_rate: 15 minutes
+/bfd/${env}/pipeline/ccw/nonsensitive/slis_repeater_lambda_invoke_rate: 1 minutes
 ## PIPELINE+RDA
 /bfd/${env}/pipeline/rda/nonsensitive/data_pipeline_ccw_rif_job_enabled: false # CCW Jobs are disabled by default on RDA Pipelines
 /bfd/${env}/pipeline/rda/nonsensitive/data_pipeline_rda_job_enabled: true

--- a/ops/terraform/services/base/values/test.yaml
+++ b/ops/terraform/services/base/values/test.yaml
@@ -47,7 +47,7 @@
 /bfd/${env}/pipeline/ccw/nonsensitive/rif_job_batch_size_claims: 100
 /bfd/${env}/pipeline/ccw/nonsensitive/rif_job_queue_size_multiple_claims: 10
 /bfd/${env}/pipeline/ccw/nonsensitive/rif_thread_multiple_claims: 25
-/bfd/${env}/pipeline/ccw/nonsensitive/slis_repeater_lambda_invoke_rate: 15 minutes
+/bfd/${env}/pipeline/ccw/nonsensitive/slis_repeater_lambda_invoke_rate: 1 minutes
 ## PIPELINE+RDA
 /bfd/${env}/pipeline/rda/nonsensitive/data_pipeline_ccw_rif_job_enabled: false # CCW Jobs are disabled by default on RDA Pipelines
 /bfd/${env}/pipeline/rda/nonsensitive/data_pipeline_rda_job_enabled: true

--- a/ops/terraform/services/pipeline/modules/bfd_pipeline_slo_alarms/main.tf
+++ b/ops/terraform/services/pipeline/modules/bfd_pipeline_slo_alarms/main.tf
@@ -136,33 +136,33 @@ resource "aws_cloudwatch_metric_alarm" "slo_load_exceeds_9am_est" {
   metric_query {
     expression  = "(e1 - (DAY(e1) + 5) * 86400 - (HOUR(e1) + 7) * 3600 - (${local.eastern_seconds_utc_offset} + (MINUTE(e1) * 60)) + 604800)"
     id          = "e4"
-    label       = "currentMonday9AMEastern"
+    label       = "Unix Timestamp of Week's Current Monday 9 AM ET"
     return_data = false
   }
 
   metric_query {
     expression  = "EPOCH(m1)"
     id          = "e1"
-    label       = "Expression1"
+    label       = "Unix Time"
     return_data = false
   }
 
   metric_query {
     expression  = "FILL(m1, REPEAT)"
     id          = "e7"
-    label       = "Expression7"
+    label       = "Filled Fully Loaded"
     return_data = false
   }
 
   metric_query {
     expression  = "FILL(m2, REPEAT)"
     id          = "e9"
-    label       = "Expression9"
+    label       = "Filled Time Available"
     return_data = false
   }
 
   metric_query {
-    expression  = "IF(e9 > e7 && e4 > e9, 1, 0)"
+    expression  = "IF(e9 > e7 && e4 > e9 && e1 > e4, 1, 0)"
     id          = "e3"
     label       = "Has ongoing load exceeded Monday 9 AM EST/EDT?"
     return_data = true

--- a/ops/terraform/services/pipeline/modules/bfd_pipeline_slo_alarms/main.tf
+++ b/ops/terraform/services/pipeline/modules/bfd_pipeline_slo_alarms/main.tf
@@ -162,6 +162,13 @@ resource "aws_cloudwatch_metric_alarm" "slo_load_exceeds_9am_est" {
   }
 
   metric_query {
+    # Breaking this down:
+    # 1. e9 > e7 - If the Pipeline is currently loading something
+    # 2. e4 > e9 - If the Pipeline was started prior to the upcoming Monday
+    # 3. e1 > e4 - If the current time (when the Alarm evaluates) exceeds Monday at 9 AM; basically,
+    #    is current time after current Monday 9 AM ET?
+    # If all are true, this means that an ongoing load did not finish prior to the current Monday at
+    # 9 AM ET, and so the SLO has been broken 
     expression  = "IF(e9 > e7 && e4 > e9 && e1 > e4, 1, 0)"
     id          = "e3"
     label       = "Has ongoing load exceeded Monday 9 AM EST/EDT?"

--- a/ops/terraform/services/pipeline/modules/bfd_pipeline_slo_alarms/main.tf
+++ b/ops/terraform/services/pipeline/modules/bfd_pipeline_slo_alarms/main.tf
@@ -16,9 +16,13 @@ locals {
   # alarm.
   topic_names_by_env = {
     prod = {
-      alert      = local.victor_ops_sns
-      warning    = local.bfd_warnings_slack_sns
-      alert_ok   = local.default_alert_ok_sns
+      # FUTURE: When SLO Alarms are known to correctly alarm, reevaluate alarm destinations
+      # alert      = local.victor_ops_sns
+      # warning    = local.bfd_warnings_slack_sns
+      # alert_ok   = local.default_alert_ok_sns
+      alert      = local.bfd_test_slack_sns
+      warning    = local.bfd_test_slack_sns
+      alert_ok   = null
       warning_ok = null
     }
     prod-sbx = {
@@ -94,7 +98,7 @@ resource "aws_cloudwatch_metric_alarm" "slo_load_exceeds_9am_est" {
   evaluation_periods  = 1
   datapoints_to_alarm = 1
   threshold           = 1
-  treat_missing_data  = "notBreaching"
+  treat_missing_data  = "ignore"
 
   alarm_actions = local.alert_arn
   ok_actions    = local.alert_ok_arn
@@ -173,10 +177,10 @@ resource "aws_cloudwatch_metric_alarm" "slo_data_load_ingestion_time" {
   datapoints_to_alarm = 1
   evaluation_periods  = 1
   threshold           = each.value.threshold
-  treat_missing_data  = "notBreaching"
+  treat_missing_data  = "ignore"
 
-  alarm_actions = local.alert_arn
-  ok_actions    = local.alert_ok_arn
+  alarm_actions = each.value.type == "warning" ? local.warning_arn : local.alert_arn
+  ok_actions    = each.value.type == "warning" ? local.warning_ok_arn : local.alert_ok_arn
 
   alarm_description = join("", [
     "BFD Pipeline in ${local.env} environment failed to load data within a ",


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BFD-2971](https://jira.cms.gov/browse/BFD-2971)

**User Story or Bug Summary:**

<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->

The CloudWatch Alarms for the following Pipeline SLOs:

- `Data Availability - CCW RIF Pipeline Job - Time to ingest a weekly batch load once available in S3`
- `Data Availability - CCW RIF Pipeline Job - Weekend data load availability`

are evaluating and alerting incorrectly.

Specifically, the CloudWatch Alarm for the first SLO is evaluating data sparsely such that the Alarm oscillates from `OK` to `ALARM` and then back to `OK` every 15 minutes. This is causing a flood of alerts to be sent to the on-call engineer, where only a single alert should have been sent at the moment the SLO was broken.

The Alarm for the second SLO is _evaluating_ incorrectly such that the Alarm enters `ALARM` at 00:00 UTC of the current Monday if the current Pipeline load is ongoing, instead of at 09:00 ET. This is causing alerts to be sent to the on-call engineer _13 hours_ before it's possible for the SLO to be violated.

---

### What Does This PR Do?

<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

This PR:

- Updates the rate at which Pipeline SLIs/metrics (specifically, when a particular load is made available and when it is completed) from once every 15 minutes to once every minute
  - Rough math shows that the cost of this Lambda, per-environment, will rise from approximately $0.12 to $1.78 per-year; this doesn't factor in CloudWatch Metrics cost, but it should be basically nothing
  - This is necessary to resolve issues with the `Data Availability - CCW RIF Pipeline Job - Time to ingest a weekly batch load once available in S3` SLO's CloudWatch Alarm, as it evaluates sparsely every 15 minutes opposed to once-every-minute. This is causing the Alarm to repeatedly enter `ALARM` and return to `OK` every 15 minutes, opposed to remaining in `ALARM` once the SLO is broken
- Updates the CloudWatch SLO Alarm resource definition for the `Data Availability - CCW RIF Pipeline Job - Weekend data load availability` SLO to correct a mistake in the Metric Math that caused the Alarm to evaluate at 00:00 UTC instead of 09:00 ET
- Updates both CloudWatch SLO Alarms to _ignore_ missing data when evaluating instead of treating it as `OK`
  - This should ensure that Alarms maintain their state (`ALARM` or `OK`) if the `repeater` Lambda fails to submit metrics for a few minutes
- Updates both CloudWatch SLO Alarms to send their notifications to the #bfd-test Slack channel instead of VictorOps

This PR has been verified by:

- `terraform plan`ning against `prod` `pipeline`, verifying that only the expected changes are planned
- `terraform apply`ing against `test` `pipeline`, verifying that all changes apply as expected

### What Should Reviewers Watch For?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:

<!-- Add some items to the following list here -->

- Verify all PR security questions and checklists have been completed and addressed.

### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

- If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

  - Does this PR add any new software dependencies?
    - [ ] Yes
    - [x] No
  - Does this PR modify or invalidate any of our security controls?
    - [ ] Yes
    - [x] No
  - Does this PR store or transmit data that was not stored or transmitted before?
    - [ ] Yes
    - [x] No

- If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
  - Do you think this PR requires additional review of its security implications for other reasons?
    - [ ] Yes
    - [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

- N/A

### Submitter Checklist

<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

- [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
- [x] This PR is reasonably limited in scope, to help ensure that:
  1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
  2. There isn't too much of a burden on reviewers.
  3. Any problems it causes have a small "blast radius".
  4. It'll be easier to rollback if that becomes necessary.
- [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
- [x] The data dictionary has been updated with any field mapping changes, if any were made.
- [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
- [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
- [x] Reviews are requested from both:
  - At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
  - Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
- [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
  - Please review the standards every few months to ensure you're familiar with them.
