### PR TITLE
BFD-2991: Fix SSH Users in Ephemeral Envs

### DIFF
--- a/ops/terraform/services/migrator/main.tf
+++ b/ops/terraform/services/migrator/main.tf
@@ -88,6 +88,7 @@ resource "aws_instance" "this" {
     account_id                                  = local.account_id
     db_migrator_db_url                          = "jdbc:postgresql://${local.rds_writer_endpoint}:5432/fhirdb"
     env                                         = local.env
+    seed_env                                    = local.seed_env
     migrator_monitor_enabled                    = local.migrator_monitor_enabled
     migrator_monitor_heartbeat_interval_seconds = local.migrator_monitor_heartbeat_interval_seconds
   })

--- a/ops/terraform/services/migrator/user-data.tftpl
+++ b/ops/terraform/services/migrator/user-data.tftpl
@@ -55,4 +55,4 @@ fi
 EOF
 chmod 0644 /etc/profile.d/set-bfd-login-env.sh
 
-bash /usr/local/bin/permit-user-access "${env}"
+bash /usr/local/bin/permit-user-access "${seed_env}"

--- a/ops/terraform/services/pipeline/main.tf
+++ b/ops/terraform/services/pipeline/main.tf
@@ -151,6 +151,7 @@ resource "aws_launch_template" "this" {
   user_data = base64encode(templatefile("${path.module}/user-data.sh.tftpl", {
     account_id        = local.account_id
     env               = local.env
+    seed_env          = local.seed_env
     pipeline_bucket   = aws_s3_bucket.this.bucket
     pipeline_instance = each.value.instance_name
     writer_endpoint   = "jdbc:postgresql://${local.rds_writer_endpoint}:5432/fhirdb${local.jdbc_suffix}"
@@ -324,6 +325,7 @@ resource "aws_instance" "pipeline" {
   user_data = templatefile("${path.module}/user-data.sh.tftpl", {
     account_id        = local.account_id
     env               = local.env
+    seed_env          = local.seed_env
     pipeline_bucket   = aws_s3_bucket.this.bucket
     pipeline_instance = each.value.instance_name
     writer_endpoint   = "jdbc:postgresql://${local.rds_writer_endpoint}:5432/fhirdb${local.jdbc_suffix}"

--- a/ops/terraform/services/pipeline/user-data.sh.tftpl
+++ b/ops/terraform/services/pipeline/user-data.sh.tftpl
@@ -66,4 +66,4 @@ fi
 EOF
 chmod 0644 /etc/profile.d/set-bfd-login-env.sh
 
-bash /usr/local/bin/permit-user-access "${env}"
+bash /usr/local/bin/permit-user-access "${seed_env}"

--- a/ops/terraform/services/server/main.tf
+++ b/ops/terraform/services/server/main.tf
@@ -144,6 +144,7 @@ module "fhir_asg" {
   role          = local.legacy_service
   layer         = "app"
   lb_config     = module.fhir_lb.lb_config
+  seed_env      = local.seed_env
 
   # Initial size is one server per AZ
   asg_config = {

--- a/ops/terraform/services/server/modules/bfd_server_asg/README.md
+++ b/ops/terraform/services/server/modules/bfd_server_asg/README.md
@@ -94,6 +94,7 @@ No modules.
 | <a name="input_mgmt_config"></a> [mgmt\_config](#input\_mgmt\_config) | n/a | `object({ vpn_sg = string, tool_sg = string, remote_sg = string, ci_cidrs = list(string) })` | n/a | yes |
 | <a name="input_role"></a> [role](#input\_role) | n/a | `string` | n/a | yes |
 | <a name="input_scaling_networkin_interval_mb"></a> [scaling\_networkin\_interval\_mb](#input\_scaling\_networkin\_interval\_mb) | The interval value in megabytes for evaluating the asg scaling capacity, based on the metric FilteredNetworkIn | `number` | `100000000` | no |
+| <a name="input_seed_env"></a> [seed\_env](#input\_seed\_env) | The solution's source environment. For established environments this is equal to the environment's name | `any` | n/a | yes |
 
 ## Outputs
 

--- a/ops/terraform/services/server/modules/bfd_server_asg/main.tf
+++ b/ops/terraform/services/server/modules/bfd_server_asg/main.tf
@@ -1,5 +1,6 @@
 locals {
-  env = terraform.workspace
+  env      = terraform.workspace
+  seed_env = var.seed_env
 
   # When the CustomEndpoint is empty, fall back to the ReaderEndpoint
   rds_reader_endpoint = data.external.rds.result["ReaderEndpoint"]
@@ -138,6 +139,7 @@ resource "aws_launch_template" "main" {
 
   user_data = base64encode(templatefile("${path.module}/templates/${var.launch_config.user_data_tpl}", {
     env                   = local.env
+    seed_env              = local.seed_env
     port                  = var.lb_config.port
     accountId             = var.launch_config.account_id
     data_server_db_url    = "jdbc:postgresql://${local.rds_reader_endpoint}:5432/fhirdb${var.jdbc_suffix}"

--- a/ops/terraform/services/server/modules/bfd_server_asg/templates/fhir_server.tpl
+++ b/ops/terraform/services/server/modules/bfd_server_asg/templates/fhir_server.tpl
@@ -62,4 +62,4 @@ fi
 EOF
 chmod 0644 /etc/profile.d/set-bfd-login-env.sh
 
-bash /usr/local/bin/permit-user-access "${env}"
+bash /usr/local/bin/permit-user-access "${seed_env}"

--- a/ops/terraform/services/server/modules/bfd_server_asg/variables.tf
+++ b/ops/terraform/services/server/modules/bfd_server_asg/variables.tf
@@ -3,6 +3,11 @@ variable "env_config" {
   type        = object({ default_tags = map(string), vpc_id = string, azs = list(string) })
 }
 
+variable "seed_env" {
+  description = "The solution's source environment. For established environments this is equal to the environment's name"
+  sensitive   = false
+}
+
 variable "kms_key_alias" {
   description = "Key alias of environment's KMS key"
   type        = string

--- a/ops/terraform/services/server/server-load/main.tf
+++ b/ops/terraform/services/server/server-load/main.tf
@@ -104,6 +104,7 @@ resource "aws_instance" "this" {
   user_data = templatefile("${path.module}/user-data.sh.tftpl", {
     account_id         = local.account_id
     env                = local.env
+    seed_env           = local.seed_env
     aws_current_region = data.aws_region.current.name
     asg_name           = data.aws_autoscaling_group.asg.name
 

--- a/ops/terraform/services/server/server-load/user-data.sh.tftpl
+++ b/ops/terraform/services/server/server-load/user-data.sh.tftpl
@@ -64,4 +64,4 @@ fi
 EOF
 chmod 0644 /etc/profile.d/set-bfd-login-env.sh
 
-bash /usr/local/bin/permit-user-access "${env}"
+bash /usr/local/bin/permit-user-access "${seed_env}"


### PR DESCRIPTION
**JIRA Ticket:**
[BFD-2991](https://jira.cms.gov/browse/BFD-2991)

**User Story or Bug Summary:**
Provide a minor correction to #1978 for ssh user creation support in ephemeral environments.

---

### What Does This PR Do?
In brief, this change set uses the `seed_env` or _seed environment_ to determine which users enjoy SSH access for both established, path-to-production environments as well as ephemeral environments. **Note** that in established environments such as `test`, `prod-sbx`, and `prod`, the following is true for each terraservice: `seed_env == env`. For more information, see the [bfd-terraservice child module output documentation](https://github.com/CMSgov/beneficiary-fhir-data/blob/bb86ea0686678f6539ef5060c439e2c77a7575e9/ops/terraform/services/_modules/bfd-terraservice/README.md#outputs).

### What Should Reviewers Watch For?
<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items to the following list here -->
* Reviewers might turn to somewhat crude but useful search utilities like ripgrep (`rg`) or grep (if you like to take it slow) evaluate acceptance:
```sh
# from the local working copy's root, looking for uniform application of seed_env, not env
rg permit-user-access ops/terraform/services
```
* ensure the seed_env is defined in each use of template files called from terraform
* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [x] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [x] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [x] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x]  The data dictionary has been updated with any field mapping changes, if any were made.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.