### PR TITLE
BFD-2987: Build data dictionary and OpenAPI artifacts

### DIFF
--- a/apps/bfd-server/bfd-server-war/pom.xml
+++ b/apps/bfd-server/bfd-server-war/pom.xml
@@ -458,7 +458,7 @@
                             </arguments>
                         </configuration>
                         <id>create-openapi-artifacts</id>
-                        <phase>install</phase>
+                        <phase>verify</phase>
                         <goals>
                             <goal>exec</goal>
                         </goals>

--- a/apps/bfd-server/bfd-server-war/pom.xml
+++ b/apps/bfd-server/bfd-server-war/pom.xml
@@ -439,6 +439,32 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>${exec.maven.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <configuration>
+                            <classpathScope>test</classpathScope>
+                            <executable>java</executable>
+                            <arguments>
+                                <argument>-classpath</argument>
+                                <classpath/>
+                                <argument>gov.cms.bfd.server.war.OpenApiDocs</argument>
+                                <argument>${project.version}</argument>
+                                <argument>${project.basedir}</argument>
+                                <argument>${project.basedir}/../../../dist</argument>
+                            </arguments>
+                        </configuration>
+                        <id>create-openapi-artifacts</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/apps/bfd-server/bfd-server-war/pom.xml
+++ b/apps/bfd-server/bfd-server-war/pom.xml
@@ -417,30 +417,6 @@
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <version>${build.helper.maven.plugin.version}</version>
-                <executions>
-                    <execution>
-                        <!-- Reserve random available ports for the server to use. -->
-                        <id>reserve-server-ports</id>
-                        <goals>
-                            <goal>reserve-network-port</goal>
-                        </goals>
-                        <phase>pre-integration-test</phase>
-                        <configuration>
-                            <outputFile>${project.build.directory}/server-work/server-ports.properties</outputFile>
-                            <minPortNumber>8000</minPortNumber>
-                            <maxPortNumber>9999</maxPortNumber>
-                            <randomPort>true</randomPort>
-                            <portNames>
-                                <portName>server.port.https</portName>
-                            </portNames>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>${exec.maven.plugin.version}</version>
                 <executions>
@@ -462,6 +438,71 @@
                         <goals>
                             <goal>exec</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>${build.helper.maven.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <!-- Reserve random available ports for the server to use. -->
+                        <id>reserve-server-ports</id>
+                        <goals>
+                            <goal>reserve-network-port</goal>
+                        </goals>
+                        <phase>pre-integration-test</phase>
+                        <configuration>
+                            <outputFile>${project.build.directory}/server-work/server-ports.properties</outputFile>
+                            <minPortNumber>8000</minPortNumber>
+                            <maxPortNumber>9999</maxPortNumber>
+                            <randomPort>true</randomPort>
+                            <portNames>
+                                <portName>server.port.https</portName>
+                            </portNames>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>attach-dd-openapi-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>${project.basedir}/../../../dist/V1-data-dictionary-${project.version}.csv</file>
+                                    <type>csv</type>
+                                    <classifier>v1-data-dictionary</classifier>
+                                </artifact>
+                                <artifact>
+                                    <file>${project.basedir}/../../../dist/V1-data-dictionary-${project.version}.json</file>
+                                    <type>json</type>
+                                    <classifier>v1-data-dictionary</classifier>
+                                </artifact>
+                                <artifact>
+                                    <file>${project.basedir}/../../../dist/V1-OpenAPI-${project.version}.yaml</file>
+                                    <type>yaml</type>
+                                    <classifier>v1-openapi</classifier>
+                                </artifact>
+                                <artifact>
+                                    <file>${project.basedir}/../../../dist/V2-data-dictionary-${project.version}.csv</file>
+                                    <type>csv</type>
+                                    <classifier>v2-data-dictionary</classifier>
+                                </artifact>
+                                <artifact>
+                                    <file>${project.basedir}/../../../dist/V2-data-dictionary-${project.version}.json</file>
+                                    <type>json</type>
+                                    <classifier>v2-data-dictionary</classifier>
+                                </artifact>
+                                <artifact>
+                                    <file>${project.basedir}/../../../dist/V2-OpenAPI-${project.version}.yaml</file>
+                                    <type>yaml</type>
+                                    <classifier>v2-openapi</classifier>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/OpenApiDocs.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/OpenApiDocs.java
@@ -19,6 +19,7 @@ import org.hsqldb.jdbc.JDBCDataSource;
 /** Program to gather the OpenAPI yaml content for V1 and V2 and store. */
 public class OpenApiDocs {
 
+  /** The HSQL database url. */
   private static final String INMEM_HSQL_DATABASE_URL = "jdbc:bfd-test:hsqldb:mem";
 
   /** The version from the project pom. */

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/OpenApiDocs.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/OpenApiDocs.java
@@ -131,15 +131,18 @@ public class OpenApiDocs {
           "Project version, working directory, and destination directory are required.");
     }
 
-    var workingDirectory = new File(args[1]);
-    if (!workingDirectory.isDirectory()) {
-      throw new RuntimeException(String.format("Working directory (%s) is not valid.", args[1]));
+    var workingDirectory = args[1];
+    var destinationDirectory = args[2];
+
+    var workingDirectoryFile = new File(workingDirectory);
+    if (!workingDirectoryFile.isDirectory()) {
+      throw new RuntimeException(String.format("Working directory (%s) is not valid.", workingDirectory));
     }
 
-    var destinationDirectory = new File(args[2]);
-    if (!destinationDirectory.isDirectory()) {
+    var destinationDirectoryFile = new File(destinationDirectory);
+    if (!destinationDirectoryFile.isDirectory()) {
       throw new RuntimeException(
-          String.format("Destination directory (%s) is not valid.", args[2]));
+          String.format("Destination directory (%s) is not valid.", destinationDirectory));
     }
   }
 

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/OpenApiDocs.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/OpenApiDocs.java
@@ -136,7 +136,8 @@ public class OpenApiDocs {
 
     var workingDirectoryFile = new File(workingDirectory);
     if (!workingDirectoryFile.isDirectory()) {
-      throw new RuntimeException(String.format("Working directory (%s) is not valid.", workingDirectory));
+      throw new RuntimeException(
+          String.format("Working directory (%s) is not valid.", workingDirectory));
     }
 
     var destinationDirectoryFile = new File(destinationDirectory);

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/OpenApiDocs.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/OpenApiDocs.java
@@ -26,23 +26,23 @@ public class OpenApiDocs {
   private final String projectVersion;
 
   /** The destination directory for the output of the OpenAPI yaml file documents. */
-  private final String destinationDir;
+  private final String destinationDirectory;
 
   /** The base server url. */
-  private static String baseServerUrl;
+  private String baseServerUrl;
 
   /** The request specification to use with the api-docs requests. */
-  private static RequestSpecification requestAuth;
+  private RequestSpecification requestAuth;
 
   /**
    * Constructs an instance of OpenApiDocs for a given project version and destination directory.
    *
    * @param projectVersion @see #projectVersion
-   * @param destinationDir @see #destinationDir
+   * @param destinationDirectory @see #destinationDirectory
    */
-  private OpenApiDocs(String projectVersion, String destinationDir) {
+  private OpenApiDocs(String projectVersion, String destinationDirectory) {
     this.projectVersion = projectVersion;
-    this.destinationDir = destinationDir;
+    this.destinationDirectory = destinationDirectory;
   }
 
   /**
@@ -76,7 +76,7 @@ public class OpenApiDocs {
    */
   private void writeFile(String apiVersion, String contents) throws IOException {
     var fileName =
-        String.format("%s/%s-OpenAPI-%s.yaml", destinationDir, apiVersion, projectVersion);
+        String.format("%s/%s-OpenAPI-%s.yaml", destinationDirectory, apiVersion, projectVersion);
     try (var fileWriter = new FileWriter(fileName)) {
       fileWriter.write(contents);
     }
@@ -92,13 +92,17 @@ public class OpenApiDocs {
     // Validate arguments.
     validateArgs(args);
 
+    var projectVersion = args[0];
+    var workingDirectory = args[1];
+    var destinationDirectory = args[2];
+
     // Update working directory so E2E test server instance can find properties.
-    System.setProperty("user.dir", args[1]);
+    System.setProperty("user.dir", workingDirectory);
 
     // Set database url for in memory HSQL database
     System.setProperty("its.db.url", INMEM_HSQL_DATABASE_URL);
 
-    var openApiDocs = new OpenApiDocs(args[0], args[2]);
+    var openApiDocs = new OpenApiDocs(projectVersion, destinationDirectory);
     try {
       // Start E2E test server instance.
       openApiDocs.setup();
@@ -160,7 +164,7 @@ public class OpenApiDocs {
   }
 
   /** Initializes the request authorization. @see ServerRequiredTest#setRequestAuth. */
-  private static void setRequestAuth() {
+  private void setRequestAuth() {
     // Get the certs for the test
     String trustStorePath = "src/test/resources/certs/test-truststore.jks";
     String keyStorePath = "src/test/resources/certs/test-keystore.p12";

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/OpenApiDocs.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/OpenApiDocs.java
@@ -1,0 +1,120 @@
+package gov.cms.bfd.server.war;
+
+import static io.restassured.RestAssured.given;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Set;
+
+/** Program to gather the OpenAPI yaml content for V1 and V2 and store. */
+public class OpenApiDocs extends ServerRequiredTest {
+
+  /** The version from the project pom. */
+  private final String projectVersion;
+
+  /** The destination directory for the output of the OpenAPI yaml file documents. */
+  private final String destinationDir;
+
+  /**
+   * Constructs an instance of OpenApiDocs for a given project version and destination directory.
+   *
+   * @param projectVersion @see #projectVersion
+   * @param destinationDir @see #destinationDir
+   */
+  private OpenApiDocs(String projectVersion, String destinationDir) {
+    this.projectVersion = projectVersion;
+    this.destinationDir = destinationDir;
+  }
+
+  /**
+   * Downloads the OpenAPI yaml from the api-docs V1 endpoint using a local E2E test server
+   * instance.
+   *
+   * @param apiVersion the bfd api version, either V1 or V2.
+   * @throws IOException when IO operations fail
+   */
+  void downloadApiDocs(String apiVersion) throws IOException {
+    var apiDocsUrl = String.format("%s/%s/fhir/api-docs", baseServerUrl, apiVersion.toLowerCase());
+    var response =
+        given()
+            .spec(requestAuth)
+            .when()
+            .get(apiDocsUrl)
+            .then()
+            .contentType("text/yaml")
+            .extract()
+            .asString();
+
+    writeFile(apiVersion, response);
+  }
+
+  /**
+   * Write the OpenAPI yaml content to a file.
+   *
+   * @param apiVersion either V1 or V2
+   * @param contents the OpenAPI yaml contents to write to the file
+   * @throws IOException when file operations fail
+   */
+  private void writeFile(String apiVersion, String contents) throws IOException {
+    var fileName =
+        String.format("%s/%s-OpenAPI-%s.yaml", destinationDir, apiVersion, projectVersion);
+    try (var fileWriter = new FileWriter(fileName)) {
+      fileWriter.write(contents);
+    }
+  }
+
+  /**
+   * Entry point, starts an E2E test server instance and downloads OpenAPI yaml.
+   *
+   * @param args The project version, working directory, and destination directory.
+   */
+  public static void main(String[] args) {
+
+    // Validate arguments.
+    validateArgs(args);
+
+    // Update working directory so E2E test server instance can find properties.
+    System.setProperty("user.dir", args[1]);
+
+    var openApiDocs = new OpenApiDocs(args[0], args[2]);
+    try {
+      // Start E2E test server instance.
+      setup();
+
+      // Download and save OpenAPI yaml for V1 and V2.
+      for (var apiVersion : Set.of("V1", "V2")) {
+        openApiDocs.downloadApiDocs(apiVersion);
+      }
+
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    // Stop E2E server instance.
+    System.exit(0);
+  }
+
+  /**
+   * Validates the program arguments.
+   *
+   * @param args the project version, working directory, and destination directory.
+   */
+  private static void validateArgs(String[] args) {
+    if (args.length != 3) {
+      throw new RuntimeException(
+          "Project version, working directory, and destination directory are required.");
+    }
+
+    var workingDirectory = new File(args[1]);
+    if (!workingDirectory.isDirectory()) {
+      throw new RuntimeException(String.format("Working directory (%s) is not valid.", args[1]));
+    }
+
+    var destinationDirectory = new File(args[2]);
+    if (!destinationDirectory.isDirectory()) {
+      throw new RuntimeException(
+          String.format("Destination directory (%s) is not valid.", args[2]));
+    }
+  }
+}

--- a/apps/bfd-server/dev/bfd-data-dictionary/app/dd-transformer/dd_to_csv.py
+++ b/apps/bfd-server/dev/bfd-data-dictionary/app/dd-transformer/dd_to_csv.py
@@ -15,20 +15,19 @@ def build_csv_header():
 # TODO: refactor this func to address hardcoded field names
 def field_val(element_json, field):
     # handling varies by field
-    match field:
-        case "appliesTo" | "ccwMapping" | "cclfMapping":   # convert array to csv with ; as delimiter
-            return ";".join(element_json[field])
-        case "resource" | "element" | "derived" | "note" | "fhirPath" | "example":   # pull from fhirMapping object
-            return element_json["fhirMapping"][0][field]
-        case "discriminator" | "additional":  # pull from fhir mapping object and convert from array to csv with ; as delim
-            return ";".join(element_json["fhirMapping"][0][field])
-        case "AB2D" | "BB2" | "BCDA" | "BFD" | "DPC" | "SyntheticData": # convert from array to individual columns
-            if field in element_json["suppliedIn"]:
-                return "X"
-            else:
-                return ""
-        case _:  # default just return the value from the top level key
-            return element_json[field]
+    if field in {"appliesTo", "ccwMapping", "cclfMapping"}:
+        return ";".join(element_json[field])
+    elif field in {"resource", "element", "derived", "note", "fhirPath", "example"}:
+        return element_json["fhirMapping"][0][field]
+    elif field in {"discriminator", "additional"}:
+        return ";".join(element_json["fhirMapping"][0][field])
+    elif field in {"AB2D", "BB2", "BCDA", "BFD", "DPC", "SyntheticData"}:
+        if field in element_json["suppliedIn"]:
+            return "X"
+        else:
+            return ""
+    else:
+        return element_json[field]
 
 # func to build a csv of the element
 def build_csv_row(element):

--- a/apps/bfd-server/dev/bfd-data-dictionary/app/dd-transformer/dd_to_csv.py
+++ b/apps/bfd-server/dev/bfd-data-dictionary/app/dd-transformer/dd_to_csv.py
@@ -15,13 +15,13 @@ def build_csv_header():
 # TODO: refactor this func to address hardcoded field names
 def field_val(element_json, field):
     # handling varies by field
-    if field in {"appliesTo", "ccwMapping", "cclfMapping"}:
+    if field in {"appliesTo", "ccwMapping", "cclfMapping"}:  # convert array to csv with ; as delimiter
         return ";".join(element_json[field])
-    elif field in {"resource", "element", "derived", "note", "fhirPath", "example"}:
+    elif field in {"resource", "element", "derived", "note", "fhirPath", "example"}:  # pull from fhirMapping object
         return element_json["fhirMapping"][0][field]
-    elif field in {"discriminator", "additional"}:
+    elif field in {"discriminator", "additional"}:  # pull from fhir mapping object and convert from array to csv with ; as delim
         return ";".join(element_json["fhirMapping"][0][field])
-    elif field in {"AB2D", "BB2", "BCDA", "BFD", "DPC", "SyntheticData"}:
+    elif field in {"AB2D", "BB2", "BCDA", "BFD", "DPC", "SyntheticData"}:  # convert from array to individual columns
         if field in element_json["suppliedIn"]:
             return "X"
         else:

--- a/apps/bfd-server/dev/bfd-data-dictionary/generate_dd.sh
+++ b/apps/bfd-server/dev/bfd-data-dictionary/generate_dd.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+if [[ $# != 1 ]] ; then
+  printf "Generates data dictionary csv and json files.\nUsage: %s project_version\n" "$(basename "$0")"
+  exit 1
+fi
+
+PROJECT_VERSION=$1
+
+# Identify the root of the repository as `REPO_ROOT`
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Create the typical, temporary `dist` directory
+mkdir -p "${REPO_ROOT}/dist"
+
+# Generate Versioned CSV and JSON Data Dictionaries
+for version in V1 V2; do
+    python3 "${REPO_ROOT}/apps/bfd-server/dev/bfd-data-dictionary/app/dd-transformer/dd_to_csv.py" \
+        --template "${REPO_ROOT}/apps/bfd-server/dev/bfd-data-dictionary/app/dd-transformer/template/${version,,}-to-csv.json" \
+        --source "${REPO_ROOT}/apps/bfd-server/dev/bfd-data-dictionary/data/${version}/" \
+        --target "${REPO_ROOT}/dist/${version}-data-dictionary-${PROJECT_VERSION}.csv"
+    python3 "${REPO_ROOT}/apps/bfd-server/dev/bfd-data-dictionary/app/dd-transformer/dd_to_json.py" \
+        --source "${REPO_ROOT}/apps/bfd-server/dev/bfd-data-dictionary/data/${version}/" \
+        --target "${REPO_ROOT}/dist/${version}-data-dictionary-${PROJECT_VERSION}.json"
+done
+

--- a/apps/pom.xml
+++ b/apps/pom.xml
@@ -168,6 +168,7 @@
         <hapi-fhir.version>6.8.3</hapi-fhir.version>
         <thymeleaf.version>3.1.2.RELEASE</thymeleaf.version>
         <jersey.version>2.25.1</jersey.version>
+        <exec.maven.plugin.version>3.1.0</exec.maven.plugin.version>
 
         <!--  Dependencies required for org.apache.commons -->
         <commons.lang3.version>3.13.0</commons.lang3.version>
@@ -1207,6 +1208,27 @@
                         <exclude>**/E2E.java</exclude>
                     </excludes>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>${exec.maven.plugin.version}</version>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <configuration>
+                            <executable>${project.basedir}/bfd-server/dev/bfd-data-dictionary/generate_dd.sh</executable>
+                            <arguments>
+                                <argument>${project.version}</argument>
+                            </arguments>
+                        </configuration>
+                        <id>create-dd-artifacts</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
         <extensions>

--- a/apps/pom.xml
+++ b/apps/pom.xml
@@ -1223,7 +1223,7 @@
                             </arguments>
                         </configuration>
                         <id>create-dd-artifacts</id>
-                        <phase>install</phase>
+                        <phase>verify</phase>
                         <goals>
                             <goal>exec</goal>
                         </goals>


### PR DESCRIPTION
**JIRA Ticket:**
[BFD-2987](https://jira.cms.gov/browse/BFD-2987)

**User Story or Bug Summary:**
As a BFD engineer I want the maven builds to contain all of the release artifacts necessary to deploy the application, including data dictionary files and OpenAPI specifications.

---

### What Does This PR Do?

Adds generation of the data dictionary csv and json files, and OpenAPI spec yaml files to build output.

* Adds a `generate_dd.sh`  script to generate the data dictionary csv and json files for V1 and V2.  Adapted from the runbook instructions [How-to-do-a-Deployment](https://github.com/CMSgov/beneficiary-fhir-data/wiki/How-to-do-a-Deployment).
* Modifies the `apps/pom.xml` to use the `maven-exec-plugin` to execute the script including the project version as a parameter.
* Adds a OpenAPIDocs class to the `bfd-server/bfd-server-war` test packages which leverages the existing E2E test framework to spin up a local server instance, capture the OpenAPI yaml content, and save to files.
* Modifies the `bfd-server-war/pom.xml` to run OpenAPIDocs  using the `maven-exec-plugin`.
* Modifies the `dd_to_csv.py` script to run under python v3.9.16 used by the build containers.
* Modifies the `bfd-server-war/pom.xml` to add the data dictionary and Open API yaml files as artifacts.

### What Should Reviewers Watch For?

If you're reviewing this PR, please check for these things in particular:
* Verify all PR security questions and checklists have been completed and addressed.
* The `maven-exec-plugin` is set to run as part of the maven verify lifecycle, maybe it should be configured differently. 
* The files are written to a `dist` directory in the project root, but that directory is not emptied beforehand.  Any existing files with the same names are overwritten.
* The yaml files include a server url for the local E2E test server instance and should probably be replaced with the proper server url from prod if the OpenAPI endpoints are available there. 
* There is some borrowing of code from ServerRequiredTest to initiate the db and request auth. 
* The artifacts are attached to the `bfd-server-war` project, should they go somewhere else?
![image](https://github.com/CMSgov/beneficiary-fhir-data/assets/607241/2f22b9f1-c1f2-42c7-baa3-13253eeec6e8)


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [X] Yes
      * [ ] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [X] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [X] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [X] No

### What Needs to Be Merged and Deployed Before this PR?

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist

I have gone through and verified that...:

* [X] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [X] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [X] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [X] The data dictionary has been updated with any field mapping changes, if any were made.
* [X] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [X] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [X] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [X] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    