### PR TITLE
BFD-2933: Convert AccessJsonE2E to restAssured

### DIFF
--- a/apps/bfd-server/bfd-server-shared-utils/src/main/java/gov/cms/bfd/server/sharedutils/BfdMDC.java
+++ b/apps/bfd-server/bfd-server-shared-utils/src/main/java/gov/cms/bfd/server/sharedutils/BfdMDC.java
@@ -131,10 +131,6 @@ public class BfdMDC {
   public static final String HTTP_ACCESS_REQUEST_HEADER_ACCEPT =
       computeMDCKey(MDC_PREFIX, REQUEST_PREFIX, HEADER_PREFIX, "Accept");
 
-  /** MDC key for the http request header accept charset. */
-  public static final String HTTP_ACCESS_REQUEST_HEADER_ACCEPT_CHARSET =
-      computeMDCKey(MDC_PREFIX, REQUEST_PREFIX, HEADER_PREFIX, "Accept-Charset");
-
   /** MDC key for the http request header accept encoding. */
   public static final String HTTP_ACCESS_REQUEST_HEADER_ACCEPT_ENCODING =
       computeMDCKey(MDC_PREFIX, REQUEST_PREFIX, HEADER_PREFIX, "Accept-Encoding");

--- a/apps/bfd-server/bfd-server-shared-utils/src/main/java/gov/cms/bfd/server/sharedutils/BfdMDC.java
+++ b/apps/bfd-server/bfd-server-shared-utils/src/main/java/gov/cms/bfd/server/sharedutils/BfdMDC.java
@@ -131,6 +131,10 @@ public class BfdMDC {
   public static final String HTTP_ACCESS_REQUEST_HEADER_ACCEPT =
       computeMDCKey(MDC_PREFIX, REQUEST_PREFIX, HEADER_PREFIX, "Accept");
 
+  /** MDC key for the http request header accept charset. */
+  public static final String HTTP_ACCESS_REQUEST_HEADER_ACCEPT_CHARSET =
+      computeMDCKey(MDC_PREFIX, REQUEST_PREFIX, HEADER_PREFIX, "Accept-Charset");
+
   /** MDC key for the http request header accept encoding. */
   public static final String HTTP_ACCESS_REQUEST_HEADER_ACCEPT_ENCODING =
       computeMDCKey(MDC_PREFIX, REQUEST_PREFIX, HEADER_PREFIX, "Accept-Encoding");

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/AccessJsonE2E.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/AccessJsonE2E.java
@@ -1,18 +1,28 @@
 package gov.cms.bfd.server.war;
 
 import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import gov.cms.bfd.model.rif.entities.Beneficiary;
 import gov.cms.bfd.server.sharedutils.BfdMDC;
 import gov.cms.bfd.server.war.commons.TransformerConstants;
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Verifies that access.json is written to as expected. */
 public class AccessJsonE2E extends ServerRequiredTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AccessJsonE2E.class);
+
   /** Verifies that access.json is written to within BFD-server-war via API call. */
   @Test
   public void verifyAccessJson() throws IOException {
@@ -26,62 +36,88 @@ public class AccessJsonE2E extends ServerRequiredTest {
             + "|"
             + mbiHash;
 
-    given().spec(requestAuth).expect().statusCode(200).when().get(requestString);
-
-    // Verify that the access JSON is working, as expected.
-    /*try {
-      TimeUnit.MILLISECONDS.sleep(1000); // Needed to resolve a race condition
-    } catch (InterruptedException ignored) {
-    }*/
-
     Path accessLogJson =
         ServerTestUtils.getWarProjectDirectory()
             .resolve("target")
             .resolve("server-work")
             .resolve("access.json");
+
+    // Empty the access json to avoid pollution from other tests
+    try (BufferedWriter writer = Files.newBufferedWriter(accessLogJson)) {
+      writer.write("");
+      writer.flush();
+    }
+
+    given()
+        .spec(requestAuth)
+        .contentType("application/json")
+        .expect()
+        .statusCode(200)
+        .when()
+        .get(requestString);
+
+    // Verify that the access JSON is working, as expected.
+    try {
+      TimeUnit.MILLISECONDS.sleep(1000); // Needed to resolve a race condition
+    } catch (InterruptedException ignored) {
+    }
+
     assertTrue(Files.isReadable(accessLogJson));
     assertTrue(Files.size(accessLogJson) > 0);
 
     String content = Files.readString(accessLogJson);
-    assertTrue(content.contains(BfdMDC.BENE_ID));
-    assertTrue(content.contains(BfdMDC.DATABASE_QUERY_BATCH));
-    assertTrue(content.contains(BfdMDC.DATABASE_QUERY_TYPE));
-    assertTrue(content.contains(BfdMDC.DATABASE_QUERY_BATCH_SIZE));
-    assertTrue(content.contains(BfdMDC.DATABASE_QUERY_SIZE));
-    assertTrue(content.contains(BfdMDC.DATABASE_QUERY_MILLI));
-    assertTrue(content.contains(BfdMDC.DATABASE_QUERY_SUCCESS));
-    assertTrue(content.contains(BfdMDC.DATABASE_QUERY_SOURCE_NAME));
-    assertTrue(content.contains(BfdMDC.HAPI_RESPONSE_TIMESTAMP_MILLI));
-    assertTrue(content.contains(BfdMDC.HAPI_POST_PROCESS_TIMESTAMP_MILLI));
-    assertTrue(content.contains(BfdMDC.HAPI_PRE_HANDLE_TIMESTAMP_MILLI));
-    assertTrue(content.contains(BfdMDC.HAPI_PRE_HANDLE_TIMESTAMP_MILLI));
-    assertTrue(content.contains(BfdMDC.HAPI_PRE_PROCESS_TIMESTAMP_MILLI));
-    assertTrue(content.contains(BfdMDC.HAPI_PROCESSING_COMPLETED_TIMESTAMP_MILLI));
-    assertTrue(content.contains(BfdMDC.HAPI_PROCESSING_COMPLETED_NORM_TIMESTAMP_MILLI));
-    assertTrue(content.contains(BfdMDC.HTTP_ACCESS_REQUEST_CLIENTSSL_DN));
-    assertTrue(content.contains(BfdMDC.HTTP_ACCESS_REQUEST_HEADER_ACCEPT));
-    assertTrue(content.contains(BfdMDC.HTTP_ACCESS_REQUEST_HEADER_ACCEPT_CHARSET));
-    assertTrue(content.contains(BfdMDC.HTTP_ACCESS_REQUEST_HEADER_ACCEPT_ENCODING));
-    assertTrue(content.contains(BfdMDC.HTTP_ACCESS_REQUEST_HEADER_CONN_ENCODING));
-    assertTrue(content.contains(BfdMDC.HTTP_ACCESS_REQUEST_HEADER_HOST_ENCODING));
-    assertTrue(content.contains(BfdMDC.HTTP_ACCESS_REQUEST_HEADER_USER_AGENT));
-    assertTrue(content.contains(BfdMDC.HTTP_ACCESS_REQUEST_HTTP_METHOD));
-    assertTrue(content.contains(BfdMDC.HTTP_ACCESS_REQUEST_OPERATION));
-    assertTrue(content.contains(BfdMDC.HTTP_ACCESS_REQUEST_QUERY_STR));
-    assertTrue(content.contains(BfdMDC.HTTP_ACCESS_REQUEST_TYPE));
-    assertTrue(content.contains(BfdMDC.HTTP_ACCESS_REQUEST_URI));
-    assertTrue(content.contains(BfdMDC.HTTP_ACCESS_REQUEST_URL));
-    assertTrue(content.contains(BfdMDC.HTTP_ACCESS_RESPONSE_DURATION_PER_KB));
-    assertTrue(content.contains(BfdMDC.HTTP_ACCESS_RESPONSE_DURATION_MILLISECONDS));
-    assertTrue(content.contains(BfdMDC.HTTP_ACCESS_RESPONSE_HEADER_ENCODING));
-    assertTrue(content.contains(BfdMDC.HTTP_ACCESS_RESPONSE_HEADER_LOCATION));
-    assertTrue(content.contains(BfdMDC.HTTP_ACCESS_RESPONSE_HEADER_TYPE));
-    assertTrue(content.contains(BfdMDC.HTTP_ACCESS_RESPONSE_HEADER_DATE));
-    assertTrue(content.contains(BfdMDC.HTTP_ACCESS_RESPONSE_HEADER_LAST_MODIFIED));
-    assertTrue(content.contains(BfdMDC.HTTP_ACCESS_RESPONSE_HEADER_POWERED_BY));
-    assertTrue(content.contains(BfdMDC.HTTP_ACCESS_RESPONSE_HEADER_REQUEST_ID));
-    assertTrue(content.contains(BfdMDC.HTTP_ACCESS_RESPONSE_OUTPUT_SIZE_IN_BYTES));
-    assertTrue(content.contains(BfdMDC.HTTP_ACCESS_RESPONSE_STATUS));
-    assertTrue(content.contains(BfdMDC.RESOURCES_RETURNED));
+
+    LOGGER.info(content);
+
+    List<String> headersToCheck =
+        List.of(
+            BfdMDC.BENE_ID,
+            BfdMDC.DATABASE_QUERY_BATCH,
+            BfdMDC.DATABASE_QUERY_TYPE,
+            BfdMDC.DATABASE_QUERY_BATCH_SIZE,
+            BfdMDC.DATABASE_QUERY_SIZE,
+            BfdMDC.DATABASE_QUERY_MILLI,
+            BfdMDC.DATABASE_QUERY_SUCCESS,
+            BfdMDC.DATABASE_QUERY_SOURCE_NAME,
+            BfdMDC.HAPI_RESPONSE_TIMESTAMP_MILLI,
+            BfdMDC.HAPI_POST_PROCESS_TIMESTAMP_MILLI,
+            BfdMDC.HAPI_PRE_HANDLE_TIMESTAMP_MILLI,
+            BfdMDC.HAPI_PRE_HANDLE_TIMESTAMP_MILLI,
+            BfdMDC.HAPI_PRE_PROCESS_TIMESTAMP_MILLI,
+            BfdMDC.HAPI_PROCESSING_COMPLETED_TIMESTAMP_MILLI,
+            BfdMDC.HAPI_PROCESSING_COMPLETED_NORM_TIMESTAMP_MILLI,
+            BfdMDC.HTTP_ACCESS_REQUEST_CLIENTSSL_DN,
+            BfdMDC.HTTP_ACCESS_REQUEST_HEADER_ACCEPT,
+            BfdMDC.HTTP_ACCESS_REQUEST_HEADER_ACCEPT_ENCODING,
+            BfdMDC.HTTP_ACCESS_REQUEST_HEADER_CONN_ENCODING,
+            BfdMDC.HTTP_ACCESS_REQUEST_HEADER_HOST_ENCODING,
+            BfdMDC.HTTP_ACCESS_REQUEST_HEADER_USER_AGENT,
+            BfdMDC.HTTP_ACCESS_REQUEST_HTTP_METHOD,
+            BfdMDC.HTTP_ACCESS_REQUEST_OPERATION,
+            BfdMDC.HTTP_ACCESS_REQUEST_QUERY_STR,
+            BfdMDC.HTTP_ACCESS_REQUEST_TYPE,
+            BfdMDC.HTTP_ACCESS_REQUEST_URI,
+            BfdMDC.HTTP_ACCESS_REQUEST_URL,
+            BfdMDC.HTTP_ACCESS_RESPONSE_DURATION_PER_KB,
+            BfdMDC.HTTP_ACCESS_RESPONSE_DURATION_MILLISECONDS,
+            BfdMDC.HTTP_ACCESS_RESPONSE_DURATION_MILLISECONDS,
+            BfdMDC.HTTP_ACCESS_RESPONSE_HEADER_ENCODING,
+            BfdMDC.HTTP_ACCESS_RESPONSE_HEADER_TYPE,
+            BfdMDC.HTTP_ACCESS_RESPONSE_HEADER_DATE,
+            BfdMDC.HTTP_ACCESS_RESPONSE_HEADER_LAST_MODIFIED,
+            BfdMDC.HTTP_ACCESS_RESPONSE_HEADER_POWERED_BY,
+            BfdMDC.HTTP_ACCESS_RESPONSE_HEADER_REQUEST_ID,
+            BfdMDC.HTTP_ACCESS_RESPONSE_OUTPUT_SIZE_IN_BYTES,
+            BfdMDC.HTTP_ACCESS_RESPONSE_STATUS,
+            BfdMDC.RESOURCES_RETURNED);
+
+    List<String> missingHeader = new ArrayList<>();
+    for (String header : headersToCheck) {
+      if (!content.contains(header)) {
+        missingHeader.add(header);
+      }
+    }
+    // Check we have no missing headers in a way that makes a useful assertion error if not
+    assertEquals(new ArrayList<>(), missingHeader, "Missing expected headers in access.json!");
   }
 }

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/AccessJsonE2E.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/AccessJsonE2E.java
@@ -59,8 +59,6 @@ public class AccessJsonE2E extends ServerRequiredTest {
 
     String content = Files.readString(accessLogJson);
 
-    LOGGER.info(content);
-
     List<String> headersToCheck =
         List.of(
             BfdMDC.BENE_ID,
@@ -73,7 +71,6 @@ public class AccessJsonE2E extends ServerRequiredTest {
             BfdMDC.DATABASE_QUERY_SOURCE_NAME,
             BfdMDC.HAPI_RESPONSE_TIMESTAMP_MILLI,
             BfdMDC.HAPI_POST_PROCESS_TIMESTAMP_MILLI,
-            BfdMDC.HAPI_PRE_HANDLE_TIMESTAMP_MILLI,
             BfdMDC.HAPI_PRE_HANDLE_TIMESTAMP_MILLI,
             BfdMDC.HAPI_PRE_PROCESS_TIMESTAMP_MILLI,
             BfdMDC.HAPI_PROCESSING_COMPLETED_TIMESTAMP_MILLI,
@@ -91,7 +88,6 @@ public class AccessJsonE2E extends ServerRequiredTest {
             BfdMDC.HTTP_ACCESS_REQUEST_URI,
             BfdMDC.HTTP_ACCESS_REQUEST_URL,
             BfdMDC.HTTP_ACCESS_RESPONSE_DURATION_PER_KB,
-            BfdMDC.HTTP_ACCESS_RESPONSE_DURATION_MILLISECONDS,
             BfdMDC.HTTP_ACCESS_RESPONSE_DURATION_MILLISECONDS,
             BfdMDC.HTTP_ACCESS_RESPONSE_HEADER_ENCODING,
             BfdMDC.HTTP_ACCESS_RESPONSE_HEADER_TYPE,

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/AccessJsonE2E.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/AccessJsonE2E.java
@@ -13,7 +13,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,8 +43,7 @@ public class AccessJsonE2E extends ServerRequiredTest {
 
     // Empty the access json to avoid pollution from other tests
     try (BufferedWriter writer = Files.newBufferedWriter(accessLogJson)) {
-      writer.write("");
-      writer.flush();
+      Files.writeString(accessLogJson, "");
     }
 
     given()
@@ -55,12 +53,6 @@ public class AccessJsonE2E extends ServerRequiredTest {
         .statusCode(200)
         .when()
         .get(requestString);
-
-    // Verify that the access JSON is working, as expected.
-    try {
-      TimeUnit.MILLISECONDS.sleep(1000); // Needed to resolve a race condition
-    } catch (InterruptedException ignored) {
-    }
 
     assertTrue(Files.isReadable(accessLogJson));
     assertTrue(Files.size(accessLogJson) > 0);


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BFD-2933](https://jira.cms.gov/browse/BFD-2933)

**User Story or Bug Summary:**
<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->
As a BFD Engineer I would like existing IT tests to use restAssured so that we are testing our REST endpoints as customers use them.

---

### What Does This PR Do?
<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

- Coverts the AccessJsonIT to AccessJsonE2E and converts the test to use RestAssured
  - Fixes the test to wipe access.json before running, since before it was not and the test results were based on what (if anything) had run before it. The test previously did not pass when run solo.
  - Removes two headers which don't get set as part of the test as written: Content-Location (which I don't know if/how we use this today, but we dont explicitly set or use it) and Accept-Charset (which has been deprecated and advised to not be used since 2012, and we dont explicitly set or check for this in code)
- Fixed the assert to keep track of all failed headers and do a single assert, which makes the output a lot more useful to read as well as checking for all headers at once instead of the first failed one

### What Should Reviewers Watch For?
<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items to the following list here -->
* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [x] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [x] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [x] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] The data dictionary has been updated with any field mapping changes, if any were made.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    