### PR TITLE
BFD-3051: Add UseStringDeduplication to JVM params for RIF pipeline

### DIFF
--- a/ops/terraform/services/pipeline/user-data.sh.tftpl
+++ b/ops/terraform/services/pipeline/user-data.sh.tftpl
@@ -37,7 +37,7 @@ aws ssm get-parameters-by-path \
 cat <<EOF > extra_vars.json
 {
   "data_pipeline_db_url": "${writer_endpoint}",
-  "data_pipeline_jvm_args": "-Xms{{ ((ansible_memtotal_mb * 0.80) | int) - 2048 }}m -Xmx{{ ((ansible_memtotal_mb * 0.80) | int) - 2048 }}m -XX:+PreserveFramePointer",
+  "data_pipeline_jvm_args": "-Xms{{ ((ansible_memtotal_mb * 0.80) | int) - 2048 }}m -Xmx{{ ((ansible_memtotal_mb * 0.80) | int) - 2048 }}m -XX:+PreserveFramePointer -XX:+UseStringDeduplication",
   "data_pipeline_new_relic_app_name": "BFD Pipeline %{ if pipeline_instance == "rda" ~} %{ else ~} ${pipeline_instance} %{ endif ~} ({{ env_name_std }})",
   "data_pipeline_s3_bucket": "${pipeline_bucket}",
   "data_pipeline_tmp_dir": "{{ data_pipeline_dir }}/tmp",


### PR DESCRIPTION
**JIRA Ticket:**
[BFD-3051](https://jira.cms.gov/browse/BFD-3051)

**User Story or Bug Summary:**
As a BFD engineer I want to use GC settings for the ETL pipelines that improve performance and/or help to reduce costs.

---

### What Does This PR Do?

* Modifies the shell script file template for `bfd-pipeline-server.sh`  so that it includes an additional JVM parameter to use string deduplication during garbage collection cycles.  [JEP 192: String Deduplication in G1](https://openjdk.org/jeps/192) 

Summary from BFD-3051:
Used the prod-based ephemeral environment `bfd-3051-prod` to repeatedly run through files copied from the "Done/2023-11-24T12:00:00Z" folder.  The JVM parameters were updated and measurements were captured until 1M beneficiaries were processed, which seemed sufficient to see differences in GC settings and each run took approx. 50-60 minutes total.  The processing time for beneficiaries does not include the file download times.

Findings:

- ZGC performance was worse than the default G1GC.
- String deduplication does not have a performance penalty, so we might as well enable it.
- Heap space could be lowered dramatically at the cost of a marginal increase in GC time.

![image](https://github.com/CMSgov/beneficiary-fhir-data/assets/607241/e0cd2982-94eb-4158-b5dc-e828f70b5a94)



### What Should Reviewers Watch For?

If you're reviewing this PR, please check for these things in particular:

* Verify all PR security questions and checklists have been completed and addressed.
* Is this the correct place to make this change?  It's the only reference I could find to `bfd-pipeline-server.sh`.
* Justification for this change is documented in the comments to the JIRA ticket [BFD-3051](https://jira.cms.gov/browse/BFD-3051).
* There's some evidence from the tests run that heap size could be reduced and cost savings realized by choosing an EC2 instance type with less memory, but that will require further testing since those changes also require a reduction of virtual CPU.  And there is a tradeoff between heap allocated and total GC time.

### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [X] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [X] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [X] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [X] No

### What Needs to Be Merged and Deployed Before this PR?

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist

I have gone through and verified that...:

* [X] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [X] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [X] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [X] The data dictionary has been updated with any field mapping changes, if any were made.
* [X] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [X] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [X] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [X] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    