### PR TITLE
BFD-3091: Use dynamic versions in ansible

### DIFF
--- a/.github/workflows/ci-ansible.yml
+++ b/.github/workflows/ci-ansible.yml
@@ -5,6 +5,9 @@ on:
       role:
         required: true
         type: string
+      bfd_version:
+        required: true
+        type: string
       image_tag:
         required: false
         type: string
@@ -20,4 +23,4 @@ jobs:
       - name: 'Run Tests for ${{ inputs.role }} Role'
         run: |
           export IMAGE_TAG="${image_tag:-$(git rev-parse --short HEAD)}"
-          ops/ansible/roles/${{ inputs.role }}/test/run-tests.sh "$IMAGE_TAG"
+          ops/ansible/roles/${{ inputs.role }}/test/run-tests.sh -i "$IMAGE_TAG" ${{ inputs.bfd_version }}

--- a/.github/workflows/ci-java.yml
+++ b/.github/workflows/ci-java.yml
@@ -72,6 +72,8 @@ jobs:
   mvn-verify:
     runs-on: ubuntu-20.04
     needs: workflow
+    outputs:
+      BFD_PARENT_VERSION: ${{ steps.bfd-parent-version.outputs.BFD_PARENT_VERSION }}
     if: needs.workflow.outputs.files
     steps:
       - name: 'Checkout repo'
@@ -120,9 +122,14 @@ jobs:
           echo "${{ secrets.GITHUB_TOKEN }}" \
           | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
+      - name: Determine the BFD Parent Version
+        id: bfd-parent-version
+        run: |
+          echo "BFD_PARENT_VERSION=$(yq '.project.version' apps/pom.xml)" >> "$GITHUB_OUTPUT"
+          echo "BFD_PARENT_VERSION=$(yq '.project.version' apps/pom.xml)" >> "$GITHUB_ENV"
+
       - name: Build and Deliver Apps Container Image
         run: |
-          BFD_PARENT_VERSION="$(yq '.project.version' pom.xml)"
           SANITIZED_REF="${GITHUB_REF_NAME////-}"
           IMAGE_NAME="ghcr.io/cmsgov/bfd-apps"
           SHORT_SHA="$(git rev-parse --short HEAD)"
@@ -199,15 +206,18 @@ jobs:
     uses: ./.github/workflows/ci-ansible.yml
     with:
       role: bfd-pipeline
+      bfd_version: ${{ needs.mvn-verify.outputs.BFD_PARENT_VERSION }}
 
   ansible-role-bfd-server:
     needs: mvn-verify
     uses: ./.github/workflows/ci-ansible.yml
     with:
       role: bfd-server
+      bfd_version: ${{ needs.mvn-verify.outputs.BFD_PARENT_VERSION }}
 
   ansible-role-bfd-db-migrator:
     needs: mvn-verify
     uses: ./.github/workflows/ci-ansible.yml
     with:
       role: bfd-db-migrator
+      bfd_version: ${{ needs.mvn-verify.outputs.BFD_PARENT_VERSION }}

--- a/apps/.dockerignore
+++ b/apps/.dockerignore
@@ -1,6 +1,6 @@
 *
 !bfd-model/bfd-model-rif/src/main/resources/db/migration
-!bfd-server/bfd-server-launcher/target/bfd-server-launcher-1.0.0-SNAPSHOT.zip
-!bfd-server/bfd-server-war/target/bfd-server-war-1.0.0-SNAPSHOT.war
-!bfd-pipeline/bfd-pipeline-app/target/bfd-pipeline-app-1.0.0-SNAPSHOT.zip
-!bfd-db-migrator/target/bfd-db-migrator-1.0.0-SNAPSHOT.zip
+!bfd-server/bfd-server-launcher/target/bfd-server-launcher-*.zip
+!bfd-server/bfd-server-war/target/bfd-server-war-*.war
+!bfd-pipeline/bfd-pipeline-app/target/bfd-pipeline-app-*.zip
+!bfd-db-migrator/target/bfd-db-migrator-*.zip

--- a/apps/build.groovy
+++ b/apps/build.groovy
@@ -94,10 +94,10 @@ EOF
 	}
 
 	return new AppBuildResults(
-		dbMigratorZip: 'apps/bfd-db-migrator/target/bfd-db-migrator-1.0.0-SNAPSHOT.zip',
-		dataPipelineZip: 'apps/bfd-pipeline/bfd-pipeline-app/target/bfd-pipeline-app-1.0.0-SNAPSHOT.zip',
-		dataServerLauncher: 'apps/bfd-server/bfd-server-launcher/target/bfd-server-launcher-1.0.0-SNAPSHOT.zip',
-		dataServerWar: 'apps/bfd-server/bfd-server-war/target/bfd-server-war-1.0.0-SNAPSHOT.war'
+		dbMigratorZip:      sh(returnStdout: true, script: """find "${workspace}/apps/bfd-db-migrator/target" -type f -name bfd-db-migrator-*.zip""").trim(),
+		dataPipelineZip:    sh(returnStdout: true, script: """find "${workspace}/apps/bfd-pipeline/bfd-pipeline-app/target" -type f -name bfd-pipeline-app-*.zip""").trim(),
+		dataServerLauncher: sh(returnStdout: true, script: """find "${workspace}/apps/bfd-server/bfd-server-launcher/target" -type f -name bfd-server-launcher-*.zip""").trim(),
+		dataServerWar:      sh(returnStdout: true, script: """find "${workspace}/apps/bfd-server/bfd-server-war/target" -type f -name bfd-server-war-*.war""").trim()
 	)
 }
 

--- a/ops/ansible/roles/bfd-db-migrator/README.md
+++ b/ops/ansible/roles/bfd-db-migrator/README.md
@@ -49,7 +49,8 @@ Here's an example of how to apply this role to the `bfd-db-migrator` host in an 
         import_role:
             name: bfd-db-migrator
         vars:
-            db_migrator_zip: "{{ lookup('env','HOME') }}/.m2/repository/gov/cms/bfd/bfd-db-migrator/1.0.0-SNAPSHOT/bfd-db-migrator-1.0.0-SNAPSHOT.zip"
+            bfd_version: 2.0.0-SNAPSHOT
+            db_migrator_zip: "{{ lookup('env','HOME') }}/.m2/repository/gov/cms/bfd/bfd-db-migrator/{{ bfd_version }}/bfd-db-migrator-{{ bfd_version }}.zip"
             db_migrator_db_url: 'jdbc:hsqldb:mem:test'
             db_migrator_db_username: "{{ vault_db_migrator_db_username }}"
             db_migrator_db_password: "{{ vault_db_migrator_db_password }}"

--- a/ops/ansible/roles/bfd-db-migrator/defaults/main.yml
+++ b/ops/ansible/roles/bfd-db-migrator/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+bfd_version: 1.0.0-SNAPSHOT
 env: test
 db_migrator_dir: /opt/bfd-db-migrator
 db_migrator_user: bb-migrator

--- a/ops/ansible/roles/bfd-db-migrator/templates/bfd-db-migrator-service.sh.j2
+++ b/ops/ansible/roles/bfd-db-migrator/templates/bfd-db-migrator-service.sh.j2
@@ -31,7 +31,7 @@ export NEW_RELIC_METRIC_PERIOD='{{ db_migrator_new_relic_metric_period }}'
 
 LOGS_DIR='{{ db_migrator_dir }}/'
 
-exec "{{ db_migrator_dir }}/bfd-db-migrator-1.0.0-SNAPSHOT/bfd-db-migrator.sh" \
+exec "{{ db_migrator_dir }}/bfd-db-migrator-{{ bfd_version }}/bfd-db-migrator.sh" \
 	"-DbfdDbMigrator.logs.dir=${LOGS_DIR}" \
 	-Djava.io.tmpdir={{ db_migrator_tmp_dir }} \
 	&>> "{{ db_migrator_dir }}/migrator-log.json"

--- a/ops/ansible/roles/bfd-db-migrator/test/test.sh
+++ b/ops/ansible/roles/bfd-db-migrator/test/test.sh
@@ -19,4 +19,4 @@ source venv/bin/activate
 ansible-playbook "$TEST_PLAY" --inventory=inventory.docker.yaml --syntax-check
 
 # Run the Ansible test case.
-ansible-playbook "$TEST_PLAY" --inventory=inventory.docker.yaml --extra-vars "$EXTRA_VARS"
+ansible-playbook "$TEST_PLAY" --inventory=inventory.docker.yaml --extra-vars "$EXTRA_VARS" --extra-vars bfd_version="$BFD_VERSION"

--- a/ops/ansible/roles/bfd-db-migrator/test/test_basic.yml
+++ b/ops/ansible/roles/bfd-db-migrator/test/test_basic.yml
@@ -21,7 +21,7 @@
         name: bfd-db-migrator
       vars:
         env: dev
-        db_migrator_zip: "{{ lookup('env','HOME') }}/.m2/repository/gov/cms/bfd/bfd-db-migrator/1.0.0-SNAPSHOT/bfd-db-migrator-1.0.0-SNAPSHOT.zip"
+        db_migrator_zip: "{{ lookup('env','HOME') }}/.m2/repository/gov/cms/bfd/bfd-db-migrator/{{ bfd_version }}/bfd-db-migrator-{{ bfd_version }}.zip"
         db_migrator_db_url: jdbc:postgresql://db:5432/fhirdb
         db_migrator_db_username: bfd
         db_migrator_db_password: bfd

--- a/ops/ansible/roles/bfd-pipeline/README.md
+++ b/ops/ansible/roles/bfd-pipeline/README.md
@@ -20,7 +20,7 @@ Role Variables
 
 This role is highly configurable, though it tries to provide reasonable defaults where possible. Here are the variables that must be defined by users:
 
-    data_pipeline_zip: /home/karlmdavis/workspaces/cms/beneficiary-fhir-data.git/apps/bfd-pipeline/bfd-pipeline-app/target/bfd-pipeline-app-1.0.0-SNAPSHOT.zip
+    data_pipeline_zip: /home/karlmdavis/workspaces/cms/beneficiary-fhir-data.git/apps/bfd-pipeline/bfd-pipeline-app/target/bfd-pipeline-app-2.0.0-SNAPSHOT.zip
     data_pipeline_s3_bucket: name-of-the-s3-bucket-with-the-data-to-process
     data_pipeline_hicn_hash_iterations: 42  # NIST recommends at least 1000
     data_pipeline_hicn_hash_pepper: '6E6F747468657265616C706570706572'  # Hex-encoded "nottherealpepper".
@@ -51,7 +51,7 @@ Here's an example of how to apply this role to the `etlbox` host in an Ansible p
         - include_role:
             name: bfd-pipeline
           vars:
-            data_pipeline_zip: /home/karlmdavis/workspaces/cms/beneficiary-fhir-data.git/apps/bfd-pipeline/bfd-pipeline-app/target/bfd-pipeline-app-1.0.0-SNAPSHOT.zip
+            data_pipeline_zip: /home/karlmdavis/workspaces/cms/beneficiary-fhir-data.git/apps/bfd-pipeline/bfd-pipeline-app/target/bfd-pipeline-app-2.0.0-SNAPSHOT.zip
             data_pipeline_s3_bucket: name-of-the-s3-bucket-with-the-data-to-process
             data_pipeline_hicn_hash_iterations: "{{ vault_data_pipeline_hicn_hash_iterations }}"
             data_pipeline_hicn_hash_pepper: "{{ vault_data_pipeline_hicn_hash_pepper }}"

--- a/ops/ansible/roles/bfd-pipeline/defaults/main.yml
+++ b/ops/ansible/roles/bfd-pipeline/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+bfd_version: 1.0.0-SNAPSHOT
 env_name_std: 'unknown-environment'
 
 data_pipeline_dir: /usr/local/bluebutton-data-pipeline

--- a/ops/ansible/roles/bfd-pipeline/templates/bfd-pipeline-service.sh.j2
+++ b/ops/ansible/roles/bfd-pipeline/templates/bfd-pipeline-service.sh.j2
@@ -77,7 +77,7 @@ export BFD_ENV_NAME='{{ env_name_std }}'
 # Set some additional variables.
 JVM_ARGS='{{ data_pipeline_jvm_args }}'
 
-exec "{{ data_pipeline_dir }}/bfd-pipeline-app-1.0.0-SNAPSHOT/bfd-pipeline-app.sh" \
+exec "{{ data_pipeline_dir }}/bfd-pipeline-app-{{ bfd_version }}/bfd-pipeline-app.sh" \
 	${JVM_ARGS} \
 	-Djava.io.tmpdir={{ data_pipeline_tmp_dir }} -Dorg.jboss.logging.provider=slf4j \
 	&>> "{{ data_pipeline_dir }}/bluebutton-data-pipeline.log"

--- a/ops/ansible/roles/bfd-pipeline/test/run-tests.sh
+++ b/ops/ansible/roles/bfd-pipeline/test/run-tests.sh
@@ -1,21 +1,55 @@
 #!/usr/bin/env bash
 
-##
-# This script runs our test cases locally, via Docker.
-##
-
 # Stop immediately if any command returns a non-zero result.
 set -eou pipefail
 
-# These variables can be adjusted to change which test is run.
+function help() {
+    echo "This script runs our test cases locally, via Docker."
+    echo "Usage: ${0} [-e extra-vars] [-hk] [-i image] [bfd_version]"
+    echo "Options:"
+    echo "  ${0} -e <extra-vars>: [e]xtra variables for ansible-playbook."
+    echo "  ${0} -h:              [h]elp displays this message and exits."
+    echo "  ${0} -i <ID>:         [i]mage id set in 'ghcr.io/cmsgov/bfd-apps:<ID>'. Defaults to current commit hash."
+    echo "  ${0} -k:              [k]eep the container under test instead of removing it. Defaults to removing the container."
+}
+
+# exported after getopts below...
+REMOVE_CONTAINER=true
+BFD_APPS_IMAGE_ID="$(git rev-parse --short HEAD)"
+
 export ROLE=bfd-pipeline
 export CONTAINER_NAME="$ROLE"
 export TEST_PLAY=test_basic.yml
 export ANSIBLE_SPEC="ansible"
-# use input "$1" or default to current commit's short sha
-export BFD_APPS_IMAGE_ID="${1:-$(git rev-parse --short HEAD)}"
-export ARTIFACT_DIRECTORY=".m2/repository/gov/cms/bfd/bfd-pipeline-app/1.0.0-SNAPSHOT"
-export ARTIFACT="bfd-pipeline-app-1.0.0-SNAPSHOT.zip"
+
+# iterate getopts
+while getopts "e:i:hk" option; do
+    case "$option" in
+      e) # extra-vars
+        EXTRA_VARS="$OPTARG"
+        ;;
+      h) # help
+        help
+        exit
+        ;;
+      i) # image id
+        BFD_APPS_IMAGE_ID="$OPTARG";;
+      k) # keep container
+        REMOVE_CONTAINER=false
+        ;;
+     \?) # Invalid
+        help
+        exit 1
+        ;;
+    esac
+done
+shift "$((OPTIND-1))"
+
+export BFD_VERSION="${1:-1.0.0-SNAPSHOT}"
+export ARTIFACT_DIRECTORY=".m2/repository/gov/cms/bfd/bfd-pipeline-app/${BFD_VERSION}"
+export ARTIFACT="bfd-pipeline-app-${BFD_VERSION}.zip"
+
+export REMOVE_CONTAINER EXTRA_VARS BFD_APPS_IMAGE_ID
 
 # Determine the directory that this script is in.
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/ops/ansible/roles/bfd-pipeline/test/test.sh
+++ b/ops/ansible/roles/bfd-pipeline/test/test.sh
@@ -9,7 +9,6 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Run everything from that directory.
 cd "$SCRIPT_DIR"
 
-# Re-activate existing virtualenv or exit 1
 if [ ! -d venv ]; then
   echo 'Error: Missing directory venv.'
   exit 1
@@ -20,7 +19,7 @@ source venv/bin/activate
 ansible-playbook "$TEST_PLAY" --inventory=inventory.docker.yaml --syntax-check
 
 # Run the Ansible test case.
-ansible-playbook "$TEST_PLAY" --inventory=inventory.docker.yaml
+ansible-playbook "$TEST_PLAY" --inventory=inventory.docker.yaml --extra-vars "$EXTRA_VARS" --extra-vars bfd_version="$BFD_VERSION"
 
 # Run the role/playbook again, checking to make sure it's idempotent.
 if ansible-playbook "$TEST_PLAY" --inventory=inventory.docker.yaml | tee /dev/stderr | grep -q "${CONTAINER_NAME}.*changed=0.*failed=0"; then

--- a/ops/ansible/roles/bfd-pipeline/test/test_basic.yml
+++ b/ops/ansible/roles/bfd-pipeline/test/test_basic.yml
@@ -9,7 +9,7 @@
       import_role:
         name: bfd-pipeline
       vars:
-        data_pipeline_zip: "{{ lookup('env','HOME') }}/.m2/repository/gov/cms/bfd/bfd-pipeline-app/1.0.0-SNAPSHOT/bfd-pipeline-app-1.0.0-SNAPSHOT.zip"
+        data_pipeline_zip: "{{ lookup('env','HOME') }}/.m2/repository/gov/cms/bfd/bfd-pipeline-app/{{ bfd_version }}/bfd-pipeline-app-{{ bfd_version }}.zip"
         data_pipeline_s3_bucket: 'example-fake'  # Doesn't need to actually exist.
         data_pipeline_hicn_hash_iterations: '42'  # NIST recommends at least 1000
         data_pipeline_hicn_hash_pepper: '6E6F747468657265616C706570706572'  # Hex-encoded "nottherealpepper".

--- a/ops/ansible/roles/bfd-server/defaults/main.yml
+++ b/ops/ansible/roles/bfd-server/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-
-# The directory that the Blue Button Data Server will be installed to. 
+bfd_version: 1.0.0-SNAPSHOT
+# The directory that the Blue Button Data Server will be installed to.
 data_server_dir: /usr/local/bfd-server
 
 # The directory that will be set as the 'java.io.tmpdir'

--- a/ops/ansible/roles/bfd-server/tasks/install.yml
+++ b/ops/ansible/roles/bfd-server/tasks/install.yml
@@ -79,7 +79,7 @@
 
 - name: Find New Relic Agent
   find:
-    paths: "{{ data_server_dir }}/bfd-server-launcher-1.0.0-SNAPSHOT/lib/"
+    paths: "{{ data_server_dir }}/bfd-server-launcher-{{ bfd_version }}/lib/"
     pattern: newrelic-agent*.jar
   register: find_nra
 

--- a/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
+++ b/ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2
@@ -4,7 +4,7 @@
 export BFD_PORT='{{ data_server_appserver_https_port }}'
 export BFD_KEYSTORE='{{ data_server_dir }}/bluebutton-appserver-keystore.pfx'
 export BFD_TRUSTSTORE='{{ data_server_dir }}/bluebutton-appserver-truststore.pfx'
-export BFD_WAR='{{ data_server_dir }}/{{ data_server_war | basename }}'
+export BFD_WAR="$(find {{ data_server_dir }} -name 'bfd-server-war-*.war')"
 
 # The WAR picks up its config from Java system properties, so set some variables we can use for
 # those.
@@ -184,7 +184,7 @@ service_startup_check() {
 JVM_ARGS='{{ data_server_appserver_jvmargs }}'
 
 # 3... 2... 1... launch!
-bfd-server-launcher-1.0.0-SNAPSHOT/bfd-server-launcher.sh \
+bfd-server-launcher-{{ bfd_version }}/bfd-server-launcher.sh \
   -javaagent:{{ data_server_dir }}/newrelic/newrelic.jar \
   ${JVM_ARGS} \
   "-DbfdServer.logs.dir=${LOGS_DIR}" \

--- a/ops/ansible/roles/bfd-server/test/test.sh
+++ b/ops/ansible/roles/bfd-server/test/test.sh
@@ -9,7 +9,6 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Run everything from that directory.
 cd "$SCRIPT_DIR"
 
-# Re-activate existing virtualenv or exit 1
 if [ ! -d venv ]; then
   echo 'Error: Missing directory venv.'
   exit 1
@@ -20,4 +19,4 @@ source venv/bin/activate
 ansible-playbook "$TEST_PLAY" --syntax-check --inventory=inventory.docker.yaml
 
 # Run the Ansible test case.
-ansible-playbook "$TEST_PLAY" --inventory=inventory.docker.yaml
+ansible-playbook "$TEST_PLAY" --inventory=inventory.docker.yaml --extra-vars "$EXTRA_VARS" --extra-vars bfd_version="$BFD_VERSION"

--- a/ops/ansible/roles/bfd-server/test/test_basic.yml
+++ b/ops/ansible/roles/bfd-server/test/test_basic.yml
@@ -12,8 +12,8 @@
       vars:
         # TODO: data_server_appserver_https_port anchor to be used in subsequent verification step, e.g. external curl
         data_server_appserver_https_port: &data_server_appserver_https_port "7443"
-        data_server_launcher: "{{ lookup('env','HOME') }}/.m2/repository/gov/cms/bfd/bfd-server-launcher/1.0.0-SNAPSHOT/bfd-server-launcher-1.0.0-SNAPSHOT.zip"
-        data_server_war: "{{ lookup('env','HOME') }}/.m2/repository/gov/cms/bfd/bfd-server-war/1.0.0-SNAPSHOT/bfd-server-war-1.0.0-SNAPSHOT.war"
+        data_server_launcher: "{{ lookup('env','HOME') }}/.m2/repository/gov/cms/bfd/bfd-server-launcher/{{ bfd_version }}/bfd-server-launcher-{{ bfd_version }}.zip"
+        data_server_war: "{{ lookup('env','HOME') }}/.m2/repository/gov/cms/bfd/bfd-server-war/{{ bfd_version }}/bfd-server-war-{{ bfd_version }}.war"
         data_server_ssl_client_certificates:
           - alias: client_foo
             certificate: |-

--- a/ops/deploy-ccs.groovy
+++ b/ops/deploy-ccs.groovy
@@ -85,16 +85,20 @@ def buildAppAmis(String gitBranchName, String gitCommitId, AmiIds amiIds, AppBui
 	dir('ops/ansible/playbooks-ccs'){
 
 		writeJSON file: "${workspace}/ops/ansible/playbooks-ccs/extra_vars.json", json: extraVars
-			packerBuildAmis(amiIds.platinumAmiId, gitBranchName, gitCommitId,
-					"../../packer/build_bfd-all.json")
 
-			amiIdsWrapper.platinumAmiId = amiIds.platinumAmiId
-			amiIdsWrapper.bfdPipelineAmiId = extractAmiIdFromPackerManifest(readFile(
-						file: "${workspace}/ops/ansible/playbooks-ccs/manifest_data-pipeline.json"))
-			amiIdsWrapper.bfdServerAmiId = extractAmiIdFromPackerManifest(readFile(
-						file: "${workspace}/ops/ansible/playbooks-ccs/manifest_data-server.json"))
-			amiIdsWrapper.bfdMigratorAmiId = extractAmiIdFromPackerManifest(readFile(
-						file: "${workspace}/ops/ansible/playbooks-ccs/manifest_db-migrator.json"))
+		packerBuildAmis(amiIds.platinumAmiId, gitBranchName, gitCommitId,
+				"../../packer/build_bfd-all.json")
+
+		amiIdsWrapper.platinumAmiId = amiIds.platinumAmiId
+
+		amiIdsWrapper.bfdPipelineAmiId = extractAmiIdFromPackerManifest(readFile(
+			file: "${workspace}/ops/ansible/playbooks-ccs/manifest_data-pipeline.json"))
+
+		amiIdsWrapper.bfdServerAmiId = extractAmiIdFromPackerManifest(readFile(
+			file: "${workspace}/ops/ansible/playbooks-ccs/manifest_data-server.json"))
+
+		amiIdsWrapper.bfdMigratorAmiId = extractAmiIdFromPackerManifest(readFile(
+			file: "${workspace}/ops/ansible/playbooks-ccs/manifest_db-migrator.json"))
 	}
 
 	return amiIdsWrapper

--- a/ops/deploy-ccs.groovy
+++ b/ops/deploy-ccs.groovy
@@ -74,16 +74,17 @@ def findAmis(String branchName) {
 def buildAppAmis(String gitBranchName, String gitCommitId, AmiIds amiIds, AppBuildResults appBuildResults) {
 	amiIdsWrapper = new AmiIds();
 
-	amis = [
-		'data_server_launcher': "${workspace}/${appBuildResults.dataServerLauncher}",
-		'data_server_war': "${workspace}/${appBuildResults.dataServerWar}",
-		'data_pipeline_zip': "${workspace}/${appBuildResults.dataPipelineZip}",
-		'db_migrator_zip': "${workspace}/${appBuildResults.dbMigratorZip}"
+	extraVars = [
+		'data_server_launcher': "${appBuildResults.dataServerLauncher}",
+		'data_server_war': "${appBuildResults.dataServerWar}",
+		'data_pipeline_zip': "${appBuildResults.dataPipelineZip}",
+		'db_migrator_zip': "${appBuildResults.dbMigratorZip}",
+		'bfd_version': sh(returnStdout: true, script: "yq '.project.version' ${workspace}/apps/pom.xml").trim()
 	]
 
 	dir('ops/ansible/playbooks-ccs'){
 
-		writeJSON file: "${workspace}/ops/ansible/playbooks-ccs/extra_vars.json", json: amis
+		writeJSON file: "${workspace}/ops/ansible/playbooks-ccs/extra_vars.json", json: extraVars
 			packerBuildAmis(amiIds.platinumAmiId, gitBranchName, gitCommitId,
 					"../../packer/build_bfd-all.json")
 

--- a/ops/terraform/services/server/modules/bfd_server_asg/templates/fhir_server.tpl
+++ b/ops/terraform/services/server/modules/bfd_server_asg/templates/fhir_server.tpl
@@ -39,7 +39,6 @@ cat <<EOF > extra_vars.json
   "data_server_new_relic_app_name": "BFD Server ({{ env_name_std }})",
   "data_server_new_relic_environment": "{{ env_name_std }}",
   "data_server_tmp_dir": "{{ data_server_dir }}/tmp",
-  "data_server_war": "bfd-server-war-1.0.0-SNAPSHOT.war",
   "data_server_db_url": "${data_server_db_url}",
   "env": "${env}",
   "launch_lifecycle_hook": "${launch_lifecycle_hook}"


### PR DESCRIPTION
**JIRA Ticket:**
[BFD-3091](https://jira.cms.gov/browse/BFD-3091)

**User Story or Bug Summary:**
Replace static, 1.0.0-SNAPSHOT references with a dynamic version in workflows centered around ansible.

---

### What Does This PR Do?
This introduces 2 larger changes across BFD's delivery and deployment mechanisms:
* standardize the ansible test _harness_ and scripting entrypoints to accept an optional image flag and mandatory `bfd_version` positional argument for ansible roles supporting bfd-db-migrator, bfd-pipeline, and bfd-server.
* generally defer to the version encoded in `apps/pom.xml` as a stored, ansible variable `bfd_version` _or_ accurately divine script/artifact locations through other, automatic means where possible

#### Future Work
* Inputs for `bfd_version` and the ansible default value is 1.0.0-SNAPSHOT. It might be better to take this default away on the heels of BFD-2906, et al
* The `bfd_version` is a bit of a kludge to facilitate testing the ansible roles–there are some fairly straightforward ways to avoid this, it will just take a little more time, effort, and a few additional lines to accommodate. Our role testing executes both install and launch _scopes_ (installation (via `--tag pre-ami`) is where a version string can be helpful) which makes a `bfd_version` variable too convenient ☹️
* `bfd_version` would probably better serve us as an override; in the absence of an override, the automation should take care of itself to find the appropriate artifacts and paths
* @billie-rose pointed out some of the weirdness surrounding the resultant `ansible-playbook` call that tends to result in a functional, if marked, doubling of `--extra-vars` without arguments, e.g. `ansible-playbook test_basic.yml --inventory=inventory.docker.yaml --extra-vars --extra-vars bfd_version="1.0.0-SNAPSHOT"`. Along with the other treatment of `bfd_version` (further evidence that we need to chase a better solution), we should address this, too.


### What Should Reviewers Watch For?

* Verify successful deployment to `test`: https://jenkins-east.cloud.cms.gov/bfd/job/bfd-build-deploy/job/PR-2093/ 
* Verify all PR security questions and checklists have been completed and addressed.

### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [x] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [x] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [x] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] The data dictionary has been updated with any field mapping changes, if any were made.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    