### PR TITLE
Rick/bfd 3077 deploy from nonmaster

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -185,10 +185,13 @@ try {
 			stage('Set Branch Name') {
 				currentStage = env.STAGE_NAME
 				script {
-					if (env.BRANCH_NAME.startsWith('PR')) {
+					if (env.BRANCH_NAME != null && env.BRANCH_NAME.startsWith('PR')) {
 						gitBranchName = env.CHANGE_BRANCH
 					} else {
 						gitBranchName = env.BRANCH_NAME
+					}
+					if (gitBranchName == null) {
+						gitBranchName = "rick/BFD-3077-deploy-from-nonmaster"
 					}
 				}
 			}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,6 +71,8 @@ if (params.server_regression_image_override != null) {
     server_regression_image_override = ""
 }
 
+println "hello: ${env.BRANCH_NAME}"
+
 println "deploy_prod_from_non_master: ${deploy_prod_from_non_master}"
 println "deploy_prod_skip_confirm: ${deploy_prod_skip_confirm}"
 println "user_latest_images: ${use_latest_images}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ properties([
 		booleanParam(name: 'use_latest_images', description: 'When true, defer to latest available AMIs. Skips App and App Image Stages.', defaultValue: false),
 		booleanParam(name: 'verbose_mvn_logging', description: 'When true, `mvn` will produce verbose logs.', defaultValue: false),
 		booleanParam(name: 'force_migrator_deployment', description: 'When true, force the migrator to deploy.', defaultValue: false),
-		string(name: 'server_regression_image_override', description: 'Overrides the Docker image tag used when deploying the server-regression lambda', defaultValue: null)
+		string(name: 'server_regression_image_override', description: 'Overrides the Docker image tag used when deploying the server-regression lambda', defaultValue: "")
 	]),
 	buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: ''))
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,12 +36,6 @@ properties([
 	buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: ''))
 ])
 
-println "deploy_prod_from_non_master: ${params.deploy_prod_from_non_master}"
-println "deploy_prod_skip_confirm: ${params.deploy_prod_skip_confirm}"
-println "use_latest_images: ${params.use_latest_images}"
-println "force_migrator_deployment: ${params.force_migrator_deployment}"
-println "server_regression_image_overrie: ${params.server_regression_image_override}"
-
 // These variables are accessible throughout this file (except inside methods and classes).
 def scriptForApps
 def scriptForDeploys
@@ -119,7 +113,7 @@ def sendNotifications(String buildStatus = '', String stageName = '', String git
 	}
 
 	// send Slack messages
-	// slackSend(color: buildColor, message: slackMsg)
+	slackSend(color: buildColor, message: slackMsg)
 
 	// future notifications can go here. (email, other channels, etc)
 }
@@ -148,13 +142,10 @@ try {
 			stage('Set Branch Name') {
 				currentStage = env.STAGE_NAME
 				script {
-					if (env.BRANCH_NAME != null && env.BRANCH_NAME.startsWith('PR')) {
+					if (env.BRANCH_NAME.startsWith('PR')) {
 						gitBranchName = env.CHANGE_BRANCH
 					} else {
 						gitBranchName = env.BRANCH_NAME
-					}
-					if (gitBranchName == null) {
-						gitBranchName = "rick/BFD-3077-deploy-from-nonmaster"
 					}
 				}
 			}
@@ -192,7 +183,7 @@ try {
 					gitRepoUrl = sh(returnStdout: true, script: 'git config --get remote.origin.url').trim().replaceAll(/\.git$/,"")
 
 					// Send notifications that the build has started
-					//sendNotifications('STARTED', currentStage, gitCommitId, gitRepoUrl)
+					sendNotifications('STARTED', currentStage, gitCommitId, gitRepoUrl)
 				}
 			}
 
@@ -656,5 +647,5 @@ try {
 	currentBuild.result = "FAILURE"
 	throw ex
 } finally {
-	//sendNotifications(currentBuild.currentResult, currentStage, gitCommitId, gitRepoUrl)
+	sendNotifications(currentBuild.currentResult, currentStage, gitCommitId, gitRepoUrl)
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ properties([
 		booleanParam(name: 'use_latest_images', description: 'When true, defer to latest available AMIs. Skips App and App Image Stages.', defaultValue: false),
 		booleanParam(name: 'verbose_mvn_logging', description: 'When true, `mvn` will produce verbose logs.', defaultValue: false),
 		booleanParam(name: 'force_migrator_deployment', description: 'When true, force the migrator to deploy.', defaultValue: false),
-		string(name: 'server_regression_image_override', description: 'Overrides the Docker image tag used when deploying the server-regression lambda', defaultValue: "")
+		string(name: 'server_regression_image_override', description: 'Overrides the Docker image tag used when deploying the server-regression lambda', defaultValue: null)
 	]),
 	buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: ''))
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,18 +36,46 @@ properties([
 	buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: ''))
 ])
 
-def deploy_prod_from_non_master = params.deploy_prod_from_non_master
-def deploy_prod_skip_confirm = params.deploy_prod_skip_confirm
-def use_latest_images = params.use_latest_images
-def force_migrator_deployment = params.force_migrator_deployment
-def server_regression_image_override = params.server_regression_image_override
+def deploy_prod_from_non_master
+if (params.deploy_prod_from_non_master != null) {
+    deploy_prod_from_non_master = params.deploy_prod_from_non_master
+} else {
+	deploy_prod_from_non_master = true
+}
+
+def deploy_prod_skip_confirm
+if (params.deploy_prod_skip_confirm != null) {
+    deploy_prod_skip_confirm = params.deploy_prod_skip_confirm
+} else {
+    deploy_prod_skip_confirm = false
+}
+
+def use_latest_images
+if (params.use_latest_images != null) {
+    use_latest_images = params.use_latest_images
+} else {
+	use_latest_images = false
+}
+
+def force_migrator_deployment
+if (params.force_migrator_deployment != null) {
+	force_migrator_deployment = verboseMaven = params.verbose_mvn_logging
+} else {
+    force_migrator_deployment = false
+}
+
+def server_regression_image_override
+if (params.server_regression_image_override != null) {
+    server_regression_image_override = params.server_regression_image_override
+} else {
+    server_regression_image_override = ""
+}
 
 println "deploy_prod_from_non_master: ${deploy_prod_from_non_master}"
 println "deploy_prod_skip_confirm: ${deploy_prod_skip_confirm}"
 println "user_latest_images: ${use_latest_images}"
 println "force_migrator_deployment: ${force_migrator_deployment}"
 println "server_regression_image_overrie: ${server_regression_image_override}"
-
 
 // These variables are accessible throughout this file (except inside methods and classes).
 def scriptForApps

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -126,7 +126,6 @@ echo "Starting pipeline"
 try {
 	// See ops/jenkins/cbc-build-push.sh for this image's definition.
 	podTemplate(
-			echo "In podTemplate"
 		containers: [
 			containerTemplate(
 				name: 'bfd-cbc-build',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -115,7 +115,7 @@ def sendNotifications(String buildStatus = '', String stageName = '', String git
 	}
 
 	// send Slack messages
-	slackSend(color: buildColor, message: slackMsg)
+//	slackSend(color: buildColor, message: slackMsg)
 
 	// future notifications can go here. (email, other channels, etc)
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@
 
 properties([
 	parameters([
-		booleanParam(name: 'deploy_prod_from_non_master', defaultValue: false, description: 'Whether to deploy to prod-like envs for builds of this project\'s non-master branches.'),
+		booleanParam(name: 'deploy_prod_from_non_master', defaultValue: true, description: 'Whether to deploy to prod-like envs for builds of this project\'s non-master branches.'),
 		booleanParam(name: 'deploy_prod_skip_confirm', defaultValue: false, description: 'Whether to prompt for confirmation before deploying to most prod-like envs.'),
 		booleanParam(name: 'use_latest_images', description: 'When true, defer to latest available AMIs. Skips App and App Image Stages.', defaultValue: false),
 		booleanParam(name: 'verbose_mvn_logging', description: 'When true, `mvn` will produce verbose logs.', defaultValue: false),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,6 +42,13 @@ def use_latest_images = params.use_latest_images
 def force_migrator_deployment = params.force_migrator_deployment
 def server_regression_image_override = params.server_regression_image_override
 
+println "deploy_prod_from_non_master: ${deploy_prod_from_non_master}"
+println "deploy_prod_skip_confirm: ${deploy_prod_skip_confirm}"
+println "user_latest_images: ${use_latest_images}"
+println "force_migrator_deployment: ${force_migrator_deployment}"
+println "server_regression_image_overrie: ${server_regression_image_override}"
+
+
 // These variables are accessible throughout this file (except inside methods and classes).
 def scriptForApps
 def scriptForDeploys

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,8 @@
  * </p>
  */
 
+echo "Starting Jenkinsfile"
+
 properties([
 	parameters([
 		booleanParam(name: 'deploy_prod_from_non_master', defaultValue: true, description: 'Whether to deploy to prod-like envs for builds of this project\'s non-master branches.'),
@@ -118,10 +120,13 @@ def sendNotifications(String buildStatus = '', String stageName = '', String git
 	// future notifications can go here. (email, other channels, etc)
 }
 
+echo "Starting pipeline"
+
 // begin pipeline
 try {
 	// See ops/jenkins/cbc-build-push.sh for this image's definition.
 	podTemplate(
+			echo "In podTemplate"
 		containers: [
 			containerTemplate(
 				name: 'bfd-cbc-build',

--- a/ops/jenkins/bfd-build-apps/Jenkinsfile
+++ b/ops/jenkins/bfd-build-apps/Jenkinsfile
@@ -7,14 +7,14 @@
  */
 
 properties([
-        parameters ([
-            booleanParam(name: 'verbose_mvn_logging', description: 'When true, `mvn` will produce verbose logs.',
+    parameters ([
+        booleanParam(name: 'verbose_mvn_logging', description: 'When true, `mvn` will produce verbose logs.',
                     defaultValue: false),
-            booleanParam(name: 'force_build_docker_host_ami',
+        booleanParam(name: 'force_build_docker_host_ami',
                     description: 'When true, the docker host AMI based on branch will be built. Note: `force_build_amis` must' +
                             'also be true.', defaultValue: false)
-        ])
-        ])
+    ])
+])
 
 // These variables are accessible throughout this file (except inside methods and classes).
 def verboseMaven = params.verbose_mvn_logging

--- a/ops/jenkins/bfd-build-apps/Jenkinsfile
+++ b/ops/jenkins/bfd-build-apps/Jenkinsfile
@@ -6,12 +6,14 @@
  * </p>
  */
 
+properties([
         parameters ([
             booleanParam(name: 'verbose_mvn_logging', description: 'When true, `mvn` will produce verbose logs.',
                     defaultValue: false),
             booleanParam(name: 'force_build_docker_host_ami',
                     description: 'When true, the docker host AMI based on branch will be built. Note: `force_build_amis` must' +
                             'also be true.', defaultValue: false)
+        ])
         ])
 
 // These variables are accessible throughout this file (except inside methods and classes).

--- a/ops/jenkins/bfd-build-apps/Jenkinsfile
+++ b/ops/jenkins/bfd-build-apps/Jenkinsfile
@@ -94,6 +94,7 @@ spec:
         }
     }
 
+    properties(
     parameters {
         booleanParam(name: 'verbose_mvn_logging',
             description: 'When true, `mvn` will produce verbose logs.',
@@ -102,7 +103,7 @@ spec:
             description: 'When true, the docker host AMI based on branch will be built. Note: `force_build_amis` must' +
                 'also be true.',
             defaultValue: false)
-    }
+    })
 
     stages {
         /* This stage switches the gitBranchName (needed for our CCS downsream stages)

--- a/ops/jenkins/bfd-build-apps/Jenkinsfile
+++ b/ops/jenkins/bfd-build-apps/Jenkinsfile
@@ -6,6 +6,16 @@
  * </p>
  */
 
+properties([
+        parameters ([
+            booleanParam(name: 'verbose_mvn_logging', description: 'When true, `mvn` will produce verbose logs.',
+                    defaultValue: false),
+            booleanParam(name: 'force_build_docker_host_ami',
+                    description: 'When true, the docker host AMI based on branch will be built. Note: `force_build_amis` must' +
+                            'also be true.', defaultValue: false)
+        ])
+        ])
+
 // These variables are accessible throughout this file (except inside methods and classes).
 def verboseMaven = params.verbose_mvn_logging
 def appBuildResults
@@ -93,17 +103,6 @@ spec:
 """
         }
     }
-
-    properties(
-    parameters {
-        booleanParam(name: 'verbose_mvn_logging',
-            description: 'When true, `mvn` will produce verbose logs.',
-            defaultValue: false)
-        booleanParam(name: 'force_build_docker_host_ami',
-            description: 'When true, the docker host AMI based on branch will be built. Note: `force_build_amis` must' +
-                'also be true.',
-            defaultValue: false)
-    })
 
     stages {
         /* This stage switches the gitBranchName (needed for our CCS downsream stages)

--- a/ops/jenkins/bfd-build-apps/Jenkinsfile
+++ b/ops/jenkins/bfd-build-apps/Jenkinsfile
@@ -6,14 +6,12 @@
  * </p>
  */
 
-properties([
         parameters ([
             booleanParam(name: 'verbose_mvn_logging', description: 'When true, `mvn` will produce verbose logs.',
                     defaultValue: false),
             booleanParam(name: 'force_build_docker_host_ami',
                     description: 'When true, the docker host AMI based on branch will be built. Note: `force_build_amis` must' +
                             'also be true.', defaultValue: false)
-        ])
         ])
 
 // These variables are accessible throughout this file (except inside methods and classes).

--- a/ops/jenkins/bfd-build-deploy/Jenkinsfile
+++ b/ops/jenkins/bfd-build-deploy/Jenkinsfile
@@ -49,7 +49,7 @@
          name: 'force_migrator_deployment',
          description: 'When true, force the migrator to deploy.',
          defaultValue: false
-         )
+         ),
 
          string(
          name: 'server_regression_image_override',

--- a/ops/jenkins/bfd-build-deploy/Jenkinsfile
+++ b/ops/jenkins/bfd-build-deploy/Jenkinsfile
@@ -6,6 +6,60 @@
  * </p>
  */
 
+ properties([
+     parameters ([
+         booleanParam(name: 'verbose_mvn_logging',
+         description: 'When true, `mvn` will produce verbose logs.',
+         defaultValue: false),
+
+         booleanParam(name: 'force_build_amis',
+         description: 'When true, AMIs based on branch will be built.',
+         defaultValue: false),
+
+         booleanParam(name: 'force_build_docker_host_ami',
+         description: 'When true, the docker host AMI based on branch will be built. Note: `force_build_amis` must' +
+                 'also be true.',
+         defaultValue: false),
+
+         string(
+         name: 'env',
+         description: 'The BFD Environment to deploy apps to'
+         ),
+
+         string(
+         name: 'migrator_ami_override',
+         description: 'The AMI ID to deploy migrator from',
+         defaultValue: null
+         ),
+
+         string(
+         name: 'pipeline_ami_override',
+         description: 'The AMI ID to deploy pipeline from',
+         defaultValue: null
+         ),
+
+         string(
+         name: 'server_ami_override',
+         description: 'The AMI ID to deploy server from',
+         defaultValue: null
+         ),
+
+
+         booleanParam(
+         name: 'force_migrator_deployment',
+         description: 'When true, force the migrator to deploy.',
+         defaultValue: false
+         )
+
+         string(
+         name: 'server_regression_image_override',
+         description: 'Overrides the Docker image tag used when deploying the server-regression lambda',
+         defaultValue: null
+         )
+     ])
+ ])
+
+
 // These variables are accessible throughout this file (except inside methods and classes).
 def gitBranchName
 
@@ -36,56 +90,56 @@ spec:
         }
       }
 
-  parameters {
-        booleanParam(name: 'verbose_mvn_logging',
-        description: 'When true, `mvn` will produce verbose logs.',
-        defaultValue: false)
-
-        booleanParam(name: 'force_build_amis',
-        description: 'When true, AMIs based on branch will be built.',
-        defaultValue: false)
-
-        booleanParam(name: 'force_build_docker_host_ami',
-        description: 'When true, the docker host AMI based on branch will be built. Note: `force_build_amis` must' +
-                'also be true.',
-        defaultValue: false)
-
-        string(
-        name: 'env',
-        description: 'The BFD Environment to deploy apps to'
-        )
-
-        string(
-        name: 'migrator_ami_override',
-        description: 'The AMI ID to deploy migrator from',
-        defaultValue: null
-        )
-
-        string(
-        name: 'pipeline_ami_override',
-        description: 'The AMI ID to deploy pipeline from',
-        defaultValue: null
-        )
-
-        string(
-        name: 'server_ami_override',
-        description: 'The AMI ID to deploy server from',
-        defaultValue: null
-        )
-
-
-        booleanParam(
-        name: 'force_migrator_deployment',
-        description: 'When true, force the migrator to deploy.',
-        defaultValue: false
-        )
-
-        string(
-        name: 'server_regression_image_override',
-        description: 'Overrides the Docker image tag used when deploying the server-regression lambda',
-        defaultValue: null
-        )
-  }
+//   parameters {
+//         booleanParam(name: 'verbose_mvn_logging',
+//         description: 'When true, `mvn` will produce verbose logs.',
+//         defaultValue: false)
+//
+//         booleanParam(name: 'force_build_amis',
+//         description: 'When true, AMIs based on branch will be built.',
+//         defaultValue: false)
+//
+//         booleanParam(name: 'force_build_docker_host_ami',
+//         description: 'When true, the docker host AMI based on branch will be built. Note: `force_build_amis` must' +
+//                 'also be true.',
+//         defaultValue: false)
+//
+//         string(
+//         name: 'env',
+//         description: 'The BFD Environment to deploy apps to'
+//         )
+//
+//         string(
+//         name: 'migrator_ami_override',
+//         description: 'The AMI ID to deploy migrator from',
+//         defaultValue: null
+//         )
+//
+//         string(
+//         name: 'pipeline_ami_override',
+//         description: 'The AMI ID to deploy pipeline from',
+//         defaultValue: null
+//         )
+//
+//         string(
+//         name: 'server_ami_override',
+//         description: 'The AMI ID to deploy server from',
+//         defaultValue: null
+//         )
+//
+//
+//         booleanParam(
+//         name: 'force_migrator_deployment',
+//         description: 'When true, force the migrator to deploy.',
+//         defaultValue: false
+//         )
+//
+//         string(
+//         name: 'server_regression_image_override',
+//         description: 'Overrides the Docker image tag used when deploying the server-regression lambda',
+//         defaultValue: null
+//         )
+//   }
 
   stages {
     /* This stage switches the gitBranchName (needed for our CCS downsream stages)

--- a/ops/jenkins/bfd-build-platinum/Jenkinsfile
+++ b/ops/jenkins/bfd-build-platinum/Jenkinsfile
@@ -5,6 +5,17 @@
  * This script will be run by Jenkins when building platinum AMI images.
  * </p>
  */
+properties([
+	parameters([
+        string(name: 'GOLD_AMI_ID',
+        defaultValue: '',
+        description: 'In case the latest Gold image is subpar, force a platinum build with a different gold AMI.'),
+
+        booleanParam(name: 'FORCE_PLATINUM',
+        defaultValue: false,
+        description: 'Forces a new platinum build with the latest Gold AMI ID source tagged.')
+    ])
+])
 
 // These variables are accessible throughout this file (except inside methods and classes).
 def goldAmiId
@@ -100,15 +111,15 @@ spec:
         }
     }
 
-    parameters {
-        string(name: 'GOLD_AMI_ID',
-        defaultValue: '',
-        description: 'In case the latest Gold image is subpar, force a platinum build with a different gold AMI.')
-
-        booleanParam(name: 'FORCE_PLATINUM',
-        defaultValue: false,
-        description: 'Forces a new platinum build with the latest Gold AMI ID source tagged.')
-    }
+//     parameters {
+//         string(name: 'GOLD_AMI_ID',
+//         defaultValue: '',
+//         description: 'In case the latest Gold image is subpar, force a platinum build with a different gold AMI.')
+//
+//         booleanParam(name: 'FORCE_PLATINUM',
+//         defaultValue: false,
+//         description: 'Forces a new platinum build with the latest Gold AMI ID source tagged.')
+//     }
 
     // Run Every day at 7:30 AM Eastern / 11:30 AM UTC
     triggers {

--- a/ops/jenkins/bfd-data-fda/Jenkinsfile
+++ b/ops/jenkins/bfd-data-fda/Jenkinsfile
@@ -7,6 +7,13 @@
  * this is the case, then it delivers to bfd-mgmt AWS CodeArtifact Maven Repository as appropriate.
  */
 
+properties([
+	parameters([
+        booleanParam(name: 'verbose_mvn_logging', description: 'When true, `mvn` will produce verbose logs.', defaultValue: false),
+        booleanParam(name:'forceRebuild', description: 'When true, it will force a rebuild of the fda project.', defaultValue: false)
+    ])
+])
+
 pipeline {
     agent {
         kubernetes {
@@ -36,10 +43,10 @@ spec:
      triggers {
         cron('0 14 * * *')
     }
-    parameters {
-        booleanParam(name: 'verbose_mvn_logging', description: 'When true, `mvn` will produce verbose logs.', defaultValue: false)
-        booleanParam(name:'forceRebuild', description: 'When true, it will force a rebuild of the fda project.', defaultValue: false)
-    }
+//     parameters {
+//         booleanParam(name: 'verbose_mvn_logging', description: 'When true, `mvn` will produce verbose logs.', defaultValue: false)
+//         booleanParam(name:'forceRebuild', description: 'When true, it will force a rebuild of the fda project.', defaultValue: false)
+//     }
     stages {
         stage('Setup') {
             steps {

--- a/ops/jenkins/bfd-data-npi/Jenkinsfile
+++ b/ops/jenkins/bfd-data-npi/Jenkinsfile
@@ -7,6 +7,15 @@
  * this is the case, then it delivers to bfd-mgmt AWS CodeArtifact Maven Repository as appropriate.
  */
 
+properties([
+	parameters([
+        booleanParam(name: 'verbose_mvn_logging', description: 'When true, `mvn` will produce verbose logs.', defaultValue: false),
+        string(name: 'filemonth', description: 'The month of the npi file will download', defaultValue: ''),
+        string(name: 'fileyear',  description: 'The year of the npi file will download', defaultValue: ''),
+        booleanParam(name:'forceRebuild', description: 'When true, it will force a rebuild of the npi project.', defaultValue: false)
+    ])
+])
+
 pipeline {
     agent {
         kubernetes {
@@ -36,12 +45,12 @@ spec:
      triggers {
         cron('0 14 * * *')
     }
-    parameters {
-        booleanParam(name: 'verbose_mvn_logging', description: 'When true, `mvn` will produce verbose logs.', defaultValue: false)
-        string(name: 'filemonth', description: 'The month of the npi file will download', defaultValue: '')
-        string(name: 'fileyear',  description: 'The year of the npi file will download', defaultValue: '')
-        booleanParam(name:'forceRebuild', description: 'When true, it will force a rebuild of the npi project.', defaultValue: false)
-    }
+//     parameters {
+//         booleanParam(name: 'verbose_mvn_logging', description: 'When true, `mvn` will produce verbose logs.', defaultValue: false)
+//         string(name: 'filemonth', description: 'The month of the npi file will download', defaultValue: '')
+//         string(name: 'fileyear',  description: 'The year of the npi file will download', defaultValue: '')
+//         booleanParam(name:'forceRebuild', description: 'When true, it will force a rebuild of the npi project.', defaultValue: false)
+//     }
     stages {
         stage('Setup') {
             steps {

--- a/ops/jenkins/bfd-deploy-apps/Jenkinsfile
+++ b/ops/jenkins/bfd-deploy-apps/Jenkinsfile
@@ -6,6 +6,45 @@
  * </p>
  */
 
+properties([
+	parameters([
+        string(
+        name: 'env',
+        description: 'The BFD Environment to deploy apps to'
+        ),
+
+        string(
+        name: 'migrator_ami_override',
+        description: 'The AMI ID to deploy migrator from',
+        defaultValue: null
+        ),
+
+        string(
+        name: 'pipeline_ami_override',
+        description: 'The AMI ID to deploy pipeline from',
+        defaultValue: null
+        ),
+
+        string(
+        name: 'server_ami_override',
+        description: 'The AMI ID to deploy server from',
+        defaultValue: null
+        ),
+
+        booleanParam(
+        name: 'force_migrator_deployment',
+        description: 'When true, force the migrator to deploy.',
+        defaultValue: false
+        ),
+
+        string(
+        name: 'server_regression_image_override',
+        description: 'Overrides the Docker image tag used when deploying the server-regression lambda',
+        defaultValue: null
+        )
+    ])
+])
+
 // These variables are accessible throughout this file (except inside methods and classes).
 def gitBranchName
 def migratorScripts
@@ -98,42 +137,42 @@ spec:
         }
     }
 
-    parameters {
-        string(
-        name: 'env',
-        description: 'The BFD Environment to deploy apps to'
-        )
-
-        string(
-        name: 'migrator_ami_override',
-        description: 'The AMI ID to deploy migrator from',
-        defaultValue: null
-        )
-
-        string(
-        name: 'pipeline_ami_override',
-        description: 'The AMI ID to deploy pipeline from',
-        defaultValue: null
-        )
-
-        string(
-        name: 'server_ami_override',
-        description: 'The AMI ID to deploy server from',
-        defaultValue: null
-        )
-
-        booleanParam(
-        name: 'force_migrator_deployment',
-        description: 'When true, force the migrator to deploy.',
-        defaultValue: false
-        )
-
-        string(
-        name: 'server_regression_image_override',
-        description: 'Overrides the Docker image tag used when deploying the server-regression lambda',
-        defaultValue: null
-        )
-    }
+//     parameters {
+//         string(
+//         name: 'env',
+//         description: 'The BFD Environment to deploy apps to'
+//         )
+//
+//         string(
+//         name: 'migrator_ami_override',
+//         description: 'The AMI ID to deploy migrator from',
+//         defaultValue: null
+//         )
+//
+//         string(
+//         name: 'pipeline_ami_override',
+//         description: 'The AMI ID to deploy pipeline from',
+//         defaultValue: null
+//         )
+//
+//         string(
+//         name: 'server_ami_override',
+//         description: 'The AMI ID to deploy server from',
+//         defaultValue: null
+//         )
+//
+//         booleanParam(
+//         name: 'force_migrator_deployment',
+//         description: 'When true, force the migrator to deploy.',
+//         defaultValue: false
+//         )
+//
+//         string(
+//         name: 'server_regression_image_override',
+//         description: 'Overrides the Docker image tag used when deploying the server-regression lambda',
+//         defaultValue: null
+//         )
+//     }
 
     stages {
         stage('Set Branch Name') {

--- a/ops/jenkins/bfd-deploy-pipeline-terraservice/Jenkinsfile
+++ b/ops/jenkins/bfd-deploy-pipeline-terraservice/Jenkinsfile
@@ -1,4 +1,16 @@
 // Variables defined here are accessible throughout this file (except inside methods and classes).
+properties([
+	parameters([
+        string(name: 'env', description: 'The BFD Environment to deploy the Terraservice to'),
+        string(name: 'ami_override', description: 'BFD Pipeline override AMI ID. Optional, ' +
+            'defaults to latest Pipeline AMI from `master`'),
+        booleanParam(name: 'create_ccw_pipeline_instance', defaultValue: false,
+            description: 'Whether or not the BFD CCW Pipeline instance should be created to load data'),
+        booleanParam(name: 'create_rda_pipeline_instance', defaultValue: true,
+            description: 'Whether or not the BFD RDA Pipeline instance should be created to load data')
+    ])
+])
+
 def scriptForDeploys
 def scriptForApps
 def gitBranchName
@@ -25,27 +37,27 @@ spec:
     }
   }
 
-  parameters {
-    string(
-      name: 'env',
-      description: 'The BFD Environment to deploy the Terraservice to'
-    )
-    string(
-      name: 'ami_override',
-      description: 'BFD Pipeline override AMI ID. Optional, defaults to latest Pipeline AMI from '
-                   + '`master`'
-    )
-    booleanParam(
-      name: 'create_ccw_pipeline_instance',
-      defaultValue: false,
-      description: 'Whether or not the BFD CCW Pipeline instance should be created to load data'
-    )
-    booleanParam(
-      name: 'create_rda_pipeline_instance',
-      defaultValue: true,
-      description: 'Whether or not the BFD RDA Pipeline instance should be created to load data'
-    )
-  }
+//   parameters {
+//     string(
+//       name: 'env',
+//       description: 'The BFD Environment to deploy the Terraservice to'
+//     )
+//     string(
+//       name: 'ami_override',
+//       description: 'BFD Pipeline override AMI ID. Optional, defaults to latest Pipeline AMI from '
+//                    + '`master`'
+//     )
+//     booleanParam(
+//       name: 'create_ccw_pipeline_instance',
+//       defaultValue: false,
+//       description: 'Whether or not the BFD CCW Pipeline instance should be created to load data'
+//     )
+//     booleanParam(
+//       name: 'create_rda_pipeline_instance',
+//       defaultValue: true,
+//       description: 'Whether or not the BFD RDA Pipeline instance should be created to load data'
+//     )
+//   }
 
   stages {
     stage('Set Branch Name') {

--- a/ops/jenkins/bfd-destroy-environment/Jenkinsfile
+++ b/ops/jenkins/bfd-destroy-environment/Jenkinsfile
@@ -6,6 +6,18 @@
  * </p>
  */
 
+properties([
+	parameters([
+        string(name: 'env', description: 'The BFD ephemeral environment to destroy'),
+        booleanParam(name: 'force_plan_approval',
+            description: 'When true, force the operator to manually approve each tfplan',
+            defaultValue: true),
+        booleanParam(name: 'force_stage_approval',
+            description: 'When true, force the operator to approve each stage before continuing',
+            defaultValue: false)
+    ])
+])
+
 // These variables are accessible throughout this file (except inside methods and classes).
 def gitBranchName
 def trimmedEnv
@@ -100,22 +112,22 @@ spec:
         }
     }
 
-    parameters {
-        string(
-            name: 'env',
-            description: 'The BFD ephemeral environment to destroy'
-        )
-        booleanParam(
-            name: 'force_plan_approval',
-            description: 'When true, force the operator to manually approve each tfplan',
-            defaultValue: true
-        )
-        booleanParam(
-            name: 'force_stage_approval',
-            description: 'When true, force the operator to approve each stage before continuing',
-            defaultValue: false
-        )
-    }
+//     parameters {
+//         string(
+//             name: 'env',
+//             description: 'The BFD ephemeral environment to destroy'
+//         )
+//         booleanParam(
+//             name: 'force_plan_approval',
+//             description: 'When true, force the operator to manually approve each tfplan',
+//             defaultValue: true
+//         )
+//         booleanParam(
+//             name: 'force_stage_approval',
+//             description: 'When true, force the operator to approve each stage before continuing',
+//             defaultValue: false
+//         )
+//     }
 
     stages {
         stage('Validate parameters') {

--- a/ops/jenkins/bfd-jenkins-sonarqube/Jenkinsfile
+++ b/ops/jenkins/bfd-jenkins-sonarqube/Jenkinsfile
@@ -1,5 +1,13 @@
 #!/usr/bin/env groovy
 
+properties([
+	parameters([
+        booleanParam(name: 'verbose_mvn_logging',
+        description: 'When true, `mvn` will produce verbose logs.',
+        defaultValue: false)
+    ])
+])
+
 // These variables are accessible throughout this file (except inside methods and classes).
 def verboseMaven
 if (params.verbose_mvn_logging != null) {
@@ -54,11 +62,11 @@ spec:
 """
         }
     }
-    parameters {
-        booleanParam(name: 'verbose_mvn_logging',
-        description: 'When true, `mvn` will produce verbose logs.',
-        defaultValue: false)
-    }
+//     parameters {
+//         booleanParam(name: 'verbose_mvn_logging',
+//         description: 'When true, `mvn` will produce verbose logs.',
+//         defaultValue: false)
+//     }
     environment {
         SONAR_PROJECT_KEY = 'bfd-parent'
         SONAR_HOST_URL = 'https://sonarqube.cloud.cms.gov'

--- a/ops/jenkins/bfd-job-broker/Jenkinsfile
+++ b/ops/jenkins/bfd-job-broker/Jenkinsfile
@@ -1,3 +1,10 @@
+properties([
+	parameters([
+        string(name: 'sqs_body',
+            description: 'The body of the SQS message invoking this Pipeline. Automatically populated')
+  ])
+])
+
 pipeline {
   agent {
     kubernetes {
@@ -19,12 +26,12 @@ spec:
     }
   }
 
-  parameters {
-    string(
-      name: 'sqs_body',
-      description: 'The body of the SQS message invoking this Pipeline. Automatically populated'
-    )
-  }
+//   parameters {
+//     string(
+//       name: 'sqs_body',
+//       description: 'The body of the SQS message invoking this Pipeline. Automatically populated'
+//     )
+//   }
 
   options {
     skipDefaultCheckout()

--- a/ops/jenkins/bfd-run-pipeline-oob/Jenkinsfile
+++ b/ops/jenkins/bfd-run-pipeline-oob/Jenkinsfile
@@ -1,3 +1,40 @@
+ properties([
+ 	parameters([
+    string(
+      name: 'env',
+      description: 'The BFD Environment to run the BFD Pipeline out-of-band in'
+    ),
+    choice(
+      name: 'pipeline_variant',
+      // TODO: Update with RDA when possible
+      choices: ['ccw'],
+      description: 'The variant of BFD Pipeline to run out-of-band'
+    ),
+    string(
+      name: 'timeout_minutes',
+      defaultValue: '60',
+      description: 'The timeout, in minutes, that this Jenkin Pipeline will wait until '
+                   + 'automatically scaling-in the out-of-band BFD Pipeline instance'
+    ),
+    booleanParam(
+      name: 'lock_environment_resource',
+      defaultValue: true,
+      description: 'Whether or not the corresponding environment resource is locked while this '
+                   + 'Jenkins Pipeline is running. Setting this to false will allow for '
+                   + 'deployments and other potentially destructive actions to occur while the OOB '
+                   + 'BFD Pipeline is running'
+    ),
+    booleanParam(
+      name: 'suspend_scheduled_actions',
+      defaultValue: true,
+      description: 'Whether or not AutoScaling Scheduled Actions will be suspended on the BFD '
+                   + 'Pipeline AutoScaling Group. If this is false (toggled off), ASG Scheduled '
+                   + 'Actions created by the BFD Pipeline Scheduler will execute and could '
+                   + 'potentially destroy the Pipeline created by this Jenkins Pipeline'
+    )
+  ])
+])
+
 pipeline {
   agent {
     kubernetes {
@@ -19,40 +56,40 @@ spec:
     }
   }
 
-  parameters {
-    string(
-      name: 'env',
-      description: 'The BFD Environment to run the BFD Pipeline out-of-band in'
-    )
-    choice(
-      name: 'pipeline_variant',
-      // TODO: Update with RDA when possible
-      choices: ['ccw'],
-      description: 'The variant of BFD Pipeline to run out-of-band'
-    )
-    string(
-      name: 'timeout_minutes',
-      defaultValue: '60',
-      description: 'The timeout, in minutes, that this Jenkin Pipeline will wait until '
-                   + 'automatically scaling-in the out-of-band BFD Pipeline instance'
-    )
-    booleanParam(
-      name: 'lock_environment_resource',
-      defaultValue: true,
-      description: 'Whether or not the corresponding environment resource is locked while this '
-                   + 'Jenkins Pipeline is running. Setting this to false will allow for '
-                   + 'deployments and other potentially destructive actions to occur while the OOB '
-                   + 'BFD Pipeline is running'
-    )
-    booleanParam(
-      name: 'suspend_scheduled_actions',
-      defaultValue: true,
-      description: 'Whether or not AutoScaling Scheduled Actions will be suspended on the BFD '
-                   + 'Pipeline AutoScaling Group. If this is false (toggled off), ASG Scheduled '
-                   + 'Actions created by the BFD Pipeline Scheduler will execute and could '
-                   + 'potentially destroy the Pipeline created by this Jenkins Pipeline'
-    )
-  }
+//   parameters {
+//     string(
+//       name: 'env',
+//       description: 'The BFD Environment to run the BFD Pipeline out-of-band in'
+//     )
+//     choice(
+//       name: 'pipeline_variant',
+//       // TODO: Update with RDA when possible
+//       choices: ['ccw'],
+//       description: 'The variant of BFD Pipeline to run out-of-band'
+//     )
+//     string(
+//       name: 'timeout_minutes',
+//       defaultValue: '60',
+//       description: 'The timeout, in minutes, that this Jenkin Pipeline will wait until '
+//                    + 'automatically scaling-in the out-of-band BFD Pipeline instance'
+//     )
+//     booleanParam(
+//       name: 'lock_environment_resource',
+//       defaultValue: true,
+//       description: 'Whether or not the corresponding environment resource is locked while this '
+//                    + 'Jenkins Pipeline is running. Setting this to false will allow for '
+//                    + 'deployments and other potentially destructive actions to occur while the OOB '
+//                    + 'BFD Pipeline is running'
+//     )
+//     booleanParam(
+//       name: 'suspend_scheduled_actions',
+//       defaultValue: true,
+//       description: 'Whether or not AutoScaling Scheduled Actions will be suspended on the BFD '
+//                    + 'Pipeline AutoScaling Group. If this is false (toggled off), ASG Scheduled '
+//                    + 'Actions created by the BFD Pipeline Scheduler will execute and could '
+//                    + 'potentially destroy the Pipeline created by this Jenkins Pipeline'
+//     )
+//   }
 
   options {
     // This is an unfortunate hack that allows for toggling environment-locked builds of this

--- a/ops/jenkins/bfd-run-server-load/Jenkinsfile
+++ b/ops/jenkins/bfd-run-server-load/Jenkinsfile
@@ -1,5 +1,94 @@
 #!/usr/bin/env groovy
 
+ properties([
+ 	parameters([
+        choice(name: 'ENVIRONMENT',
+           choices: ['test', 'prod-sbx', 'prod'],
+           description: 'The BFD SDLC environment to run against'),
+
+        string(name: 'TEST_HOST',
+           defaultValue: 'https://%s.bfd.cms.gov',
+           description: 'The URL under test -- should match the given environment. "%s" will be '
+                        + 'replaced with the chosen environment'),
+
+        string(name: 'AMI_ID_OVERRIDE',
+           description: 'Docker host override ami-id. '
+                        + 'Defaults to latest docker-host AMI from `master`'),
+
+        string(name: 'LOCUST_TAGS',
+           description: 'Space-delimited. Run only the locust tasks with ANY of the given @tag(s).  '
+           + 'Will run all tasks if none are provided. Defaults to an empty string.'),
+
+        string(name: 'LOCUST_EXCLUDE_TAGS',
+          description: 'Space-delimited. Exclude the locust tasks with ANY of the given @tag(s). '
+          + 'Defaults to an empty string.'),
+
+        string(name: 'INITIAL_WORKER_NODES',
+           defaultValue: '0',
+           description: 'The number of initial Locust worker nodes to spawn before checking for '
+                        + 'stop signals. Useful for static load tests'),
+
+        string(name: 'NODE_SPAWN_TIME',
+           defaultValue: '10',
+           description: 'The amount of time to wait between spawning more Lambda Locust worker '
+                        + 'nodes. Does not affect initial spawned nodes'),
+
+        string(name: 'MAX_SPAWNED_NODES',
+           defaultValue: '80',
+           description: 'The maximum number of Lambda worker nodes to spawn over the lifetime of a '
+                        + 'given test run. Does not account for failed nodes or nodes that reach '
+                        + 'their Lambda timeout'),
+
+        string(name: 'MAX_SPAWNED_USERS',
+           defaultValue: '5000',
+           description: 'The maximum number of simulated Locust users (not worker nodes) to spawn. '
+                        + 'Use this and spawn rate to constrain the load during a test run. '
+                        + 'Generally speaking, at any moment the ratio of simulated users to '
+                        + 'worker nodes should not exceed 10:1 (10 users to 1 worker) in order to '
+                        + 'get the best performance. Try to adjust NODE_SPAWN_TIME, '
+                        + 'INITIAL_WORKER_NODES, MAX_SPAWNED_NODES, and USER_SPAWN_RATE such that '
+                        + 'at any given time during the test run this ratio is not exceeded'),
+
+        string(name: 'USER_SPAWN_RATE',
+           defaultValue: '1',
+           description: 'The rate at which simulated Locust users (not worker nodes) will spawn. '
+                        + 'Set this equal to max_spawned_users if all users should be spawned '
+                        + 'immediately'),
+
+        string(name: 'TEST_RUNTIME_LIMIT',
+           defaultValue: '630',
+           description: 'Runtime limit in seconds. If STOP_ON_SCALING is false, this limit is the '
+                        + 'total amount of time the load test has to run. If STOP_ON_SCALING is '
+                        + 'true, this limit indicates the amount of time to check for scaling '
+                        + 'notifications during a test run before stopping. In this case, the '
+                        + 'total maximum runtime is assumed to be '
+                        + 'TEST_RUNTIME_LIMIT + COASTING_TIME'),
+
+        string(name: 'COASTING_TIME',
+           defaultValue: '10',
+           description: 'The amount of time, in seconds, the load test should continue for after '
+                        + 'receiving a scaling notification. Ignored if STOP_ON_SCALING is false. '
+                        + 'Ends immediately on operator stop signal'),
+
+        string(name: 'WARM_INSTANCE_TARGET',
+           defaultValue: '7',
+           description: 'The number of BFD Server instances to target before scaling causes the '
+                        + 'load test to stop'),
+
+        booleanParam(name: 'STOP_ON_SCALING',
+                 defaultValue: true,
+                 description: 'Whether the load test run should end, if COASTING_TIME is zero, or '
+                              + 'start coasting once receiving a scaling notification. Set to '
+                              + 'false for scenarios where a static load test is desired'),
+
+        booleanParam(name: 'STOP_ON_NODE_LIMIT',
+                 defaultValue: true,
+                 description: 'Whether the load test run should end once the maximum Lambda worker '
+                              + 'node limit is reached. Set to false for scenarios where a static '
+                              + 'load test is desired')
+    ])
+])
+
 // Global variable where the terraform variable map will be stored
 def terraformVars
 
@@ -30,92 +119,92 @@ spec:
     }
   }
 
-  parameters {
-    choice(name: 'ENVIRONMENT',
-           choices: ['test', 'prod-sbx', 'prod'],
-           description: 'The BFD SDLC environment to run against')
-
-    string(name: 'TEST_HOST',
-           defaultValue: 'https://%s.bfd.cms.gov',
-           description: 'The URL under test -- should match the given environment. "%s" will be '
-                        + 'replaced with the chosen environment')
-
-    string(name: 'AMI_ID_OVERRIDE',
-           description: 'Docker host override ami-id. '
-                        + 'Defaults to latest docker-host AMI from `master`')
-
-    string(name: 'LOCUST_TAGS',
-           description: 'Space-delimited. Run only the locust tasks with ANY of the given @tag(s).  '
-           + 'Will run all tasks if none are provided. Defaults to an empty string.')
-
-    string(name: 'LOCUST_EXCLUDE_TAGS',
-          description: 'Space-delimited. Exclude the locust tasks with ANY of the given @tag(s). '
-          + 'Defaults to an empty string.')
-
-    string(name: 'INITIAL_WORKER_NODES',
-           defaultValue: '0',
-           description: 'The number of initial Locust worker nodes to spawn before checking for '
-                        + 'stop signals. Useful for static load tests')
-
-    string(name: 'NODE_SPAWN_TIME',
-           defaultValue: '10',
-           description: 'The amount of time to wait between spawning more Lambda Locust worker '
-                        + 'nodes. Does not affect initial spawned nodes')
-
-    string(name: 'MAX_SPAWNED_NODES',
-           defaultValue: '80',
-           description: 'The maximum number of Lambda worker nodes to spawn over the lifetime of a '
-                        + 'given test run. Does not account for failed nodes or nodes that reach '
-                        + 'their Lambda timeout')
-
-    string(name: 'MAX_SPAWNED_USERS',
-           defaultValue: '5000',
-           description: 'The maximum number of simulated Locust users (not worker nodes) to spawn. '
-                        + 'Use this and spawn rate to constrain the load during a test run. '
-                        + 'Generally speaking, at any moment the ratio of simulated users to '
-                        + 'worker nodes should not exceed 10:1 (10 users to 1 worker) in order to '
-                        + 'get the best performance. Try to adjust NODE_SPAWN_TIME, '
-                        + 'INITIAL_WORKER_NODES, MAX_SPAWNED_NODES, and USER_SPAWN_RATE such that '
-                        + 'at any given time during the test run this ratio is not exceeded')
-
-    string(name: 'USER_SPAWN_RATE',
-           defaultValue: '1',
-           description: 'The rate at which simulated Locust users (not worker nodes) will spawn. '
-                        + 'Set this equal to max_spawned_users if all users should be spawned '
-                        + 'immediately')
-
-    string(name: 'TEST_RUNTIME_LIMIT',
-           defaultValue: '630',
-           description: 'Runtime limit in seconds. If STOP_ON_SCALING is false, this limit is the '
-                        + 'total amount of time the load test has to run. If STOP_ON_SCALING is '
-                        + 'true, this limit indicates the amount of time to check for scaling '
-                        + 'notifications during a test run before stopping. In this case, the '
-                        + 'total maximum runtime is assumed to be '
-                        + 'TEST_RUNTIME_LIMIT + COASTING_TIME')
-
-    string(name: 'COASTING_TIME',
-           defaultValue: '10',
-           description: 'The amount of time, in seconds, the load test should continue for after '
-                        + 'receiving a scaling notification. Ignored if STOP_ON_SCALING is false. '
-                        + 'Ends immediately on operator stop signal')
-
-    string(name: 'WARM_INSTANCE_TARGET',
-           defaultValue: '7',
-           description: 'The number of BFD Server instances to target before scaling causes the '
-                        + 'load test to stop')
-
-    booleanParam(name: 'STOP_ON_SCALING',
-                 defaultValue: true,
-                 description: 'Whether the load test run should end, if COASTING_TIME is zero, or '
-                              + 'start coasting once receiving a scaling notification. Set to '
-                              + 'false for scenarios where a static load test is desired')
-
-    booleanParam(name: 'STOP_ON_NODE_LIMIT',
-                 defaultValue: true,
-                 description: 'Whether the load test run should end once the maximum Lambda worker '
-                              + 'node limit is reached. Set to false for scenarios where a static '
-                              + 'load test is desired')
-  }
+//   parameters {
+//     choice(name: 'ENVIRONMENT',
+//            choices: ['test', 'prod-sbx', 'prod'],
+//            description: 'The BFD SDLC environment to run against')
+//
+//     string(name: 'TEST_HOST',
+//            defaultValue: 'https://%s.bfd.cms.gov',
+//            description: 'The URL under test -- should match the given environment. "%s" will be '
+//                         + 'replaced with the chosen environment')
+//
+//     string(name: 'AMI_ID_OVERRIDE',
+//            description: 'Docker host override ami-id. '
+//                         + 'Defaults to latest docker-host AMI from `master`')
+//
+//     string(name: 'LOCUST_TAGS',
+//            description: 'Space-delimited. Run only the locust tasks with ANY of the given @tag(s).  '
+//            + 'Will run all tasks if none are provided. Defaults to an empty string.')
+//
+//     string(name: 'LOCUST_EXCLUDE_TAGS',
+//           description: 'Space-delimited. Exclude the locust tasks with ANY of the given @tag(s). '
+//           + 'Defaults to an empty string.')
+//
+//     string(name: 'INITIAL_WORKER_NODES',
+//            defaultValue: '0',
+//            description: 'The number of initial Locust worker nodes to spawn before checking for '
+//                         + 'stop signals. Useful for static load tests')
+//
+//     string(name: 'NODE_SPAWN_TIME',
+//            defaultValue: '10',
+//            description: 'The amount of time to wait between spawning more Lambda Locust worker '
+//                         + 'nodes. Does not affect initial spawned nodes')
+//
+//     string(name: 'MAX_SPAWNED_NODES',
+//            defaultValue: '80',
+//            description: 'The maximum number of Lambda worker nodes to spawn over the lifetime of a '
+//                         + 'given test run. Does not account for failed nodes or nodes that reach '
+//                         + 'their Lambda timeout')
+//
+//     string(name: 'MAX_SPAWNED_USERS',
+//            defaultValue: '5000',
+//            description: 'The maximum number of simulated Locust users (not worker nodes) to spawn. '
+//                         + 'Use this and spawn rate to constrain the load during a test run. '
+//                         + 'Generally speaking, at any moment the ratio of simulated users to '
+//                         + 'worker nodes should not exceed 10:1 (10 users to 1 worker) in order to '
+//                         + 'get the best performance. Try to adjust NODE_SPAWN_TIME, '
+//                         + 'INITIAL_WORKER_NODES, MAX_SPAWNED_NODES, and USER_SPAWN_RATE such that '
+//                         + 'at any given time during the test run this ratio is not exceeded')
+//
+//     string(name: 'USER_SPAWN_RATE',
+//            defaultValue: '1',
+//            description: 'The rate at which simulated Locust users (not worker nodes) will spawn. '
+//                         + 'Set this equal to max_spawned_users if all users should be spawned '
+//                         + 'immediately')
+//
+//     string(name: 'TEST_RUNTIME_LIMIT',
+//            defaultValue: '630',
+//            description: 'Runtime limit in seconds. If STOP_ON_SCALING is false, this limit is the '
+//                         + 'total amount of time the load test has to run. If STOP_ON_SCALING is '
+//                         + 'true, this limit indicates the amount of time to check for scaling '
+//                         + 'notifications during a test run before stopping. In this case, the '
+//                         + 'total maximum runtime is assumed to be '
+//                         + 'TEST_RUNTIME_LIMIT + COASTING_TIME')
+//
+//     string(name: 'COASTING_TIME',
+//            defaultValue: '10',
+//            description: 'The amount of time, in seconds, the load test should continue for after '
+//                         + 'receiving a scaling notification. Ignored if STOP_ON_SCALING is false. '
+//                         + 'Ends immediately on operator stop signal')
+//
+//     string(name: 'WARM_INSTANCE_TARGET',
+//            defaultValue: '7',
+//            description: 'The number of BFD Server instances to target before scaling causes the '
+//                         + 'load test to stop')
+//
+//     booleanParam(name: 'STOP_ON_SCALING',
+//                  defaultValue: true,
+//                  description: 'Whether the load test run should end, if COASTING_TIME is zero, or '
+//                               + 'start coasting once receiving a scaling notification. Set to '
+//                               + 'false for scenarios where a static load test is desired')
+//
+//     booleanParam(name: 'STOP_ON_NODE_LIMIT',
+//                  defaultValue: true,
+//                  description: 'Whether the load test run should end once the maximum Lambda worker '
+//                               + 'node limit is reached. Set to false for scenarios where a static '
+//                               + 'load test is desired')
+//   }
 
   stages {
     stage('Run Load Tests') {

--- a/ops/jenkins/bfd-run-synthea-generation/Jenkinsfile
+++ b/ops/jenkins/bfd-run-synthea-generation/Jenkinsfile
@@ -1,5 +1,38 @@
 #!/usr/bin/env groovy
 
+properties([
+ 	parameters([
+        string(name: 'NUM_BENES',
+           defaultValue: '10000',
+           description: 'The number of synthetic beneficiaries to generate'),
+
+        string(name: 'NUM_FUTURE_MONTHS',
+           defaultValue: '0',
+           description: 'The number of months into the future that claim lines should be '
+                        + 'generated. If specified, future claims will be split in the '
+                        + 'generated output to allow for proper loading'),
+
+        booleanParam(
+            name: 'USE_TARGET_CONTRACT',
+            description: 'If checked, use the below contract partD contract number for all generated items.',
+            defaultValue: false),
+
+        string(name: 'TARGET_CONTRACT',
+           defaultValue: 'Y9999',
+           description: 'If USE_TARGET_CONTRACT is checked, indicates a single part D contract that all generated claims'
+                        + ' will be associated with.'),
+
+        booleanParam(name: 'UPDATE_END_STATE_S3',
+           defaultValue: true,
+           description: 'Specifies whether the main end_state.properties stored in the synthea S3 '
+                        + 'bucket should be updated with the end_state.properties '
+                        + 'of this run. If false, the main end_state.properties is left as-is. '
+                        + 'If true, the main end_state.properties is replaced. Regardless of this '
+                        + 'parameter\'s value, the starting and final end_state.properties will '
+                        + 'be available in the generated output directory uploaded to S3')
+  ])
+])
+
 pipeline {
   agent {
     kubernetes {
@@ -41,37 +74,37 @@ spec:
     }
   }
 
-  parameters {
-    string(name: 'NUM_BENES',
-           defaultValue: '10000',
-           description: 'The number of synthetic beneficiaries to generate')
-
-    string(name: 'NUM_FUTURE_MONTHS',
-           defaultValue: '0',
-           description: 'The number of months into the future that claim lines should be '
-                        + 'generated. If specified, future claims will be split in the '
-                        + 'generated output to allow for proper loading')
-                        
-    booleanParam(
-        name: 'USE_TARGET_CONTRACT',
-        description: 'If checked, use the below contract partD contract number for all generated items.',
-        defaultValue: false
-    )
-                        
-    string(name: 'TARGET_CONTRACT',
-           defaultValue: 'Y9999',
-           description: 'If USE_TARGET_CONTRACT is checked, indicates a single part D contract that all generated claims'
-                        + ' will be associated with.')
-
-    booleanParam(name: 'UPDATE_END_STATE_S3',
-           defaultValue: true,
-           description: 'Specifies whether the main end_state.properties stored in the synthea S3 '
-                        + 'bucket should be updated with the end_state.properties '
-                        + 'of this run. If false, the main end_state.properties is left as-is. '
-                        + 'If true, the main end_state.properties is replaced. Regardless of this '
-                        + 'parameter\'s value, the starting and final end_state.properties will '
-                        + 'be available in the generated output directory uploaded to S3')
-  }
+//   parameters {
+//     string(name: 'NUM_BENES',
+//            defaultValue: '10000',
+//            description: 'The number of synthetic beneficiaries to generate')
+//
+//     string(name: 'NUM_FUTURE_MONTHS',
+//            defaultValue: '0',
+//            description: 'The number of months into the future that claim lines should be '
+//                         + 'generated. If specified, future claims will be split in the '
+//                         + 'generated output to allow for proper loading')
+//
+//     booleanParam(
+//         name: 'USE_TARGET_CONTRACT',
+//         description: 'If checked, use the below contract partD contract number for all generated items.',
+//         defaultValue: false
+//     )
+//
+//     string(name: 'TARGET_CONTRACT',
+//            defaultValue: 'Y9999',
+//            description: 'If USE_TARGET_CONTRACT is checked, indicates a single part D contract that all generated claims'
+//                         + ' will be associated with.')
+//
+//     booleanParam(name: 'UPDATE_END_STATE_S3',
+//            defaultValue: true,
+//            description: 'Specifies whether the main end_state.properties stored in the synthea S3 '
+//                         + 'bucket should be updated with the end_state.properties '
+//                         + 'of this run. If false, the main end_state.properties is left as-is. '
+//                         + 'If true, the main end_state.properties is replaced. Regardless of this '
+//                         + 'parameter\'s value, the starting and final end_state.properties will '
+//                         + 'be available in the generated output directory uploaded to S3')
+//   }
 
   options {
     // Nothing within this repository is required for running this pipeline, so skipping the default

--- a/ops/jenkins/global-pipeline-libraries/vars/awsEc2.groovy
+++ b/ops/jenkins/global-pipeline-libraries/vars/awsEc2.groovy
@@ -3,11 +3,14 @@
 
 // Returns the AmiId for the given AMI and (Optional) git branch
 String getAmiId(String gitBranch, String amiName) {
-    command = "aws ec2 describe-images --owners self --filters \
-        ${gitBranch != "" ? "'Name=tag:Branch,Values=${gitBranch}'" : ""} \
-        'Name=name,Values=${amiName}' \
-        'Name=state,Values=available' --region us-east-1 --output json | \
-        jq -r '.Images | sort_by(.CreationDate) | last(.[]).ImageId'"
+    command = """
+set -x
+aws ec2 describe-images --owners self --filters \
+${gitBranch != "" ? "'Name=tag:Branch,Values=${gitBranch}'" : ""} \
+'Name=name,Values=${amiName}' \
+'Name=state,Values=available' --region us-east-1 --output json | \
+jq -r '.Images | sort_by(.CreationDate) | last(.[]).ImageId'"
+"""
         amiId = sh(returnStdout: true, script: command).trim()
     return amiId
 }


### PR DESCRIPTION
**JIRA Ticket:**
[BFD-3077](https://jira.cms.gov/browse/BFD-3077)
[BFD-3005](https://jira.cms.gov/browse/BFD-3005)

**User Story or Bug Summary:**
Refactor Jenkinsfile's with parameters to be defined within a properties block to enable the default values to be available on the first run when the Jenkins option is 'Build Now' instead of 'Build with Parameters'.
Change the default value for the deploy_prod_from_non_master parameter to true in the Multibranch Jenkinsfile.

---

### What Does This PR Do?
* BFD-3007 & BFD-3005 Update all Jenkinsfiles with parameters to use properties declaration. Change default from false to true in root level Jenkinsfile.

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items to the following list here -->
* Verify all PR security questions and checklists have been completed and addressed.

### What Security Implications Does This PR Have?
None.

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [X] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [X] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [X] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [X] No

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [X] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [X] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [X] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [X] The data dictionary has been updated with any field mapping changes, if any were made.
* [X] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [X] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [X] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [X] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    