### PR TITLE
BFD-3154: fix test race conditions

### DIFF
--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/DLQDaoIT.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/DLQDaoIT.java
@@ -13,6 +13,8 @@ import gov.cms.bfd.pipeline.rda.grpc.RdaPipelineTestUtils;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.List;
@@ -29,7 +31,8 @@ public class DLQDaoIT {
           .thenComparing(MessageError::getClaimType);
 
   /** Fixed time used by the {@link DLQDao} clock. */
-  private final Instant clockTime = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+  private final Instant clockTime =
+      ZonedDateTime.of(2023, 1, 2, 3, 4, 5, 0, ZoneOffset.UTC).toInstant();
 
   /** Fixed clock for predictable times. */
   private final Clock clock = Clock.fixed(clockTime, ZoneId.systemDefault());

--- a/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/DLQDaoIT.java
+++ b/apps/bfd-pipeline/bfd-pipeline-rda-grpc/src/test/java/gov/cms/bfd/pipeline/rda/grpc/source/DLQDaoIT.java
@@ -42,7 +42,7 @@ public class DLQDaoIT {
 
   /** Precomputed value for threshold of record expiration. */
   private final Instant oldestUpdateDateToKeep =
-      clock.instant().truncatedTo(ChronoUnit.MILLIS).minus(maxAgeDays, ChronoUnit.DAYS);
+      clock.instant().truncatedTo(ChronoUnit.MICROS).minus(maxAgeDays, ChronoUnit.DAYS);
 
   /**
    * Verifies that basic insert, read, and delete operations work properly since they are used in
@@ -174,8 +174,7 @@ public class DLQDaoIT {
                     assertEquals(recordToUpdate.getCreatedDate(), rec.getCreatedDate());
                     // the update date should have been updated
                     assertEquals(
-                        clock.instant().truncatedTo(ChronoUnit.MILLIS),
-                        rec.getUpdatedDate().truncatedTo(ChronoUnit.MILLIS));
+                        clock.instant().truncatedTo(ChronoUnit.MICROS), rec.getUpdatedDate());
                   });
               assertContentsHaveSamePropertyValues(
                   allRecordsAfter, remainingRecords, ComparatorForSorting);


### PR DESCRIPTION
**JIRA Ticket:**
[BFD-3154](https://jira.cms.gov/browse/BFD-3154)

**User Story or Bug Summary:**

Post removal of HSQLDB, a race condition appears to be present when evaluating certain code paths that were more tightly coupled to HSQLDB setup routines, etc. This is causing intermittent failures in GHA.

---

### What Does This PR Do?

Modifies `runTestWithTemporaryDb()` to use the same postgres container as all other tests.  The name of the method was retained since the test is still using a temporary pooled data source and transaction manager.  Changing all 16 tests that call this method seemed unnecessary.

Adds code to wait for the postgres database within the docker container to begin processing queries successfully before allowing tests to run.

Eliminates the use of current time of day and all of the `Instant.truncatedTo()` method calls in DLQDaoIT.  It appeared that some rounding issues caused intermittent comparison failures when using postgresql.

Also removed an unused static class, `LoggerWriter`, in `DatabaseTestUtils`. 

### What Should Reviewers Watch For?
<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items to the following list here -->
* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [x] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [x] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [x] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] The data dictionary has been updated with any field mapping changes, if any were made.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    