### PR TITLE
BFD-3313: Adjust autoscaling policies

### DIFF
--- a/ops/terraform/services/server/modules/bfd_server_asg/main.tf
+++ b/ops/terraform/services/server/modules/bfd_server_asg/main.tf
@@ -36,10 +36,10 @@ locals {
     { begin = 1 * var.scaling_request_count_interval, end = 2 * var.scaling_request_count_interval, desired_capacity = local.scaling_capacity_step * 2 },
     # If RequestCount is greater than or equal to 2 * var.scaling_request_count_interval count/min,
     # but less than 4 * var.scaling_request_count_interval count/min we want to be at 9 instances
-    { begin = 2 * var.scaling_request_count_interval, end = 4 * var.scaling_request_count_interval, desired_capacity = local.scaling_capacity_step * 3 },
+    { begin = 2 * var.scaling_request_count_interval, end = 3 * var.scaling_request_count_interval, desired_capacity = local.scaling_capacity_step * 3 },
     # Whenever traffic is greater than or equal to 4 * var.scaling_request_count_interval count/min
     # we want to be at 12 instances
-    { begin = 4 * var.scaling_request_count_interval, end = null, desired_capacity = local.scaling_capacity_step * 4 },
+    { begin = 3 * var.scaling_request_count_interval, end = null, desired_capacity = local.scaling_capacity_step * 4 },
   ]
   scalein_config  = slice(local.scaling_stages, 0, length(local.scaling_stages) - 1)
   scaleout_config = slice(local.scaling_stages, 1, length(local.scaling_stages))

--- a/ops/terraform/services/server/modules/bfd_server_asg/main.tf
+++ b/ops/terraform/services/server/modules/bfd_server_asg/main.tf
@@ -238,7 +238,7 @@ resource "aws_cloudwatch_metric_alarm" "avg_cpu_low" {
   comparison_operator = "LessThanThreshold"
   datapoints_to_alarm = local.scaling_alarms_config.scale_in.datapoints_to_alarm
   evaluation_periods  = local.scaling_alarms_config.scale_in.consecutive_periods_to_alarm
-  threshold           = 1
+  threshold           = local.scale_in_cpu_threshold
   treat_missing_data  = "notBreaching"
   alarm_actions       = [aws_autoscaling_policy.avg_cpu_low.arn]
 
@@ -267,7 +267,7 @@ resource "aws_autoscaling_policy" "avg_cpu_low" {
   policy_type               = "StepScaling"
 
   step_adjustment {
-    metric_interval_lower_bound = 0
+    metric_interval_upper_bound = 0
     scaling_adjustment          = "-${local.scaling_capacity_step}"
   }
 }
@@ -367,7 +367,7 @@ resource "aws_autoscaling_policy" "avg_cpu_high" {
     content {
       metric_interval_lower_bound = step_adjustment.key
       metric_interval_upper_bound = step_adjustment.key + 1 != length(local.scale_out_cpu_thresholds) ? step_adjustment.key + 1 : null
-      scaling_adjustment          = step_adjustment.value.desired_capacity
+      scaling_adjustment          = local.scaling_capacity_step + (local.scaling_capacity_step * (step_adjustment.key + 1))
     }
   }
 }

--- a/ops/terraform/services/server/modules/bfd_server_asg/main.tf
+++ b/ops/terraform/services/server/modules/bfd_server_asg/main.tf
@@ -26,23 +26,16 @@ locals {
       consecutive_periods_to_alarm = 10
     }
   }
-  # begin is inclusive, end is exclusive
-  scaling_stages = [
-    # If RequestCount is less than 1 * var.scaling_request_count_interval count/min, exclusive, we
-    # want to be at 3 instances
-    { begin = null, end = 1 * var.scaling_request_count_interval, desired_capacity = local.scaling_capacity_step * 1 },
-    # If RequestCount is greater than or equal to 1 * var.scaling_request_count_interval count/min,
-    # but less than 2 * var.scaling_request_count_interval count/min we want to be at 6 instances
-    { begin = 1 * var.scaling_request_count_interval, end = 2 * var.scaling_request_count_interval, desired_capacity = local.scaling_capacity_step * 2 },
-    # If RequestCount is greater than or equal to 2 * var.scaling_request_count_interval count/min,
-    # but less than 4 * var.scaling_request_count_interval count/min we want to be at 9 instances
-    { begin = 2 * var.scaling_request_count_interval, end = 3 * var.scaling_request_count_interval, desired_capacity = local.scaling_capacity_step * 3 },
-    # Whenever traffic is greater than or equal to 4 * var.scaling_request_count_interval count/min
-    # we want to be at 12 instances
-    { begin = 3 * var.scaling_request_count_interval, end = null, desired_capacity = local.scaling_capacity_step * 4 },
+  scale_in_cpu_threshold = 15 # 15 percent average cpu for above period will cause scale-in
+  # 3 ranges of CPU utilization to scale out at, with each range intended to _increase_ the scaling
+  # response when average CPU utilization is increased. For example, if CPU utilization hits 90%
+  # over the evaluation period of scale-out at 3 instances, we want to scale-out to 12 instances
+  # immediately
+  scale_out_cpu_thresholds = [
+    { begin = 50, end = 75 },
+    { begin = 75, end = 90 },
+    { begin = 90, end = null }
   ]
-  scalein_config  = slice(local.scaling_stages, 0, length(local.scaling_stages) - 1)
-  scaleout_config = slice(local.scaling_stages, 1, length(local.scaling_stages))
 
   on_launch_lifecycle_hook_name = "bfd-${local.env}-${var.role}-on-launch"
 }
@@ -240,83 +233,53 @@ resource "aws_autoscaling_group" "main" {
 ## Autoscaling Policies and Cloudwatch Alarms
 #
 
-resource "aws_cloudwatch_metric_alarm" "filtered_req_count_low" {
-  for_each = { for v in local.scalein_config : "${v.desired_capacity}-instances" => v }
-
-  alarm_name          = "bfd-${var.role}-${local.env}-req-count-low-${each.key}"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
+resource "aws_cloudwatch_metric_alarm" "avg_cpu_low" {
+  alarm_name          = "bfd-${var.role}-${local.env}-avg-cpu-low"
+  comparison_operator = "LessThanThreshold"
   datapoints_to_alarm = local.scaling_alarms_config.scale_in.datapoints_to_alarm
   evaluation_periods  = local.scaling_alarms_config.scale_in.consecutive_periods_to_alarm
   threshold           = 1
   treat_missing_data  = "notBreaching"
-  alarm_actions       = [aws_autoscaling_policy.filtered_req_count_low_scaling[each.key].arn]
+  alarm_actions       = [aws_autoscaling_policy.avg_cpu_low.arn]
 
   metric_query {
     id          = "m1"
-    return_data = false
-
-    metric {
-      dimensions = {
-        LoadBalancerName = "bfd-${local.env}-${var.role}"
-      }
-      metric_name = "RequestCount"
-      namespace   = "AWS/ELB"
-      period      = local.scaling_alarms_config.scale_in.eval_period
-      stat        = "Sum"
-    }
-  }
-
-  metric_query {
-    id          = "m2"
-    return_data = false
+    return_data = true
 
     metric {
       dimensions = {
         AutoScalingGroupName = aws_autoscaling_group.main.name
       }
-      metric_name = "GroupDesiredCapacity"
+      metric_name = "CPUUtilization"
       namespace   = "AWS/AutoScaling"
       period      = local.scaling_alarms_config.scale_in.eval_period
       stat        = "Average"
     }
   }
-
-  metric_query {
-    id    = "e1"
-    label = "Set to ${each.value.desired_capacity} capacity units"
-    expression = "IF(${join(" && ", compact([
-      each.value.begin != null ? "m1 > ${each.value.begin}" : null,
-      each.value.end != null ? "m1 <= ${each.value.end}" : null,
-      "m2 > ${each.value.desired_capacity}"
-    ]))}, 1, 0)"
-    return_data = true
-  }
 }
 
-resource "aws_autoscaling_policy" "filtered_req_count_low_scaling" {
-  for_each = { for v in local.scalein_config : "${v.desired_capacity}-instances" => v }
-
-  name                      = "bfd-${var.role}-${local.env}-req-count-low-scalein-${each.key}"
+resource "aws_autoscaling_policy" "avg_cpu_low" {
+  name                      = "bfd-${var.role}-${local.env}-avg-cpu-low"
   autoscaling_group_name    = aws_autoscaling_group.main.name
   estimated_instance_warmup = 0 # explicitly disable warmup as lifecycle hooks handle it more accurately
-  adjustment_type           = "ExactCapacity"
+  adjustment_type           = "ChangeInCapacity"
   metric_aggregation_type   = "Average"
   policy_type               = "StepScaling"
 
   step_adjustment {
     metric_interval_lower_bound = 0
-    scaling_adjustment          = each.value.desired_capacity
+    scaling_adjustment          = "-${local.scaling_capacity_step}"
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "filtered_req_count_high" {
-  alarm_name          = "bfd-${var.role}-${local.env}-req-count-high"
+resource "aws_cloudwatch_metric_alarm" "avg_cpu_high" {
+  alarm_name          = "bfd-${var.role}-${local.env}-avg-cpu-high"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   datapoints_to_alarm = local.scaling_alarms_config.scale_out.datapoints_to_alarm
   evaluation_periods  = local.scaling_alarms_config.scale_out.consecutive_periods_to_alarm
   threshold           = 1
   treat_missing_data  = "notBreaching"
-  alarm_actions       = [aws_autoscaling_policy.filtered_req_count_high_scaling.arn]
+  alarm_actions       = [aws_autoscaling_policy.avg_cpu_high.arn]
 
   metric_query {
     id          = "m1"
@@ -324,14 +287,15 @@ resource "aws_cloudwatch_metric_alarm" "filtered_req_count_high" {
 
     metric {
       dimensions = {
-        LoadBalancerName = "bfd-${local.env}-${var.role}"
+        AutoScalingGroupName = aws_autoscaling_group.main.name
       }
-      metric_name = "RequestCount"
-      namespace   = "AWS/ELB"
-      period      = local.scaling_alarms_config.scale_out.eval_period
-      stat        = "Sum"
+      metric_name = "CPUUtilization"
+      namespace   = "AWS/AutoScaling"
+      period      = local.scaling_alarms_config.scale_in.eval_period
+      stat        = "Average"
     }
   }
+
   metric_query {
     id          = "m2"
     return_data = false
@@ -342,35 +306,56 @@ resource "aws_cloudwatch_metric_alarm" "filtered_req_count_high" {
       }
       metric_name = "GroupDesiredCapacity"
       namespace   = "AWS/AutoScaling"
-      period      = local.scaling_alarms_config.scale_out.eval_period
+      period      = local.scaling_alarms_config.scale_in.eval_period
       stat        = "Average"
     }
   }
 
+  metric_query {
+    id          = "m3"
+    return_data = false
+
+    metric {
+      dimensions = {
+        AutoScalingGroupName = aws_autoscaling_group.main.name
+      }
+      metric_name = "GroupInServiceInstances"
+      namespace   = "AWS/AutoScaling"
+      period      = local.scaling_alarms_config.scale_in.eval_period
+      stat        = "Average"
+    }
+  }
+
+  # This is a bit complex, but in short this creates an IF() metric math for each defined range that
+  # will scale proportionally to the incoming load. However, because of the quirks of default Step
+  # Scaling policies, these generated expressions guard against additional, erroneous scaling by
+  # ensuring these ranges are only evaluated when the desired capacity matches the existing
+  # capacity. Otherwise, normal Step Scaling policies will continue to scale indefinitely (until the
+  # maximum) as instances take too long to warmup and contribute to aggregated CPU metrics
   dynamic "metric_query" {
-    for_each = local.scaleout_config
+    for_each = local.scale_out_cpu_thresholds
     content {
       id    = "e${metric_query.key}"
-      label = "Set to ${metric_query.value.desired_capacity} capacity units"
+      label = "Scaling Capacity Scalar (DesiredCapacity = (${local.scaling_capacity_step} + (${local.scaling_capacity_step} * SCS)))"
       expression = "IF(${join(" && ", compact([
         metric_query.value.begin != null ? "m1 > ${metric_query.value.begin}" : null,
         metric_query.value.end != null ? "m1 <= ${metric_query.value.end}" : null,
-        "m2 < ${metric_query.value.desired_capacity}"
-      ]))}, ${metric_query.key + 1}, 0)"
+        "m2 == m3"
+      ]))}, MIN([m3/${local.scaling_capacity_step} + ${metric_query.key}, TIME_SERIES(${length(local.scale_out_cpu_thresholds)})]), 0)"
       return_data = false
     }
   }
 
   metric_query {
-    expression  = "MAX([${join(",", [for i in range(length(local.scaleout_config)) : "e${i}"])}])"
-    id          = "e${length(local.scaleout_config)}"
+    expression  = "MAX([${join(",", [for i in range(length(local.scale_out_cpu_thresholds)) : "e${i}"])}])"
+    id          = "e${length(local.scale_out_cpu_thresholds)}"
     label       = "ScalingCapacityScalar"
     return_data = true
   }
 }
 
-resource "aws_autoscaling_policy" "filtered_req_count_high_scaling" {
-  name                      = "bfd-${var.role}-${local.env}-req-count-high-scaleout"
+resource "aws_autoscaling_policy" "avg_cpu_high" {
+  name                      = "bfd-${var.role}-${local.env}-avg-cpu-high"
   autoscaling_group_name    = aws_autoscaling_group.main.name
   estimated_instance_warmup = 0 # explicitly disable warmup as lifecycle hooks handle it more accurately
   adjustment_type           = "ExactCapacity"
@@ -378,10 +363,10 @@ resource "aws_autoscaling_policy" "filtered_req_count_high_scaling" {
   policy_type               = "StepScaling"
 
   dynamic "step_adjustment" {
-    for_each = local.scaleout_config
+    for_each = local.scale_out_cpu_thresholds
     content {
       metric_interval_lower_bound = step_adjustment.key
-      metric_interval_upper_bound = step_adjustment.key + 1 != length(local.scaleout_config) ? step_adjustment.key + 1 : null
+      metric_interval_upper_bound = step_adjustment.key + 1 != length(local.scale_out_cpu_thresholds) ? step_adjustment.key + 1 : null
       scaling_adjustment          = step_adjustment.value.desired_capacity
     }
   }

--- a/ops/terraform/services/server/modules/bfd_server_asg/variables.tf
+++ b/ops/terraform/services/server/modules/bfd_server_asg/variables.tf
@@ -63,8 +63,8 @@ variable "jdbc_suffix" {
   type        = string
 }
 
-variable "scaling_networkin_interval_mb" {
-  description = "The interval value in megabytes for evaluating the asg scaling capacity, based on the metric FilteredNetworkIn"
+variable "scaling_request_count_interval" {
+  description = "The distinct interval for each scaling range, based on the ELB metric RequestCount"
   type        = number
-  default     = 100000000
+  default     = 5000
 }


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BFD-3313](https://jira.cms.gov/browse/BFD-3313)

**User Story or Bug Summary:**

<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->

As a US taxpayer, I want BFD to be as efficient as possible so that I can be confident that my tax dollars are not going to waste.

---

### What Does This PR Do?

<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

This PR updates the BFD Server's ASG scaling policies to scale based upon average CPU utilization across the ASG. These new scaling policies are designed keeping in mind that:

- BFD Server typically sees large bulk loads, rather than consistent, sustained traffic
- Average CPU utilization is _inversely_ proportional to the number of instances in the ASG
  - As in, the average utilization goes _down_ as the number of instances _increase_
- Step Scaling policies are based upon CloudWatch Alarms that can remain in `ALARM` (and thus cause scaling) _after_ scale-out begins but _before_ the scaled-out instances contribute to the average CPU utilization metric
  - This leads to feedback where, with traditional Step Scaling policies tuned to respond aggressively, the ASG will scale-out indefinitely to the maximum
  - This is largely due to Step Scaling policies being designed for consistent, sustained traffic that may increase in intensity _gradually_. BFD Server does **not** typically see this behavior

With the above assumptions in mind, this PR implements a bespoke CPU-based scaling solution that _can_ be aggressive while not falling victim to the aforementioned erroneous scaling behavior.

Specifically, there are now ranges of CPU that we scale on:

- `0%` to `50%` CPU: No scaling
- `50%` to `75%` CPU:
  - At 3 instances, scale to 6
  - At 6 instances, scale to 9
  - At 9 instances, scale to 12
- `75%` to `90%` CPU:
  - At 3 instances, scale to 9
  - At 6 instances, scale to 12
  - At 9 instances, scale to 12
- `90%` CPU and above:
  - Scale to 12, regardless of current instance count

These ranges, and corresponding scaling actions, are designed to allow the Server to respond aggressively to large incoming workloads while considering the inverse proportionality of CPU and instance count.

This PR has been verified by:

- `terraform apply`ing to `test`, _verifying that_ it applies properly and all policies/Alarms are created
- Using the Regression Suite to generate load with policies configured with much lower bounds (to simulate higher load), _verifying that_:
  - the Server scales
  - the Server does not erroneously scale beyond what is expected
  - the Server scales-in after load has ceased, as expected

### What Should Reviewers Watch For?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:

<!-- Add some items to the following list here -->

- Verify all PR security questions and checklists have been completed and addressed.

### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

- If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

  - Does this PR add any new software dependencies?
    - [ ] Yes
    - [x] No
  - Does this PR modify or invalidate any of our security controls?
    - [ ] Yes
    - [x] No
  - Does this PR store or transmit data that was not stored or transmitted before?
    - [ ] Yes
    - [x] No

- If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
  - Do you think this PR requires additional review of its security implications for other reasons?
    - [ ] Yes
    - [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

- N/A

### Submitter Checklist

<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

- [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
- [x] This PR is reasonably limited in scope, to help ensure that:
  1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
  2. There isn't too much of a burden on reviewers.
  3. Any problems it causes have a small "blast radius".
  4. It'll be easier to rollback if that becomes necessary.
- [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
- [x] The data dictionary has been updated with any field mapping changes, if any were made.
- [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
- [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
- [x] Reviews are requested from both:
  - At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
  - Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
- [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
  - Please review the standards every few months to ensure you're familiar with them.
