### PR TITLE
BFD-3348: Alarm on SFTP Outbound Timeouts

### DIFF
--- a/ops/terraform/services/eft/modules/bfd_eft_outbound_o11y/README.md
+++ b/ops/terraform/services/eft/modules/bfd_eft_outbound_o11y/README.md
@@ -1,6 +1,6 @@
-# `bft_eft_outbound_o11y` Submodule
+# `bft_eft_outbound_o11y` Module
 
-This Submodule contains the resources and Lambda source code for several Alarms and a Lambda that sends BFD EFT Outbound status notifications to a Slack channel configured in `base` configuration.
+This module contains the resources and Lambda source code for several Alarms and a Lambda that sends BFD EFT Outbound status notifications to a Slack channel configured in `base` configuration.
 
 <!-- BEGIN_TF_DOCS -->
 <!-- GENERATED WITH `terraform-docs .`
@@ -59,6 +59,7 @@ No outputs.
 | Name | Type |
 |------|------|
 | [aws_cloudwatch_metric_alarm.lambda_errors](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.lambda_timeouts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.sns_failures](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_iam_policy.slack_notifier_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.slack_notifier](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -68,6 +69,7 @@ No outputs.
 | [aws_sns_topic_subscription.sns_to_slack_notifier](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
 | [archive_file.slack_notifier_src](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_lambda_function.outbound_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lambda_function) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_sns_topic.breach_topics](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/sns_topic) | data source |
 | [aws_sns_topic.ok_topics](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/sns_topic) | data source |

--- a/ops/terraform/services/eft/modules/bfd_eft_outbound_o11y/data-sources.tf
+++ b/ops/terraform/services/eft/modules/bfd_eft_outbound_o11y/data-sources.tf
@@ -18,6 +18,10 @@ data "aws_sqs_queue" "outbound_lambda_dlq" {
   name = var.outbound_lambda_dlq_name
 }
 
+data "aws_lambda_function" "outbound_lambda" {
+  function_name = var.outbound_lambda_name
+}
+
 data "aws_ssm_parameter" "slack_webhook" {
   name            = local.slack_webhook_ssm_path
   with_decryption = true

--- a/ops/terraform/services/eft/modules/bfd_eft_outbound_o11y/timeouts.tf
+++ b/ops/terraform/services/eft/modules/bfd_eft_outbound_o11y/timeouts.tf
@@ -1,0 +1,30 @@
+resource "aws_cloudwatch_metric_alarm" "lambda_timeouts" {
+  alarm_name          = "${local.alarms_config.lambda_errors.alarm_name}-timeout"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  # `period` calculated for previous 15 minutes to catch **all** lambda failures
+  period    = 60 * 15
+  statistic = "Maximum"
+  # `threshold` expressed expressed in milliseconds
+  threshold           = data.aws_lambda_function.outbound_lambda.timeout * 1000
+  datapoints_to_alarm = 1
+  treat_missing_data  = "notBreaching"
+
+  alarm_description = join("", [
+    "The ${var.outbound_lambda_name} has timed out in ${local.env}. View the ",
+    "linked CloudWatch Log Group for more details on the failure, and inspect the failing event ",
+    "in the linked DLQ",
+    "\n",
+    "\n* CloudWatch Log Group: <${local.alarms_config.lambda_errors.log_group_url}|${local.alarms_config.lambda_errors.log_group_name}>",
+    "\n* Dead Letter Queue: <${local.alarms_config.lambda_errors.queue_url}|${var.outbound_lambda_dlq_name}>",
+  ])
+
+  metric_name = "Duration"
+  namespace   = local.lambda_metrics_namespace
+  dimensions = {
+    FunctionName = var.outbound_lambda_name
+  }
+
+  alarm_actions = local.alarms_config.lambda_errors.breach_topic_arn != null ? [local.alarms_config.lambda_errors.breach_topic_arn] : null
+  ok_actions    = local.alarms_config.lambda_errors.ok_topic_arn != null ? [local.alarms_config.lambda_errors.ok_topic_arn] : null
+}

--- a/ops/terraform/services/eft/modules/bfd_eft_outbound_o11y/timeouts.tf
+++ b/ops/terraform/services/eft/modules/bfd_eft_outbound_o11y/timeouts.tf
@@ -2,10 +2,10 @@ resource "aws_cloudwatch_metric_alarm" "lambda_timeouts" {
   alarm_name          = "${local.alarms_config.lambda_errors.alarm_name}-timeout"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1
-  # `period` calculated for previous 15 minutes to catch **all** lambda failures
+  # `period` is expressed in minutes, calculated here for previous 15 minutes to catch **all** lambda timeouts
   period    = 60 * 15
   statistic = "Maximum"
-  # `threshold` expressed expressed in milliseconds
+  # `threshold` expressed in milliseconds
   threshold           = data.aws_lambda_function.outbound_lambda.timeout * 1000
   datapoints_to_alarm = 1
   treat_missing_data  = "notBreaching"


### PR DESCRIPTION
**JIRA Ticket:**
[BFD-3348](https://jira.cms.gov/browse/BFD-3348)

**User Story or Bug Summary:**
Alert on SFTP Outbound Timeouts in Lambda-based EFT

---

### What Does This PR Do?
This implements a cloudwatch alarm using the existing slack notifier that is triggered if a lambda's duration exceeds its configured timeout.

`AWS/Lambda/${FunctionName}/Duration` is calculated at the end of a function's execution but recorded/timestamped at execution time, i.e. if a function is executed at 01:00 and times out at 01:15, a duration of >900s will be recorded at 01:00.  Because of this **and** our configuring the timeout to match the maximum allotted 15m, the alarm must _look back_ to the previous 15m period to report on these timeout failures.

### What Should Reviewers Watch For?
<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items to the following list here -->
* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [x] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [x] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [x] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
*  [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] The data dictionary has been updated with any field mapping changes, if any were made.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
    