### PR TITLE
BFD-3408: Introduce EFT version override

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -250,7 +250,10 @@ try {
 						awsAuth.assumeRole()
 						terraform.deployTerraservice(
 							env: bfdEnv,
-							directory: "ops/terraform/services/eft"
+							directory: "ops/terraform/services/eft",
+							tfVars: [
+								bfd_version_override: gitBranchName
+							]
 						)
 					}
 				}
@@ -564,7 +567,10 @@ try {
 							awsAuth.assumeRole()
 							terraform.deployTerraservice(
 								env: bfdEnv,
-								directory: "ops/terraform/services/eft"
+								directory: "ops/terraform/services/eft",
+								tfVars: [
+									bfd_version_override: gitBranchName
+								]
 							)
 						}
 					}

--- a/ops/terraform/services/eft/README.md
+++ b/ops/terraform/services/eft/README.md
@@ -34,7 +34,9 @@ terraform destroy $(for r in `terraform state list | grep -vE "aws_ec2_subnet_ci
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_bfd_version_override"></a> [bfd\_version\_override](#input\_bfd\_version\_override) | BFD release version override. When empty, defaults to attempting to resolve the release version from GitHub. | `string` | `null` | no |
 
 <!-- GENERATED WITH `terraform-docs .`
      Manually updating the README.md will be overwritten.

--- a/ops/terraform/services/eft/data-sources.tf
+++ b/ops/terraform/services/eft/data-sources.tf
@@ -33,7 +33,7 @@ data "aws_ecr_repository" "ecr" {
 
 data "aws_ecr_image" "sftp_outbound_transfer" {
   repository_name = data.aws_ecr_repository.ecr.name
-  image_tag       = local.latest_version
+  image_tag       = local.bfd_version
 }
 
 data "aws_ec2_managed_prefix_list" "vpn" {

--- a/ops/terraform/services/eft/main.tf
+++ b/ops/terraform/services/eft/main.tf
@@ -11,11 +11,12 @@ module "terraservice" {
 }
 
 locals {
-  default_tags     = module.terraservice.default_tags
-  env              = module.terraservice.env
-  seed_env         = module.terraservice.seed_env
-  is_ephemeral_env = module.terraservice.is_ephemeral_env
-  latest_version   = module.terraservice.latest_bfd_release
+  default_tags       = module.terraservice.default_tags
+  env                = module.terraservice.env
+  seed_env           = module.terraservice.seed_env
+  is_ephemeral_env   = module.terraservice.is_ephemeral_env
+  latest_bfd_release = module.terraservice.latest_bfd_release
+  bfd_version        = var.bfd_version_override == null ? local.latest_bfd_release : var.bfd_version_override
 
   service   = "eft"
   layer     = "data"

--- a/ops/terraform/services/eft/main.tf
+++ b/ops/terraform/services/eft/main.tf
@@ -207,7 +207,7 @@ locals {
   outbound_lambda_name         = "sftp-outbound-transfer"
   outbound_lambda_full_name    = "${local.full_name}-${local.outbound_lambda_name}"
   outbound_lambda_src          = replace(local.outbound_lambda_name, "-", "_")
-  outbound_lambda_image_uri    = "${data.aws_ecr_repository.ecr.repository_url}:${local.latest_version}"
+  outbound_lambda_image_uri    = "${data.aws_ecr_repository.ecr.repository_url}:${local.bfd_version}"
   outbound_notifs_topic_prefix = "${local.full_name}-outbound-events"
   # For some reason, the transfer server endpoint service does not support us-east-1b and instead
   # opts to support us-east-1d. In order to enable support for this sub-az in the future

--- a/ops/terraform/services/eft/variables.tf
+++ b/ops/terraform/services/eft/variables.tf
@@ -1,0 +1,5 @@
+variable "bfd_version_override" {
+  default     = null
+  description = "BFD release version override. When empty, defaults to resolving the release version from GitHub releases."
+  type        = string
+}


### PR DESCRIPTION
**JIRA Ticket:**
[BFD-3408](https://jira.cms.gov/browse/BFD-3408)

**User Story or Bug Summary:**
BFD EFT terraservice fails to deploy when attempting to resolve the latest github release version.

---

### What Does This PR Do?
While this does not address the issues with Jenkins pipeline and resolving the latest release version itself, it should resolve the immediate deployment pipeline issues where this is most problematic. With this, the EFT terraservice now uses the GitHub-derived latest release version as a default when no such override is provided, similar to how the other terraservices function.

### What Should Reviewers Watch For?
<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items to the following list here -->
* Verify all PR security questions and checklists have been completed and addressed.


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then **you must** supply a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence here: **N/A**

    * Does this PR add any new software dependencies? 
      * [ ] Yes
      * [x] No
    * Does this PR modify or invalidate any of our security controls?
      * [ ] Yes
      * [x] No
    * Does this PR store or transmit data that was not stored or transmitted before?
      * [ ] Yes
      * [x] No

* If the answer to any of the questions below is **Yes**, then please add @<!-- -->StewGoin as a reviewer, and note that this PR **should not be merged** unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons?
      * [ ] Yes
      * [x] No

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following prerequisite changes have been fully deployed:

* N/A


### Submitter Checklist
<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [x] I have named this PR and branch so they are [automatically linked](https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html) to the (most) relevant Jira issue. Ie: `BFD-123: Adds foo`
* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] The data dictionary has been updated with any field mapping changes, if any were made.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. DC GEO, BB2, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.