### PR TITLE
BFD-3508: Introduce Automatic Scaling of RDS Reader Nodes

### DIFF
--- a/ops/jenkins/bfd-deploy-apps/Jenkinsfile
+++ b/ops/jenkins/bfd-deploy-apps/Jenkinsfile
@@ -19,6 +19,11 @@ properties([
     booleanParam(name: 'force_migrator_deployment', description: 'When true, force the migrator to deploy.',
       defaultValue: false),
 
+    booleanParam(
+      name: 'disable_rds_scheduling_override',
+      description: 'When true, disables RDS off-hours scheduled scaling of reader nodes. Applicable only to ephemeral/test environments',
+      defaultValue: false),
+
     string(name: 'server_regression_image_override',
       description: 'Overrides the Docker image tag used when deploying the server-regression lambda',
       defaultValue: null)
@@ -195,11 +200,15 @@ spec:
                 script {
                     currentStage = env.STAGE_NAME
                     try {
+                        // Guard against Jenkins' poor parameter handling on first run
+                        def disableRdsScheduledScaling = params.disable_rds_scheduling_override == null ? false : params.disable_rds_scheduling_override
+                        def terraformVars = [disable_rds_scheduling_override: disableRdsScheduledScaling]
                         lock(resource: lockResource) {
                             awsAuth.assumeRole()
                             terraform.deployTerraservice(
                                 env: trimmedEnv,
-                                directory: 'ops/terraform/services/common'
+                                directory: 'ops/terraform/services/common',
+                                tfVars: terraformVars
                             )
                         }
                     } catch (org.jenkinsci.plugins.workflow.steps.FlowInterruptedException e) {

--- a/ops/terraform/services/base/values/ephemeral.yaml
+++ b/ops/terraform/services/base/values/ephemeral.yaml
@@ -5,7 +5,11 @@
 /bfd/${env}/common/nonsensitive/rds_backup_retention_period: 1
 /bfd/${env}/common/nonsensitive/rds_cluster_identifier: bfd-${env}-aurora-cluster
 /bfd/${env}/common/nonsensitive/rds_iam_database_authentication_enabled: true
-/bfd/${env}/common/nonsensitive/rds_instance_count: 1
+/bfd/${env}/common/nonsensitive/rds_min_reader_nodes: 0 # Only enable writer node by default
+/bfd/${env}/common/nonsensitive/rds_max_reader_nodes: 0 # Only enable writer node by default
+/bfd/${env}/common/nonsensitive/rds_scaling_cpu_target: 75
+/bfd/${env}/common/nonsensitive/rds_scale_in_cooldown: 300
+/bfd/${env}/common/nonsensitive/rds_scale_out_cooldown: 300
 /bfd/${env}/migrator/nonsensitive/instance_type: m6a.large
 /bfd/${env}/migrator/nonsensitive/volume_iops: 3000
 /bfd/${env}/migrator/nonsensitive/volume_size: 100

--- a/ops/terraform/services/base/values/prod-sbx.yaml
+++ b/ops/terraform/services/base/values/prod-sbx.yaml
@@ -58,8 +58,12 @@
 /bfd/${env}/common/nonsensitive/rds_master_username: bfduser
 /bfd/${env}/common/nonsensitive/rds_cluster_identifier: bfd-prod-sbx-aurora-cluster
 /bfd/${env}/common/nonsensitive/rds_instance_class: db.r6i.2xlarge
-/bfd/${env}/common/nonsensitive/rds_instance_count: "2"
 /bfd/${env}/common/nonsensitive/rds_security_group: bfd-prod-sbx-aurora-cluster
+/bfd/${env}/common/nonsensitive/rds_min_reader_nodes: 1
+/bfd/${env}/common/nonsensitive/rds_max_reader_nodes: 1
+/bfd/${env}/common/nonsensitive/rds_scaling_cpu_target: 75
+/bfd/${env}/common/nonsensitive/rds_scale_in_cooldown: 300
+/bfd/${env}/common/nonsensitive/rds_scale_out_cooldown: 300
 /bfd/${env}/common/nonsensitive/vpc_name: bfd-prod-sbx-vpc
 /bfd/${env}/common/nonsensitive/vpn_security_group: bfd-prod-sbx-vpn-private
 /bfd/${env}/migrator/nonsensitive/ref_dir: /opt/bfd-db-migrator

--- a/ops/terraform/services/base/values/prod.yaml
+++ b/ops/terraform/services/base/values/prod.yaml
@@ -108,8 +108,12 @@
 /bfd/${env}/common/nonsensitive/rds_master_username: bfduser
 /bfd/${env}/common/nonsensitive/rds_cluster_identifier: bfd-prod-aurora-cluster
 /bfd/${env}/common/nonsensitive/rds_instance_class: db.r6i.12xlarge
-/bfd/${env}/common/nonsensitive/rds_instance_count: "3"
 /bfd/${env}/common/nonsensitive/rds_security_group: bfd-prod-aurora-cluster
+/bfd/${env}/common/nonsensitive/rds_min_reader_nodes: 1
+/bfd/${env}/common/nonsensitive/rds_max_reader_nodes: 3
+/bfd/${env}/common/nonsensitive/rds_scaling_cpu_target: 75
+/bfd/${env}/common/nonsensitive/rds_scale_in_cooldown: 300
+/bfd/${env}/common/nonsensitive/rds_scale_out_cooldown: 300
 /bfd/${env}/common/nonsensitive/vpc_name: bfd-prod-vpc
 /bfd/${env}/common/nonsensitive/vpn_security_group: bfd-prod-vpn-private
 /bfd/${env}/migrator/nonsensitive/ref_dir: /opt/bfd-db-migrator

--- a/ops/terraform/services/base/values/test.yaml
+++ b/ops/terraform/services/base/values/test.yaml
@@ -111,8 +111,12 @@
 /bfd/${env}/common/nonsensitive/rds_master_username: bfduser
 /bfd/${env}/common/nonsensitive/rds_cluster_identifier: bfd-test-aurora-cluster
 /bfd/${env}/common/nonsensitive/rds_instance_class: db.r6i.2xlarge
-/bfd/${env}/common/nonsensitive/rds_instance_count: "1"
 /bfd/${env}/common/nonsensitive/rds_security_group: bfd-test-aurora-cluster
+/bfd/${env}/common/nonsensitive/rds_min_reader_nodes: 0
+/bfd/${env}/common/nonsensitive/rds_max_reader_nodes: 0
+/bfd/${env}/common/nonsensitive/rds_scaling_cpu_target: 75
+/bfd/${env}/common/nonsensitive/rds_scale_in_cooldown: 300
+/bfd/${env}/common/nonsensitive/rds_scale_out_cooldown: 300
 /bfd/${env}/common/nonsensitive/vpc_name: bfd-test-vpc
 /bfd/${env}/common/nonsensitive/vpn_security_group: bfd-test-vpn-private
 /bfd/${env}/migrator/nonsensitive/ref_dir: /opt/bfd-db-migrator

--- a/ops/terraform/services/common/README.md
+++ b/ops/terraform/services/common/README.md
@@ -30,35 +30,38 @@ In addition to the [Requirements (below)](#requirements), you (or the automation
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.22 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.53.0 |
 
 <!-- GENERATED WITH `terraform-docs .`
-Updates to text between BEGIN_TF_DOCS and END_TFDOCS tags
-will be overwritten.
-For more details, see the file '.terraform-docs.yml' or
-https://terraform-docs.io/user-guide/configuration/
+     Updates to text between BEGIN_TF_DOCS and END_TFDOCS tags
+     will be overwritten.
+     For more details, see the file '.terraform-docs.yml' or
+     https://terraform-docs.io/user-guide/configuration/
 -->
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_disable_rds_scheduling_override"></a> [disable\_rds\_scheduling\_override](#input\_disable\_rds\_scheduling\_override) | If true, RDS off hours scheduled scale-in actions will be disabled for this environment. Defaults<br>  to false. | `bool` | `false` | no |
 | <a name="input_rds_apply_immediately"></a> [rds\_apply\_immediately](#input\_rds\_apply\_immediately) | Apply any changes to an rds cluster immediately. Use caution as this may cause downtime. Defaults to false. | `bool` | `false` | no |
 | <a name="input_rds_deletion_protection_override"></a> [rds\_deletion\_protection\_override](#input\_rds\_deletion\_protection\_override) | RDS Deletion Protection Override: `true` to enable deletion protection, `false` to disable deletion protection. The<br>  default `null` will use whatever the default value is for the given environment. For example, normally we disable<br>  deletion protection for ephemeral clusters; setting this to `true` would enable it. | `bool` | `null` | no |
 
 <!-- GENERATED WITH `terraform-docs .`
-Manually updating the README.md will be overwritten.
-For more details, see the file '.terraform-docs.yml' or
-https://terraform-docs.io/user-guide/configuration/
+     Manually updating the README.md will be overwritten.
+     For more details, see the file '.terraform-docs.yml' or
+     https://terraform-docs.io/user-guide/configuration/
 -->
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [aws_appautoscaling_scheduled_action.scale_in](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_scheduled_action) | resource |
-| [aws_appautoscaling_scheduled_action.scale_out](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_scheduled_action) | resource |
-| [aws_appautoscaling_target.replicas](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_target) | resource |
+| [aws_appautoscaling_policy.replicas_cpu_scaling](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_policy) | resource |
+| [aws_appautoscaling_scheduled_action.off_hours_scale_in](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_scheduled_action) | resource |
+| [aws_appautoscaling_scheduled_action.work_hours_scale_out](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_scheduled_action) | resource |
+| [aws_appautoscaling_target.dynamic_replicas](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_target) | resource |
+| [aws_appautoscaling_target.static_replicas](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/appautoscaling_target) | resource |
 | [aws_cloudwatch_log_group.var_log_messages](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.var_log_secure](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_db_parameter_group.aurora_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_parameter_group) | resource |
@@ -71,10 +74,9 @@ https://terraform-docs.io/user-guide/configuration/
 | [aws_iam_role_policy.db_auth](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.db_auth](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_rds_cluster.aurora_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster) | resource |
-| [aws_rds_cluster_endpoint.beta_reader](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_endpoint) | resource |
-| [aws_rds_cluster_endpoint.readers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_endpoint) | resource |
-| [aws_rds_cluster_instance.nodes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_instance) | resource |
+| [aws_rds_cluster_instance.writer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_instance) | resource |
 | [aws_rds_cluster_parameter_group.aurora_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_parameter_group) | resource |
+| [aws_route53_zone.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 | [aws_s3_bucket.logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_logging.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
@@ -99,9 +101,6 @@ https://terraform-docs.io/user-guide/configuration/
 | [aws_security_group.management](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
 | [aws_security_group.tools](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
 | [aws_security_group.vpn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
-| [aws_ssm_parameter.medicare_opt_out_config_admin_users](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
-| [aws_ssm_parameter.medicare_opt_out_config_read_roles](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
-| [aws_ssm_parameter.medicare_opt_out_config_write_accts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameters_by_path.nonsensitive](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameters_by_path) | data source |
 | [aws_ssm_parameters_by_path.sensitive](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameters_by_path) | data source |
 | [aws_subnet.data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |

--- a/ops/terraform/services/common/app-autoscaling.tf
+++ b/ops/terraform/services/common/app-autoscaling.tf
@@ -1,6 +1,6 @@
-resource "aws_appautoscaling_target" "replicas" {
-  # only applicable for test environment
-  count = local.env == "test" ? 1 : 0
+resource "aws_appautoscaling_target" "dynamic_replicas" {
+  # only applicable for test environment or ephemeral environments
+  count = local.env == "test" || local.is_ephemeral_env ? 1 : 0
 
   service_namespace  = "rds"
   scalable_dimension = "rds:cluster:ReadReplicaCount"
@@ -9,8 +9,8 @@ resource "aws_appautoscaling_target" "replicas" {
   # NOTE: These are the initial, additional capacity settings for the target. Scaling events by schedule and
   # policy directly update these values on the app autoscaling target. As a result, changes to either
   # min_capacity and max_capacity fields are ignored by the lifecycle meta argument below.
-  min_capacity = 0
-  max_capacity = 0
+  min_capacity = local.rds_min_reader_nodes
+  max_capacity = local.rds_max_reader_nodes
 
   lifecycle {
     ignore_changes = [
@@ -20,37 +20,69 @@ resource "aws_appautoscaling_target" "replicas" {
   }
 }
 
-resource "aws_appautoscaling_scheduled_action" "scale_out" {
-  count = local.env == "test" ? 1 : 0
+resource "aws_appautoscaling_target" "static_replicas" {
+  # only applicable for prod/prod-sbx (not test or ephemeral)
+  count = local.env != "test" && !local.is_ephemeral_env ? 1 : 0
 
-  name               = "bfd-${local.env}-scale-out"
-  service_namespace  = aws_appautoscaling_target.replicas[0].service_namespace
-  resource_id        = aws_appautoscaling_target.replicas[0].resource_id
-  scalable_dimension = aws_appautoscaling_target.replicas[0].scalable_dimension
+  service_namespace  = "rds"
+  scalable_dimension = "rds:cluster:ReadReplicaCount"
+  resource_id        = "cluster:${aws_rds_cluster.aurora_cluster.id}"
+
+  min_capacity = local.rds_min_reader_nodes
+  max_capacity = local.rds_max_reader_nodes
+}
+
+locals {
+  replicas_scaling_target = local.env == "test" || local.is_ephemeral_env ? one(aws_appautoscaling_target.dynamic_replicas) : one(aws_appautoscaling_target.static_replicas)
+}
+
+resource "aws_appautoscaling_policy" "replicas_cpu_scaling" {
+  name               = "bfd-${local.env}-cpu-scaling"
+  service_namespace  = local.replicas_scaling_target.namespace
+  resource_id        = local.replicas_scaling_target.resource_id
+  scalable_dimension = local.replicas_scaling_target.scalable_dimension
+  policy_type        = "TargetTrackingScaling"
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "RDSReaderAverageCPUUtilization"
+    }
+
+    target_value       = local.rds_scaling_cpu_target
+    scale_in_cooldown  = local.rds_scale_in_cooldown
+    scale_out_cooldown = local.rds_scale_out_cooldown
+  }
+}
+
+resource "aws_appautoscaling_scheduled_action" "work_hours_scale_out" {
+  count = local.env == "test" || local.is_ephemeral_env ? 1 : 0
+
+  name               = "bfd-${local.env}-work-hours-scale-out"
+  service_namespace  = local.replicas_scaling_target.namespace
+  resource_id        = local.replicas_scaling_target.resource_id
+  scalable_dimension = local.replicas_scaling_target.scalable_dimension
   schedule           = "cron(00 07 ? * MON-FRI *)"
   timezone           = "America/New_York"
 
   # NOTE: min_capacity and max_capacity will count nodes that are and
   # are not managed by app-autoscaling when calculating the desired capacity.
   scalable_target_action {
-    min_capacity = 1
-    max_capacity = 1
+    min_capacity = local.rds_min_reader_nodes
+    max_capacity = local.rds_max_reader_nodes
   }
 }
 
-resource "aws_appautoscaling_scheduled_action" "scale_in" {
-  count = local.env == "test" ? 1 : 0
+resource "aws_appautoscaling_scheduled_action" "off_hours_scale_in" {
+  count = local.env == "test" || local.is_ephemeral_env ? 1 : 0
 
-  name               = "bfd-${local.env}-scale-in"
-  service_namespace  = aws_appautoscaling_target.replicas[0].service_namespace
-  resource_id        = aws_appautoscaling_target.replicas[0].resource_id
-  scalable_dimension = aws_appautoscaling_target.replicas[0].scalable_dimension
+  name               = "bfd-${local.env}-off-hours-scale-in"
+  service_namespace  = local.replicas_scaling_target.namespace
+  resource_id        = local.replicas_scaling_target.resource_id
+  scalable_dimension = local.replicas_scaling_target.scalable_dimension
   schedule           = "cron(00 19 ? * MON-FRI *)"
   timezone           = "America/New_York"
 
   # NOTE: min_capacity and max_capacity only impacts nodes managed by app-autoscaling
-  # when this number is fewer than the number of nodes defined by the cluster
-  # This will not scale-in nodes defined under aws_rds_cluster_instance.nodes
   scalable_target_action {
     min_capacity = 0
     max_capacity = 0

--- a/ops/terraform/services/common/aurora-cluster.tf
+++ b/ops/terraform/services/common/aurora-cluster.tf
@@ -116,8 +116,7 @@ resource "aws_db_parameter_group" "aurora_cluster" {
   }
 }
 
-resource "aws_rds_cluster_instance" "nodes" {
-  count                           = local.rds_instance_count
+resource "aws_rds_cluster_instance" "writer" {
   auto_minor_version_upgrade      = true
   ca_cert_identifier              = "rds-ca-rsa4096-g1"
   cluster_identifier              = aws_rds_cluster.aurora_cluster.id
@@ -126,7 +125,7 @@ resource "aws_rds_cluster_instance" "nodes" {
   db_parameter_group_name         = aws_rds_cluster.aurora_cluster.db_instance_parameter_group_name
   engine                          = aws_rds_cluster.aurora_cluster.engine
   engine_version                  = aws_rds_cluster.aurora_cluster.engine_version
-  identifier                      = "${aws_rds_cluster.aurora_cluster.id}-node-${count.index}"
+  identifier                      = "${aws_rds_cluster.aurora_cluster.id}-writer-node"
   instance_class                  = local.rds_instance_class
   monitoring_interval             = 15
   monitoring_role_arn             = data.aws_iam_role.monitoring.arn
@@ -135,41 +134,4 @@ resource "aws_rds_cluster_instance" "nodes" {
   preferred_maintenance_window    = aws_rds_cluster.aurora_cluster.preferred_maintenance_window
   publicly_accessible             = false
   tags                            = { Layer = "data" }
-}
-
-### The following configuration is almost exlcusively for separated, custom reader endpoints
-### supporting development of synthea data
-locals {
-  # declare a reader_nodes collection for nodes that aren't currently identified as a writer
-  reader_nodes = [for node in aws_rds_cluster_instance.nodes : node if !node.writer]
-}
-
-# This is the general reader endpoint in production
-resource "aws_rds_cluster_endpoint" "readers" {
-  # Create the separate endpoint for prod clusters
-  count = local.env == "prod" ? 1 : 0
-
-  cluster_identifier          = aws_rds_cluster.aurora_cluster.id
-  cluster_endpoint_identifier = "bfd-${local.env}-ro"
-  custom_endpoint_type        = "READER"
-
-  # EXCLUDED_MEMBERS assigns ALL but the last reader to the custom endpoint
-  excluded_members = [
-    element(local.reader_nodes, length(local.reader_nodes) - 1).id
-  ]
-}
-
-# This is the reserved synthea reader endpoint in production
-resource "aws_rds_cluster_endpoint" "beta_reader" {
-  # Create the separate endpoint for prod clusters
-  count = local.env == "prod" ? 1 : 0
-
-  cluster_identifier          = aws_rds_cluster.aurora_cluster.id
-  cluster_endpoint_identifier = "bfd-${local.env}-beta-reader"
-  custom_endpoint_type        = "READER"
-
-  # STATIC_MEMBERS assigns just the last reader node to the custom endpoint
-  static_members = [
-    element(local.reader_nodes, length(local.reader_nodes) - 1).id
-  ]
 }

--- a/ops/terraform/services/common/main.tf
+++ b/ops/terraform/services/common/main.tf
@@ -55,6 +55,11 @@ locals {
   rds_iam_database_authentication_enabled = local.nonsensitive_config["rds_iam_database_authentication_enabled"]
   rds_instance_class                      = local.nonsensitive_config["rds_instance_class"]
   rds_instance_count                      = local.nonsensitive_config["rds_instance_count"]
+  rds_scaling_min_instances               = local.nonsensitive_config["rds_scaling_min_instances"]
+  rds_scaling_max_instances               = local.nonsensitive_config["rds_scaling_max_instances"]
+  rds_scaling_cpu_target                  = local.nonsensitive_config["rds_scaling_cpu_target"]
+  rds_scale_in_cooldown                   = local.nonsensitive_config["rds_scale_in_cooldown"]
+  rds_scale_out_cooldown                  = local.nonsensitive_config["rds_scale_out_cooldown"]
   rds_master_password                     = lookup(local.sensitive_config, "rds_master_password", null)
   rds_master_username                     = lookup(local.nonsensitive_config, "rds_master_username", null)
   rds_snapshot_identifier                 = lookup(local.nonsensitive_config, "rds_snapshot_identifier", null)

--- a/ops/terraform/services/common/main.tf
+++ b/ops/terraform/services/common/main.tf
@@ -54,9 +54,8 @@ locals {
   rds_cluster_identifier                  = "bfd-${local.env}-aurora-cluster"
   rds_iam_database_authentication_enabled = local.nonsensitive_config["rds_iam_database_authentication_enabled"]
   rds_instance_class                      = local.nonsensitive_config["rds_instance_class"]
-  rds_instance_count                      = local.nonsensitive_config["rds_instance_count"]
-  rds_scaling_min_instances               = local.nonsensitive_config["rds_scaling_min_instances"]
-  rds_scaling_max_instances               = local.nonsensitive_config["rds_scaling_max_instances"]
+  rds_min_reader_nodes                    = local.nonsensitive_config["rds_min_reader_nodes"]
+  rds_max_reader_nodes                    = local.nonsensitive_config["rds_max_reader_nodes"]
   rds_scaling_cpu_target                  = local.nonsensitive_config["rds_scaling_cpu_target"]
   rds_scale_in_cooldown                   = local.nonsensitive_config["rds_scale_in_cooldown"]
   rds_scale_out_cooldown                  = local.nonsensitive_config["rds_scale_out_cooldown"]

--- a/ops/terraform/services/common/scripts/destroy-autoscaled-nodes.sh
+++ b/ops/terraform/services/common/scripts/destroy-autoscaled-nodes.sh
@@ -1,30 +1,93 @@
 #!/bin/bash
+# Terraform helper script called as a local-exec provisioner at destroy-time of the Aurora cluster
+# resource. This script will enumerate the autoscaled reader nodes within the given Aurora cluster
+# (provided by environment variable $DB_CLUSTER_ID), mark them all for deletion, and then wait
+# indefinitely for all nodes to be successfully deleted.
 
-set -x
+set -euo pipefail
 
-nodes_in_cluster=$(
-  aws rds describe-db-clusters --db-cluster-identifier "$DB_CLUSTER_ID" |
-    jq -r '.DBClusters[].DBClusterMembers[].DBInstanceIdentifier'
-)
+# Be _extra_ careful about the cluster ID given by the $DB_CLUSTER_ID environment variable.
+# Specifically, remove all whitespace (which is invalid for a cluster ID) and ensure that the
+# resulting, trimmed ID is non-empty before even making any deletion attempts as the AWS CLI will
+# treat an empty cluster ID as equivalent to "give me all clusters" when calling
+# describe-db-clusters
+trimmed_cluster_id="$(echo "$DB_CLUSTER_ID" | tr -d '[:space:]')"
+if [[ -z $trimmed_cluster_id ]]; then
+  echo "DB_CLUSTER_ID must not be an empty string or whitespace"
+  exit 1
+fi
+
+# jq expression returns the first element in the returned array as a precaution against a scenario
+# where multiple clusters are erroneously returned. Otherwise, the nodes in all clusters would be
+# marked for deletion. Additionally, we select for only the nodes with names containing
+# "autoscaling" to avoid possibly deleting the writer node which is managed by Terraform directly
+nodes_in_cluster="$(
+  aws rds describe-db-clusters --db-cluster-identifier "$trimmed_cluster_id" |
+    jq -r '.DBClusters[0].DBClusterMembers[].DBInstanceIdentifier | select(. | contains("autoscaling"))'
+)"
+
+# If there are no autoscaling nodes to delete, immediately exit
+if [[ -z $nodes_in_cluster ]]; then
+  echo "No nodes in $trimmed_cluster_id to delete"
+  exit
+fi
 
 for node in $nodes_in_cluster; do
-  instance_status="$(aws rds describe-db-instances --db-instance-identifier "$node" | jq -r '.DBInstances[].DBInstanceStatus')"
-  if [[ -n $instance_status && $instance_status != "deleting" ]]; then
+  # stderr is redirected to /dev/null to ensure that if there are any errors this variable is empty
+  # and no operation is done
+  instance_details_json="$(
+    aws rds describe-db-instances --db-instance-identifier "$node" 2>/dev/null || echo ""
+  )"
+
+  # If the instance is empty, then don't do anything
+  if [[ -z $instance_details_json ]]; then
+    continue
+  fi
+
+  instance_status="$(
+    echo "$instance_details_json" |
+      jq --arg trimmed_cluster_id "$trimmed_cluster_id" \
+        -r '.DBInstances[0] | select(.DBClusterIdentifier == $trimmed_cluster_id) | .DBInstanceStatus'
+  )"
+  if [[ $instance_status != "deleting" ]]; then
+    echo "Marking $node for deletion"
+    # Redirect stdout to /dev/null as the JSON response is unnecessary
     aws rds delete-db-instance --db-instance-identifier "$node" > /dev/null
   fi
 done
 
+echo "All autoscaling nodes in $trimmed_cluster_id marked for deletion"
+
 while true; do
+  echo "Verifying if all autoscaling nodes in $trimmed_cluster_id have been deleted..."
+
   deleting_nodes=0
   for node in $nodes_in_cluster; do
-    instance_status="$(aws rds describe-db-instances --db-instance-identifier "$node" | jq -r '.DBInstances[].DBInstanceStatus')"
+    instance_details_json="$(
+      aws rds describe-db-instances --db-instance-identifier "$node" 2>/dev/null || echo ""
+    )"
+
+    # If the instance is empty, then don't do anything
+    if [[ -z $instance_details_json ]]; then
+      continue
+    fi
+
+    instance_status="$(
+      echo "$instance_details_json" |
+        jq --arg trimmed_cluster_id "$trimmed_cluster_id" \
+          -r '.DBInstances[0] | select(.DBClusterIdentifier == $trimmed_cluster_id) | .DBInstanceStatus'
+    )"
     if [[ $instance_status == "deleting" ]]; then
+      echo "Deletion of $node is still in progress"
       ((deleting_nodes += 1))
     fi
   done
 
-  if (( deleting_nodes == 0)); then
+  if ((deleting_nodes == 0)); then
+    echo "All autoscaling nodes in $trimmed_cluster_id have been deleted"
     exit
   fi
+
+  echo "$deleting_nodes autoscaling node(s) have not yet been deleted. Sleeping for 5 seconds before retrying"
   sleep 5
 done

--- a/ops/terraform/services/common/scripts/destroy-autoscaled-nodes.sh
+++ b/ops/terraform/services/common/scripts/destroy-autoscaled-nodes.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -x
+
+nodes_in_cluster=$(
+  aws rds describe-db-clusters --db-cluster-identifier "$DB_CLUSTER_ID" |
+    jq -r '.DBClusters[].DBClusterMembers[].DBInstanceIdentifier'
+)
+
+for node in $nodes_in_cluster; do
+  instance_status="$(aws rds describe-db-instances --db-instance-identifier "$node" | jq -r '.DBInstances[].DBInstanceStatus')"
+  if [[ -n $instance_status && $instance_status != "deleting" ]]; then
+    aws rds delete-db-instance --db-instance-identifier "$node" > /dev/null
+  fi
+done
+
+while true; do
+  deleting_nodes=0
+  for node in $nodes_in_cluster; do
+    instance_status="$(aws rds describe-db-instances --db-instance-identifier "$node" | jq -r '.DBInstances[].DBInstanceStatus')"
+    if [[ $instance_status == "deleting" ]]; then
+      ((deleting_nodes += 1))
+    fi
+  done
+
+  if (( deleting_nodes == 0)); then
+    exit
+  fi
+  sleep 5
+done

--- a/ops/terraform/services/common/variables.tf
+++ b/ops/terraform/services/common/variables.tf
@@ -13,3 +13,12 @@ variable "rds_deletion_protection_override" {
   EOF
   type        = bool
 }
+
+variable "disable_rds_scheduling_override" {
+  default     = false
+  description = <<EOF
+  If true, RDS off hours scheduled scale-in actions will be disabled for this environment. Defaults
+  to false.
+  EOF
+  type        = bool
+}


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
BFD-3508

### What Does This PR Do?

<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

**NOTE: These changes modify the names of some Terraform resource definitions in `common`, specifically existing application autoscaling resources and the `aws_rds_cluster_instance.nodes` resource. We will need to move these resources to their new names prior to deployment in all environments**

This PR implements RDS application autoscaling which allows us to automatically scale-in and scale-out read replicas in our Aurora clusters.

More specifically:

- Application autoscaling targets and policies have been defined in `common/app-autoscaling.tf` to enable CPU-based automatic scaling of RDS reader nodes. Corresponding SSM parameters have been introduced to control the target CPU utilization (set to 75% average across all nodes in all environments), the scale-out and scale-in cooldowns (300 seconds in all environments), and the min and max capacity (differs between environments, see changes to environment `.yaml`s)
- The Terraform that manages the nodes in the Aurora cluster has been refactored such that Terraform only creates the _writer_ node. If reader nodes are desired in a given environment, the `/bfd/*/common/nonsensitive/rds_min_reader_nodes` SSM parameter should be set to the minimum number of desired reader nodes and the application autoscaling policies will then create the readers automatically after the writer node is available
- The writer node in each Aurora cluster is now named `<CLUSTER_ID>-writer-node`. There is no means by which we can control the name of the read replicas created by application autoscaling, so there is no reason to continue with our existing naming scheme
- Existing scheduled scaling policies/actions in `test` have been extended to also cover ephemeral environments so that ephemeral environments will also scale-in after hours and scale-out during work hours. A new variable override has been added to `common`, `disable_rds_scheduling_override`, that allows the operator to disable this scheduled scaling behavior if there is a need
- A corresponding parameter that controls the aforementioned override has been added to the `bfd-deploy-apps` Jenkins pipeline for use with ephemeral environments
- A `destroy`-time [`local-exec` provisioner](https://developer.hashicorp.com/terraform/language/resources/provisioners/local-exec) has been added to the `aws_rds_cluster.aurora_cluster` resource that runs a newly-added bash script: `ops/terraform/services/common/scripts/destroy-autoscaled-nodes.sh`. This is necessary as Terraform does not manage autoscaled nodes and Aurora clusters cannot be deleted if they are not empty, so attempting to `terraform destroy` an ephemeral environment with autoscaled nodes would otherwise be impossible. This new script will enumerate all autoscaled reader nodes within the cluster, mark them for deletion, and wait indefinitely for them to be deleted before Terraform attempts to destroy the Aurora cluster
- Some Terraform resources have been renamed to better reflect their purpose
- Unused `prod` endpoints have been removed entirely (the "beta reader" and "readers" endpoints, specifically)

### What Should Reviewers Watch For?

<!--
Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:

<!-- Add some items here -->

- Scrutinize the `ops/terraform/services/common/scripts/destroy-autoscaled-nodes.sh` for any possible logic error. I've added as many safeguards as I could possibly think of, but an earlier version of this script caused our most recent incident
- Does 75% CPU across all nodes make sense as a target? Does this need to be higher/lower? Do the values for the cooldowns also make sense?
- Does it make sense to do scheduled scale-in/scale-out in ephemeral environments?

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:

- Adds any new software dependencies
- Modifies any security controls
- Adds new transmission or storage of data
- Any other changes that could possibly affect security?

- [x] I have considered the above security implications as it relates to this PR. (If one or more of the above apply, it cannot be merged without the ISSO or team security engineer's (`@sb-benohe`) approval.)

### Validation

Have you fully verified and tested these changes? Is the acceptance criteria met? Please provide reproducible testing instructions, code snippets, or screenshots as applicable.

- `terraform apply`ing these changes to the `3508-test` ephemeral environment, _verifying that_:
  - It `apply`s successfully
  - No unexpected resources were created
  - Application autoscaling policies automatically create the minimum number of reader nodes specified by configuration
- Deploying `server` _immediately after_ `common` in `3508-test`, _verifying that_:
  - The BFD Server instances pass their healthchecks and are able to connect to the database, even if the autoscaled reader node(s) haven't yet scaled out
  - (Assuming BFD-3507 is in effect) the BFD Server automatically connects to the autoscaled reader node once it is available and all connections are drained from the writer
- Waiting until 7 PM ET after deployment of `3508-test` with an autoscaled reader node in the Aurora cluster, _verifying that_ the autoscaled node is scaled-in due to off hours scale-in scheduled actions
  - Correspondingly, the work hours scale out scheduled action successfully _scaled-out_ reader nodes
- `terraform destroy`ing `common` in `3508-test`, _verifying that_:
  - The `local-exec` provisioner on the cluster successfully deleted the autoscaled reader nodes without affecting other nodes in other clusters
  - All resources are destroyed successfully without error
