### PR TITLE
BFD-3465: Implement CI Workflow for Static Site

### DIFF
--- a/.github/actions/await-cw-logging/action.yml
+++ b/.github/actions/await-cw-logging/action.yml
@@ -20,12 +20,12 @@ runs:
   steps:
     - name: Validate inputs
       run: |
-        int_regex='^[0-9]+$'
-        if ! [[ "${{ inputs.waitTimeSeconds }}" =~ $re && "${{ inputs.waitTimeSeconds }}" != 0 ]]; then
+        pos_int_regex='^[1-9][0-9]*$'
+        if ! [[ "${{ inputs.waitTimeSeconds }}" =~ $pos_int_regex ]]; then
           echo "'waitTimeSeconds' must be a positive integer"
           exit 1
         fi
-        if ! [[ "${{ inputs.sleepTimeSeconds }}" =~ $re && "${{ inputs.sleepTimeSeconds }}" != 0 ]]; then
+        if ! [[ "${{ inputs.sleepTimeSeconds }}" =~ $pos_int_regex ]]; then
           echo "'sleepTimeSeconds' must be a positive integer"
           exit 1
         fi

--- a/.github/actions/await-cw-logging/action.yml
+++ b/.github/actions/await-cw-logging/action.yml
@@ -40,7 +40,7 @@ runs:
       run: |
         seconds_waited=0
 
-        while (( seconds_waited < ${{ input.waitTimeSeconds }} )); do
+        while (( seconds_waited < ${{ inputs.waitTimeSeconds }} )); do
           remaining_aws_processes="$(ps aux | grep '[p]ut-log-events' || true)"
 
           if [[ -z $remaining_aws_processes ]]; then
@@ -48,8 +48,8 @@ runs:
             exit 0
           fi
 
-          sleep ${{ input.sleepTimeSeconds }}
-          seconds_waited=$(( seconds_waited + ${{ input.sleepTimeSeconds }}))
+          sleep ${{ inputs.sleepTimeSeconds }}
+          seconds_waited=$(( seconds_waited + ${{ inputs.sleepTimeSeconds }}))
         done
 
         echo "Some logs could not be uploaded to CloudWatch"

--- a/.github/actions/await-cw-logging/action.yml
+++ b/.github/actions/await-cw-logging/action.yml
@@ -5,11 +5,11 @@
 name: "Await Background CloudWatch Logging"
 description: "Action that waits for a specified time for ongoing CloudWatch logging to finish"
 inputs:
-  waitTimeSeconds:
+  wait-time-seconds:
     description: "Amount of time, in seconds, to wait total"
     required: true
     default: "60"
-  sleepTimeSeconds:
+  sleep-time-seconds:
     description: >-
       Amount of time, in seconds, to sleep between checking for orphaned AWS CLI PutLogEvents
       processes
@@ -21,12 +21,12 @@ runs:
     - name: Validate inputs
       run: |
         pos_int_regex='^[1-9][0-9]*$'
-        if ! [[ "${{ inputs.waitTimeSeconds }}" =~ $pos_int_regex ]]; then
-          echo "'waitTimeSeconds' must be a positive integer"
+        if ! [[ "${{ inputs.wait-time-seconds }}" =~ $pos_int_regex ]]; then
+          echo "'wait-time-seconds' must be a positive integer"
           exit 1
         fi
-        if ! [[ "${{ inputs.sleepTimeSeconds }}" =~ $pos_int_regex ]]; then
-          echo "'sleepTimeSeconds' must be a positive integer"
+        if ! [[ "${{ inputs.sleep-time-seconds }}" =~ $pos_int_regex ]]; then
+          echo "'sleep-time-seconds' must be a positive integer"
           exit 1
         fi
       shell: bash
@@ -40,7 +40,7 @@ runs:
       run: |
         seconds_waited=0
 
-        while (( seconds_waited < ${{ inputs.waitTimeSeconds }} )); do
+        while (( seconds_waited < ${{ inputs.wait-time-seconds }} )); do
           remaining_aws_processes="$(ps aux | grep '[p]ut-log-events' || true)"
 
           if [[ -z $remaining_aws_processes ]]; then
@@ -48,8 +48,8 @@ runs:
             exit 0
           fi
 
-          sleep ${{ inputs.sleepTimeSeconds }}
-          seconds_waited=$(( seconds_waited + ${{ inputs.sleepTimeSeconds }}))
+          sleep ${{ inputs.sleep-time-seconds }}
+          seconds_waited=$(( seconds_waited + ${{ inputs.sleep-time-seconds }}))
         done
 
         echo "Some logs could not be uploaded to CloudWatch"

--- a/.github/actions/await-cw-logging/action.yml
+++ b/.github/actions/await-cw-logging/action.yml
@@ -1,0 +1,56 @@
+# This Composite Action is a companion to the "stdout-to-cwlogs.sh" script that is used to log
+# dynamic, sensitive stdout from commands in GHA. If any command's stdout is piped to that script,
+# this Action should be included in the Workflow as an "always" step to ensure logs are properly
+# submitted once the Workflow completes
+name: "Await Background CloudWatch Logging"
+description: "Action that waits for a specified time for ongoing CloudWatch logging to finish"
+inputs:
+  waitTimeSeconds:
+    description: "Amount of time, in seconds, to wait total"
+    required: true
+    default: "60"
+  sleepTimeSeconds:
+    description: >-
+      Amount of time, in seconds, to sleep between checking for orphaned AWS CLI PutLogEvents
+      processes
+    required: true
+    default: "1"
+runs:
+  using: "composite"
+  steps:
+    - name: Validate inputs
+      run: |
+        int_regex='^[0-9]+$'
+        if ! [[ "${{ inputs.waitTimeSeconds }}" =~ $re && "${{ inputs.waitTimeSeconds }}" != 0 ]]; then
+          echo "'waitTimeSeconds' must be a positive integer"
+          exit 1
+        fi
+        if ! [[ "${{ inputs.sleepTimeSeconds }}" =~ $re && "${{ inputs.sleepTimeSeconds }}" != 0 ]]; then
+          echo "'sleepTimeSeconds' must be a positive integer"
+          exit 1
+        fi
+      shell: bash
+
+    # The backgrounded AWS CLI invocations of "put-log-events" in "stdout-to-cwlogs.sh" can linger
+    # even after the command it's logging. We don't want to lose those logs, as GHA will
+    # automatically terminate "orphan" background processes in the built-in "Cleanup Job" step. So,
+    # this step ensures that lingering PutLogEvents calls are able to finish before getting
+    # terminated automatically
+    - name: Await AWS put-log-events
+      run: |
+        seconds_waited=0
+
+        while (( seconds_waited < ${{ input.waitTimeSeconds }} )); do
+          remaining_aws_processes="$(ps aux | grep '[p]ut-log-events' || true)"
+
+          if [[ -z $remaining_aws_processes ]]; then
+            echo "All logs have been submitted"
+            exit 0
+          fi
+
+          sleep ${{ input.sleepTimeSeconds }}
+          seconds_waited=$(( seconds_waited + ${{ input.sleepTimeSeconds }}))
+        done
+
+        echo "Some logs could not be uploaded to CloudWatch"
+      shell: bash

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -69,37 +69,17 @@ runs:
         echo "tf_vars_args=$tf_vars_args" >> $GITHUB_OUTPUT
       shell: bash
 
-    - name: Check existing Terraform version
-      id: check-tf-version
+    - name: Check if tfvm is installed
+      id: check-tfvm-installed
       run: |
-        cur_version="NONE"
-        if [[ -x "$(command -v terraform)" ]]; then
-          # Terraform emits multiple unnecessary lines when running "terraform --version" indicating
-          # the OS, arch, whether Terraform is out-of-date, etc. We don't care about anything but
-          # the version, so the grep matches on the version number and returns only the match
-          cur_version="$(terraform --version | grep -Po "(?<=Terraform v)(.*)$")"
-        fi
-        echo "cur_version=$cur_version" >> $GITHUB_OUTPUT
+        is_tfvm_installed="$([[ -x "$(command -v tfvm)" ]] && echo "true" || echo "false")"
+        echo "is_tfvm_installed=$is_tfvm_installed" >> $GITHUB_OUTPUT
       shell: bash
 
-    # - name: Get required Terraform version
-    #   uses: dflook/terraform-version@v1
-    #   id: terraform-version
-    #   with:
-    #     path: ${{ github.workspace }}/${{ inputs.servicePath }}
-
     - name: Setup Terraform
-      # Only install Terraform if the current runner does not have the expected version of Terraform
-      # installed already
-      # if: steps.check-tf-version.outputs.cur_version != steps.terraform-version.outputs.terraform
-      if: steps.check-tf-version.outputs.cur_version == 'NONE'
-      # uses: hashicorp/setup-terraform@v3
+      # Only install tfvm/Terraform if the current runner does not have tfvm installed
+      if: steps.check-tfvm-installed.outputs.is_tfvm_installed == 'false'
       uses: cbuschka/setup-tfvm@v1
-      # with:
-      #   terraform_version: ${{ steps.terraform-version.outputs.terraform }}
-      #   # No subsequent jobs require the output of the Terraform commands, so we can stip installing
-      #   # the wrapper that sets the "stdout", "stderr", etc. outputs on steps running Terraform
-      #   terraform_wrapper: false
 
     - name: Terraform init
       run: |

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -1,20 +1,20 @@
 name: "Deploy Terraservice"
 description: "Composite action to deploy a given Terraservice"
 inputs:
-  bfdEnvironment:
+  bfd-env:
     description: "The BFD environment to deploy the given service to"
     required: true
-  servicePath:
+  service-path:
     description: "The path to the Terraservice relative to the root of the repository"
     required: true
-  cloudwatchLogGroup:
+  cw-log-group:
     description: "Name of CloudWatch Log Group to submit Terraform logs to; must exist"
     required: true
-  cloudwatchLogStream:
+  cw-log-stream:
     description: >-
       Name of CloudWatch Log Stream to submit Terraform logs to; will be created if necessary
     required: true
-  terraformVarsJson:
+  terraform-vars-json:
     description: "JSON object map of variables to their values"
     required: false
     default: "{}"
@@ -28,26 +28,26 @@ runs:
         echo "STDOUT_TO_CWLOGS_SCRIPT=${{ github.workspace }}/.github/scripts/stdout-to-cwlogs.sh" \
           >> $GITHUB_ENV
         # Necessary for the "stdout-to-cwlogs.sh" script
-        echo "CLOUDWATCH_LOG_GROUP=${{ inputs.cloudwatchLogGroup }}" >> $GITHUB_ENV
-        echo "CLOUDWATCH_LOG_STREAM=${{ inputs.cloudwatchLogStream }}" >> $GITHUB_ENV
+        echo "CLOUDWATCH_LOG_GROUP=${{ inputs.cw-log-group }}" >> $GITHUB_ENV
+        echo "CLOUDWATCH_LOG_STREAM=${{ inputs.cw-log-stream }}" >> $GITHUB_ENV
       shell: bash
 
     - name: Validate inputs
       run: |
-        if [[ ! -d "${{ github.workspace }}/${{ inputs.servicePath }}" ]]; then
-          echo "Directory '${{ inputs.servicePath }}' does not exist; has the BFD repo been" \
+        if [[ ! -d "${{ github.workspace }}/${{ inputs.service-path }}" ]]; then
+          echo "Directory '${{ inputs.service-path }}' does not exist; has the BFD repo been" \
             "checked-out?"
           exit 1
         fi
         # See https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_CreateLogStream.html
-        echo "${{ inputs.cloudwatchLogStream }}" | grep -Pv '[:*]'
+        echo "${{ inputs.cw-log-stream }}" | grep -Pv '[:*]'
 
         is_valid_log_group="$(
-          aws logs describe-log-groups --log-group-name-pattern "${{ inputs.cloudwatchLogGroup }}" |
+          aws logs describe-log-groups --log-group-name-pattern "${{ inputs.cw-log-group }}" |
             jq -r '.logGroups != []'
         )"
         if [[ $is_valid_log_group == "false" ]]; then
-          echo "'${{ inputs.cloudwatchLogGroup }}' does not exist; was the the correct Log Group" \
+          echo "'${{ inputs.cw-log-group }}' does not exist; was the the correct Log Group" \
             "specified?"
           exit 1
         fi
@@ -59,8 +59,8 @@ runs:
         # not. Attempt to create it, swallowing any error code that is returned and also capture
         # the stderr output so that it can be checked
         create_log_stream_stderr="$(
-          aws logs create-log-stream --log-group-name "${{ inputs.cloudwatchLogGroup }}" \
-            --log-stream-name "${{ inputs.cloudwatchLogStream }}" 2>&1 >/dev/null || true
+          aws logs create-log-stream --log-group-name "${{ inputs.cw-log-group }}" \
+            --log-stream-name "${{ inputs.cw-log-stream }}" 2>&1 >/dev/null || true
         )"
 
         # If there was an error message logged by create-log-stream and that error was not
@@ -71,12 +71,12 @@ runs:
           $create_log_stream_stderr != *"ResourceAlreadyExistsException"* ]] \
           ; then
           echo "Unrecoverable error occurred when trying to create Log Stream" \
-            "'${{inputs.cloudwatchLogStream }}' in Log Group '${{ inputs.cloudwatchLogGroup }}'"
+            "'${{inputs.cw-log-stream }}' in Log Group '${{ inputs.cw-log-group }}'"
           echo "$create_log_stream_stderr"
           exit 1
         fi
 
-        echo "'${{inputs.cloudwatchLogStream }}' in Log Group '${{ inputs.cloudwatchLogGroup }}'" \
+        echo "'${{inputs.cw-log-stream }}' in Log Group '${{ inputs.cw-log-group }}'" \
           "created or exists already"
         echo "Tail the Log Stream to view Terraform output in realtime"
       shell: bash
@@ -93,7 +93,7 @@ runs:
       id: gen-tf-vars-args
       run: |
         tf_vars_args="$(
-          echo "${{ inputs.terraformVarsJson }}" | jq -r 'to_entries |
+          echo "${{ inputs.terraform-vars-json }}" | jq -r 'to_entries |
             map(select(.value != null and .value != "")) |
             map("\"-var=" + .key + "=" + (.value | tostring)+ "\"") |
             join(" ")'
@@ -115,38 +115,38 @@ runs:
 
     - name: Terraform init
       run: |
-        cd "${{ github.workspace }}/${{ inputs.servicePath }}"
+        cd "${{ github.workspace }}/${{ inputs.service-path }}"
         terraform --version
         terraform init -no-color
       shell: bash
 
     - name: Select Terraform workspace
       run: |
-        cd "${{ github.workspace }}/${{ inputs.servicePath }}"
-        terraform workspace new "${{ inputs.bfdEnvironment }}" 2> /dev/null || true &&\
-        terraform workspace select "${{ inputs.bfdEnvironment }}" -no-color
+        cd "${{ github.workspace }}/${{ inputs.service-path }}"
+        terraform workspace new "${{ inputs.bfd-env }}" 2> /dev/null || true &&\
+        terraform workspace select "${{ inputs.bfd-env }}" -no-color
       shell: bash
 
     - name: Generate Terraform plan
       run: |
-        cd "${{ github.workspace }}/${{ inputs.servicePath }}"
+        cd "${{ github.workspace }}/${{ inputs.service-path }}"
 
         # Often the terraform plan logged to stdout as well as the errors logged to stderr include
         # sensitive/private information. GHA logs are available for anyone logged in with a GitHub
         # account to view, and so this information must be protected. Instead of logging to stdout,
         # all potentially sensitive Terraform log output is instead logged to CloudWatch
-        echo "Generating Terraform plan for ${{ inputs.servicePath }}..."
+        echo "Generating Terraform plan for ${{ inputs.service-path }}..."
         terraform plan ${{ steps.gen-tf-vars-args.outputs.tf_vars_args }} -no-color \
           -out=tfplan 2>&1 | "$STDOUT_TO_CWLOGS_SCRIPT"
-        echo "Plan generated for ${{ inputs.servicePath }} successfully"
+        echo "Plan generated for ${{ inputs.service-path }} successfully"
       shell: bash
 
     - name: Apply Terraservice
       run: |
-        cd "${{ github.workspace }}/${{ inputs.servicePath }}"
-        echo "Applying Terraform plan for ${{ inputs.servicePath }}..."
+        cd "${{ github.workspace }}/${{ inputs.service-path }}"
+        echo "Applying Terraform plan for ${{ inputs.service-path }}..."
         terraform apply -no-color -input=false tfplan 2>&1 | "$STDOUT_TO_CWLOGS_SCRIPT"
-        echo "Terraform plan for ${{ inputs.servicePath }} applied"
+        echo "Terraform plan for ${{ inputs.service-path }} applied"
       shell: bash
 
     # Ensures that orphaned, background AWS PutLogEvents invocations from using

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -1,0 +1,85 @@
+name: "Deploy Terraservice"
+description: "Composite action to deploy a given Terraservice; assumes BFD repo checked-out at workspace root"
+inputs:
+  bfdEnvironment:
+    description: "The BFD environment to deploy the given service to"
+    required: true
+  servicePath:
+    description: "The path to the Terraservice relative to the root of the repository"
+    required: true
+  terraformVarsJson:
+    description: "JSON object map of variables to their values"
+    required: false
+    default: "{}"
+runs:
+  using: "composite"
+  steps:
+    - name: Validate Terraservice path
+      run: |
+        if [[ ! -d "${{ inputs.servicePath }}"]]; then
+          echo "Directory '${{ inputs.servicePath }}' does not exist; has the BFD repo been checked-out?"
+          exit 1
+        fi
+      shell: bash
+
+    - name: Generate Terraform vars args
+      id: gen-tf-vars-args
+      run: |
+        tf_vars_args="$(
+          echo "${{ inputs.terraformVarsJson }}" | jq -r 'to_entries |
+            map(select(.value != null and .value != "")) |
+            map("\"-var=" + .key + "=" + (.value | tostring)+ "\"") |
+            join(" ")'
+        )"
+        echo "tf_vars_args=$tf_vars_args" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Check existing Terraform version
+      id: check-tf-version
+      run: |
+        cur_version="NONE"
+        if [[ -x "$(command -v terraform)" ]]; then
+          cur_version="$(terraform --version)"
+        fi
+        echo "cur_version=$cur_version" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Get required Terraform version
+      uses: dflook/terraform-version@v1
+      id: terraform-version
+      with:
+        path: ${{ github.workspace }}/${{ inputs.servicePath }}
+
+    - name: Setup Terraform
+      if: steps.check-tf-version.outputs.cur_version != steps.terraform-version.outputs.terraform
+      uses: hashicorp/setup-terraform@v3
+      with:
+        terraform_version: ${{ steps.terraform-version.outputs.terraform }}
+        # No subsequent jobs require the output of the Terraform commands, so we can stip installing
+        # the wrapper
+        terraform_wrapper: false
+
+    - name: Terraform init
+      run: |
+        cd "${{ github.workspace }}/${{ inputs.servicePath }}"
+        terraform init -no-color
+      shell: bash
+
+    - name: Select Terraform workspace
+      run: |
+        cd "${{ github.workspace }}/${{ inputs.servicePath }}"
+        terraform workspace new "${{ inputs.bfdEnvironment }}" 2> /dev/null || true &&\
+        terraform workspace select "${{ inputs.bfdEnvironment }}" -no-color
+      shell: bash
+
+    - name: Generate Terraform plan
+      run: |
+        cd "${{ github.workspace }}/${{ inputs.servicePath }}"
+        terraform plan ${{ steps.gen-tf-vars-args.outputs.tf_vars_args }} -no-color -out=tfplan
+      shell: bash
+
+    - name: Apply Terraservice
+      run: |
+        cd "${{ github.workspace }}/${{ inputs.servicePath }}"
+        terraform apply -no-color -input=false tfplan
+      shell: bash

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -164,9 +164,9 @@ runs:
         seconds_waited=0
 
         while (( seconds_waited < 60 )); do
-          remaining_aws_processes="$(psgrep -f "put-log-events")"
+          remaining_aws_processes="$(ps aux | grep '[p]ut-log-events' || true)"
 
-          if [[ $remaining_aws_processes == *"No processes found"* ]]; then
+          if [[ -z $remaining_aws_processes ]]; then
             echo "All logs have been submitted"
             exit 0
           fi

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -175,3 +175,4 @@ runs:
         done
 
         echo "Some log events were unable to be uploaded"
+      shell: bash

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -104,6 +104,7 @@ runs:
     - name: Terraform init
       run: |
         cd "${{ github.workspace }}/${{ inputs.servicePath }}"
+        terraform --version
         terraform init -no-color
       shell: bash
 

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -190,10 +190,10 @@ runs:
         # log events that CloudWatch understands
         jq -s '. | map(select(.message != ""))' "${{ steps.tf-logs-file-path.outputs.raw_logs_path }}" > \
           "${{ steps.tf-logs-file-path.outputs.processed_logs_path }}"
-        # Submit the "processed" logs file to CloudWatch
+        # Submit the "processed" logs file to CloudWatch. Capture stdout and ignore it
         aws logs put-log-events --log-group-name "${{ inputs.cloudwatchLogGroup }}" \
           --log-stream-name "${{ inputs.cloudwatchLogStream }}" \
-          --log-events "file://${{ steps.tf-logs-file-path.outputs.processed_logs_path }}"
+          --log-events "file://${{ steps.tf-logs-file-path.outputs.processed_logs_path }}" 1>/dev/null
 
         echo "Terraform logs put to Log Group '${{ inputs.cloudwatchLogGroup }}' in Log Stream '${{ inputs.cloudwatchLogStream }}'"
       shell: bash

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -22,7 +22,7 @@ runs:
   steps:
     - name: Validate inputs
       run: |
-        if [[ ! -d "${{ inputs.servicePath }}"]]; then
+        if [[ ! -d "${{ github.workspace }}/${{ inputs.servicePath }}" ]]; then
           echo "Directory '${{ inputs.servicePath }}' does not exist; has the BFD repo been checked-out?"
           exit 1
         fi

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -18,10 +18,19 @@ inputs:
     required: false
     default: "{}"
 env:
-  STDOUT_TO_CWLOGS_SCRIPT: "${{ github.workspace }}/.github/scripts/stdout-to-cwlogs.sh"
+  # Necessary for the "stdout-to-cwlogs.sh" script
+  CLOUDWATCH_LOG_GROUP: ${{ inputs.cloudwatchLogGroup }}
+  CLOUDWATCH_LOG_STREAM: ${{ inputs.cloudwatchLogStream }}
 runs:
   using: "composite"
   steps:
+    # This step is necessary as it seems that the "github" object is unavailable when the
+    # Workflow-level "env" is evaluated
+    - name: Setup environment
+      run: |
+        echo "STDOUT_TO_CWLOGS_SCRIPT=${{ github.workspace }}/.github/scripts/stdout-to-cwlogs.sh" >> $GITHUB_ENV
+      shell: bash
+
     - name: Validate inputs
       run: |
         if [[ ! -d "${{ github.workspace }}/${{ inputs.servicePath }}" ]]; then
@@ -41,7 +50,7 @@ runs:
         fi
       shell: bash
 
-    - name: Create Log Stream if needed and update env
+    - name: Create Log Stream if needed
       run: |
         # While the Log Group provided in the inputs is assumed to exist already, the Log Stream is
         # not. Attempt to create it, swallowing any error code that is returned and also capture
@@ -62,10 +71,6 @@ runs:
 
         echo "'${{inputs.cloudwatchLogStream }}' in Log Group '${{ inputs.cloudwatchLogGroup }}' created or exists already"
         echo "Tail the Log Stream to view Terraform output in realtime"
-
-        # Add the Log Group and Log Stream to the runner's environment
-        echo "CLOUDWATCH_LOG_GROUP=${{ inputs.cloudwatchLogGroup }}" >> $GITHUB_ENV
-        echo "CLOUDWATCH_LOG_STREAM=${{inputs.cloudwatchLogStream }}" >> $GITHUB_ENV
       shell: bash
 
     # Maps a given JSON object string of variable names to values, i.e.:

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -18,7 +18,7 @@ inputs:
     required: false
     default: "{}"
 env:
-  STDOUT_TO_CWLOGS_SCRIPT: ${{ github.workspace }}/.github/scripts/stdout-to-cwlogs.sh
+  STDOUT_TO_CWLOGS_SCRIPT: "${{ github.workspace }}/.github/scripts/stdout-to-cwlogs.sh"
 runs:
   using: "composite"
   steps:

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -188,7 +188,7 @@ runs:
 
         # Process the "raw" JSON logs from each Terraform invocation into an array of non-empty
         # log events that CloudWatch understands
-        jq '. | map(select(.message != ""))' "${{ steps.tf-logs-file-path.outputs.raw_logs_path }}" > \
+        jq -s '. | map(select(.message != ""))' "${{ steps.tf-logs-file-path.outputs.raw_logs_path }}" > \
           "${{ steps.tf-logs-file-path.outputs.processed_logs_path }}"
         # Submit the "processed" logs file to CloudWatch
         aws logs put-log-events --log-group-name "${{ inputs.cloudwatchLogGroup }}" \

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -35,8 +35,7 @@ runs:
     - name: Validate inputs
       run: |
         if [[ ! -d "${{ github.workspace }}/${{ inputs.servicePath }}" ]]; then
-          printf "$s" \
-            "Directory '${{ inputs.servicePath }}' does not exist; has the BFD repo been" \
+          echo "Directory '${{ inputs.servicePath }}' does not exist; has the BFD repo been" \
             "checked-out?"
           exit 1
         fi
@@ -48,8 +47,7 @@ runs:
             jq -r '.logGroups != []'
         )"
         if [[ $is_valid_log_group == "false" ]]; then
-          printf "%s" \
-            "'${{ inputs.cloudwatchLogGroup }}' does not exist; was the the correct Log Group" \
+          echo "'${{ inputs.cloudwatchLogGroup }}' does not exist; was the the correct Log Group" \
             "specified?"
           exit 1
         fi
@@ -72,15 +70,13 @@ runs:
           -n $create_log_stream_stderr &&
           $create_log_stream_stderr != *"ResourceAlreadyExistsException"* ]] \
           ; then
-          printf "%s" \
-            "Unrecoverable error occurred when trying to create Log Stream" \
+          echo "Unrecoverable error occurred when trying to create Log Stream" \
             "'${{inputs.cloudwatchLogStream }}' in Log Group '${{ inputs.cloudwatchLogGroup }}'"
           echo "$create_log_stream_stderr"
           exit 1
         fi
 
-        printf "%s" \
-          "'${{inputs.cloudwatchLogStream }}' in Log Group '${{ inputs.cloudwatchLogGroup }}'" \
+        echo "'${{inputs.cloudwatchLogStream }}' in Log Group '${{ inputs.cloudwatchLogGroup }}'" \
           "created or exists already"
         echo "Tail the Log Stream to view Terraform output in realtime"
       shell: bash

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -104,7 +104,13 @@ runs:
     - name: Check if tfvm is installed
       id: check-tfvm-installed
       run: |
-        is_tfvm_installed="$([[ -x "$(command -v tfvm)" ]] && echo "true" || echo "false")"
+        is_tfvm_installed="$(
+          if [[ -x "$(command -v tfvm)" ]]; then
+            echo "true"
+          else
+            echo "false"
+          fi
+         )"
         echo "is-tfvm-installed=$is_tfvm_installed" >> $GITHUB_OUTPUT
       shell: bash
 

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -12,10 +12,10 @@ inputs:
     required: false
     default: "{}"
   cloudwatchLogGroup:
-    description: "Name of CloudWatch Log Group to submit Terraform logs to"
+    description: "Name of CloudWatch Log Group to submit Terraform logs to; must exist"
     required: true
   cloudwatchLogStream:
-    description: "Name of CloudWatch Log Stream to submit Terraform logs to"
+    description: "Name of CloudWatch Log Stream to submit Terraform logs to; will be created if necessary"
     required: true
 runs:
   using: "composite"
@@ -26,10 +26,17 @@ runs:
           echo "Directory '${{ inputs.servicePath }}' does not exist; has the BFD repo been checked-out?"
           exit 1
         fi
-        # See https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_CreateLogGroup.html
-        echo "${{ inputs.cloudwatchLogGroup }}" | grep -P '^[a-zA-Z0-9_\-/\.#]+$' | grep -Pv '^/aws/'
         # See https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_CreateLogStream.html
         echo "${{ inputs.cloudwatchLogStream }}" | grep -Pv '[:*]'
+
+        is_valid_log_group="$(
+          aws logs describe-log-groups --log-group-name-pattern "${{ inputs.cloudwatchLogGroup }}" |
+            jq -r '.logGroups != []'
+        )"
+        if [[ $is_valid_log_group == "false" ]]; then
+          echo "'${{ inputs.cloudwatchLogGroup }}' does not exist; was the the correct Log Group specified?"
+          exit 1
+        fi
 
         # Mask Terraform variable JSON as it could potentially include sensitive values
         echo "::add-mask::${{ inputs.terraformVarsJson }}"
@@ -156,6 +163,23 @@ runs:
         if [[ -z "${{ steps.tf-logs-file-path.outputs.raw_logs_path }}" || ! -f "${{ steps.tf-logs-file-path.outputs.raw_logs_path }}" ]]; then
           echo "No logs to submit to CloudWatch"
           exit
+        fi
+
+        # While the Log Group provided in the inputs is assumed to exist already, the Log Stream is
+        # not. Attempt to create it, swallowing any error code that is returned and also capture
+        # the stderr output so that it can be checked
+        create_log_stream_stderr="$(
+          aws logs create-log-stream --log-group-name "${{ inputs.cloudwatchLogGroup }}" \
+            --log-stream-name "${{ inputs.cloudwatchLogStream }}" 2>&1 >/dev/null || true
+        )"
+
+        # If there was an error message logged by create-log-stream and that error was not
+        # indicating that the Log Stream already exists (which is fine), then log that there was an
+        # unrecoverable error and exit
+        if [[ -n $create_log_stream_stderr && $create_log_stream_stderr != *"ResourceAlreadyExistsException"* ]]; then
+          echo "Unrecoverable error occurred when trying to create Log Stream '${{inputs.cloudwatchLogStream }}' in Log Group '${{ inputs.cloudwatchLogGroup }}' ";
+          echo "$create_log_stream_stderr"
+          exit 1
         fi
 
         # Process the "raw" JSON logs from each Terraform invocation into an array of non-empty

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -92,7 +92,7 @@ runs:
       # Only install Terraform if the current runner does not have the expected version of Terraform
       # installed already
       # if: steps.check-tf-version.outputs.cur_version != steps.terraform-version.outputs.terraform
-      if: steps.check-tf-version.outputs.cur_version == "NONE"
+      if: steps.check-tf-version.outputs.cur_version == 'NONE'
       # uses: hashicorp/setup-terraform@v3
       uses: cbuschka/setup-tfvm@v1
       # with:

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -11,7 +11,8 @@ inputs:
     description: "Name of CloudWatch Log Group to submit Terraform logs to; must exist"
     required: true
   cloudwatchLogStream:
-    description: "Name of CloudWatch Log Stream to submit Terraform logs to; will be created if necessary"
+    description: >-
+      Name of CloudWatch Log Stream to submit Terraform logs to; will be created if necessary
     required: true
   terraformVarsJson:
     description: "JSON object map of variables to their values"
@@ -24,7 +25,8 @@ runs:
     # unavailable when the top-level "env" is evaluated for Composite Actions
     - name: Setup environment
       run: |
-        echo "STDOUT_TO_CWLOGS_SCRIPT=${{ github.workspace }}/.github/scripts/stdout-to-cwlogs.sh" >> $GITHUB_ENV
+        echo "STDOUT_TO_CWLOGS_SCRIPT=${{ github.workspace }}/.github/scripts/stdout-to-cwlogs.sh" \
+          >> $GITHUB_ENV
         # Necessary for the "stdout-to-cwlogs.sh" script
         echo "CLOUDWATCH_LOG_GROUP=${{ inputs.cloudwatchLogGroup }}" >> $GITHUB_ENV
         echo "CLOUDWATCH_LOG_STREAM=${{ inputs.cloudwatchLogStream }}" >> $GITHUB_ENV
@@ -33,7 +35,9 @@ runs:
     - name: Validate inputs
       run: |
         if [[ ! -d "${{ github.workspace }}/${{ inputs.servicePath }}" ]]; then
-          echo "Directory '${{ inputs.servicePath }}' does not exist; has the BFD repo been checked-out?"
+          printf "$s" \
+            "Directory '${{ inputs.servicePath }}' does not exist; has the BFD repo been" \
+            "checked-out?"
           exit 1
         fi
         # See https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_CreateLogStream.html
@@ -44,7 +48,9 @@ runs:
             jq -r '.logGroups != []'
         )"
         if [[ $is_valid_log_group == "false" ]]; then
-          echo "'${{ inputs.cloudwatchLogGroup }}' does not exist; was the the correct Log Group specified?"
+          printf "%s" \
+            "'${{ inputs.cloudwatchLogGroup }}' does not exist; was the the correct Log Group" \
+            "specified?"
           exit 1
         fi
       shell: bash
@@ -62,13 +68,20 @@ runs:
         # If there was an error message logged by create-log-stream and that error was not
         # indicating that the Log Stream already exists (which is fine), then log that there was an
         # unrecoverable error and exit
-        if [[ -n $create_log_stream_stderr && $create_log_stream_stderr != *"ResourceAlreadyExistsException"* ]]; then
-          echo "Unrecoverable error occurred when trying to create Log Stream '${{inputs.cloudwatchLogStream }}' in Log Group '${{ inputs.cloudwatchLogGroup }}' ";
+        if [[
+          -n $create_log_stream_stderr &&
+          $create_log_stream_stderr != *"ResourceAlreadyExistsException"* ]] \
+          ; then
+          printf "%s" \
+            "Unrecoverable error occurred when trying to create Log Stream" \
+            "'${{inputs.cloudwatchLogStream }}' in Log Group '${{ inputs.cloudwatchLogGroup }}'"
           echo "$create_log_stream_stderr"
           exit 1
         fi
 
-        echo "'${{inputs.cloudwatchLogStream }}' in Log Group '${{ inputs.cloudwatchLogGroup }}' created or exists already"
+        printf "%s" \
+          "'${{inputs.cloudwatchLogStream }}' in Log Group '${{ inputs.cloudwatchLogGroup }}'" \
+          "created or exists already"
         echo "Tail the Log Stream to view Terraform output in realtime"
       shell: bash
 

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -7,16 +7,16 @@ inputs:
   servicePath:
     description: "The path to the Terraservice relative to the root of the repository"
     required: true
-  terraformVarsJson:
-    description: "JSON object map of variables to their values"
-    required: false
-    default: "{}"
   cloudwatchLogGroup:
     description: "Name of CloudWatch Log Group to submit Terraform logs to; must exist"
     required: true
   cloudwatchLogStream:
     description: "Name of CloudWatch Log Stream to submit Terraform logs to; will be created if necessary"
     required: true
+  terraformVarsJson:
+    description: "JSON object map of variables to their values"
+    required: false
+    default: "{}"
 defaults:
   run:
     shell: bash

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -23,7 +23,7 @@ defaults:
 runs:
   using: "composite"
   steps:
-    - name: Validate and mask inputs
+    - name: Validate inputs
       run: |
         if [[ ! -d "${{ inputs.servicePath }}"]]; then
           echo "Directory '${{ inputs.servicePath }}' does not exist; has the BFD repo been checked-out?"
@@ -40,9 +40,6 @@ runs:
           echo "'${{ inputs.cloudwatchLogGroup }}' does not exist; was the the correct Log Group specified?"
           exit 1
         fi
-
-        # Mask Terraform variable JSON as it could potentially include sensitive values
-        echo "::add-mask::${{ inputs.terraformVarsJson }}"
 
     - name: Get Terraform logs file paths
       id: tf-logs-file-path

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -17,18 +17,17 @@ inputs:
     description: "JSON object map of variables to their values"
     required: false
     default: "{}"
-env:
-  # Necessary for the "stdout-to-cwlogs.sh" script
-  CLOUDWATCH_LOG_GROUP: ${{ inputs.cloudwatchLogGroup }}
-  CLOUDWATCH_LOG_STREAM: ${{ inputs.cloudwatchLogStream }}
 runs:
   using: "composite"
   steps:
-    # This step is necessary as it seems that the "github" object is unavailable when the
-    # Workflow-level "env" is evaluated
+    # This step is necessary as it seems that some objects (like "github" or "inputs") are
+    # unavailable when the top-level "env" is evaluated for Composite Actions
     - name: Setup environment
       run: |
         echo "STDOUT_TO_CWLOGS_SCRIPT=${{ github.workspace }}/.github/scripts/stdout-to-cwlogs.sh" >> $GITHUB_ENV
+        # Necessary for the "stdout-to-cwlogs.sh" script
+        echo "CLOUDWATCH_LOG_GROUP=${{ inputs.cloudwatchLogGroup }}" >> $GITHUB_ENV
+        echo "CLOUDWATCH_LOG_STREAM=${{ inputs.cloudwatchLogStream }}" >> $GITHUB_ENV
       shell: bash
 
     - name: Validate inputs

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -39,7 +39,7 @@ runs:
         fi
       shell: bash
 
-    - name: Create CloudWatch Log Stream if needed
+    - name: Create Log Stream if needed and update env
       run: |
         # While the Log Group provided in the inputs is assumed to exist already, the Log Stream is
         # not. Attempt to create it, swallowing any error code that is returned and also capture
@@ -60,6 +60,10 @@ runs:
 
         echo "'${{inputs.cloudwatchLogStream }}' in Log Group '${{ inputs.cloudwatchLogGroup }}' created or exists already"
         echo "Tail the Log Stream to view Terraform output in realtime"
+
+        # Add the Log Group and Log Stream to the runner's environment
+        echo "CLOUDWATCH_LOG_GROUP=${{ inputs.cloudwatchLogGroup }}" >> $GITHUB_ENV
+        echo "CLOUDWATCH_LOG_STREAM=${{inputs.cloudwatchLogStream }}" >> $GITHUB_ENV
       shell: bash
 
     # Maps a given JSON object string of variable names to values, i.e.:
@@ -115,25 +119,10 @@ runs:
         # Often the terraform plan logged to stdout as well as the errors logged to stderr include
         # sensitive/private information. GHA logs are available for anyone logged in with a GitHub
         # account to view, and so this information must be protected. Instead of logging to stdout,
-        # all potentially sensitive Terraform log output is transformed into a format CloudWatch
-        # Logs understands and uploaded to CloudWatch Logs via Bash process susbtitution
+        # all potentially sensitive Terraform log output is instead logged to CloudWatch
         echo "Generating Terraform plan for ${{ inputs.servicePath }}..."
-        terraform plan ${{ steps.gen-tf-vars-args.outputs.tf_vars_args }} -no-color -out=tfplan &> >(
-          while read line; do
-            log_event="$(
-              jq -n \
-                --arg unix_ts "$(date +%s%3N)" \
-                --arg line "$line" \
-                '[{ "timestamp": ($unix_ts | tonumber), "message": ($line | tostring) }]'
-            )"
-            # Runs in a background subshell to avoid slowing down the Terraform process while
-            # trying to put the log output to CloudWatch. Errors are ignored and all output is
-            # redirected to /dev/null
-            (aws logs put-log-events --log-group-name "${{ inputs.cloudwatchLogGroup }}" \
-              --log-stream-name "${{ inputs.cloudwatchLogStream }}" \
-              --log-events "$log_event" &>/dev/null || true) &
-          done
-        )
+        terraform plan ${{ steps.gen-tf-vars-args.outputs.tf_vars_args }} -no-color \
+          -out=tfplan 2>&1 | "${{ github.workspace }}/.github/scripts/stdout-to-cwlogs.sh"
         echo "Plan generated for ${{ inputs.servicePath }} successfully"
       shell: bash
 
@@ -158,21 +147,8 @@ runs:
     #     echo "Terraform plan for ${{ inputs.servicePath }} applied"
     # shell: bash
 
-    - name: Await AWS put-log-events
+    # Ensures that orphaned, background AWS PutLogEvents invocations from using
+    # "stdout-to-cwlogs.sh" are able to complete before being cleaned-up by GHA
+    - name: Await Terraform CloudWatch logging
       if: always()
-      run: |
-        seconds_waited=0
-
-        while (( seconds_waited < 60 )); do
-          remaining_aws_processes="$(ps aux | grep '[p]ut-log-events' || true)"
-
-          if [[ -z $remaining_aws_processes ]]; then
-            echo "All logs have been submitted"
-            exit 0
-          fi
-          sleep 1
-          seconds_waited=$(( seconds_waited + 1))
-        done
-
-        echo "Some log events were unable to be uploaded"
-      shell: bash
+      uses: ./.github/actions/await-cw-logging

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -17,6 +17,8 @@ inputs:
     description: "JSON object map of variables to their values"
     required: false
     default: "{}"
+env:
+  STDOUT_TO_CWLOGS_SCRIPT: ${{ github.workspace }}/.github/scripts/stdout-to-cwlogs.sh
 runs:
   using: "composite"
   steps:
@@ -122,30 +124,17 @@ runs:
         # all potentially sensitive Terraform log output is instead logged to CloudWatch
         echo "Generating Terraform plan for ${{ inputs.servicePath }}..."
         terraform plan ${{ steps.gen-tf-vars-args.outputs.tf_vars_args }} -no-color \
-          -out=tfplan 2>&1 | "${{ github.workspace }}/.github/scripts/stdout-to-cwlogs.sh"
+          -out=tfplan 2>&1 | "$STDOUT_TO_CWLOGS_SCRIPT"
         echo "Plan generated for ${{ inputs.servicePath }} successfully"
       shell: bash
 
-    # TODO: Uncomment
-    # - name: Apply Terraservice
-    #   run: |
-    #     cd "${{ github.workspace }}/${{ inputs.servicePath }}"
-    #     echo "Applying Terraform plan for ${{ inputs.servicePath }}..."
-    #     terraform apply -no-color -input=false tfplan &> >(
-          # while read line; do
-          #   log_event="$(
-          #     jq -n \
-          #       --arg unix_ts "$(date +%s%3N)" \
-          #       --arg line "$line" \
-          #       '[{ "timestamp": ($unix_ts | tonumber), "message": ($line | tostring) }]'
-          #   )"
-          #   (aws logs put-log-events --log-group-name "${{ inputs.cloudwatchLogGroup }}" \
-          #     --log-stream-name "${{ inputs.cloudwatchLogStream }}" \
-          #     --log-events "$log_event" &>/dev/null || true) &
-          # done
-    #     )
-    #     echo "Terraform plan for ${{ inputs.servicePath }} applied"
-    # shell: bash
+    - name: Apply Terraservice
+      run: |
+        cd "${{ github.workspace }}/${{ inputs.servicePath }}"
+        echo "Applying Terraform plan for ${{ inputs.servicePath }}..."
+        terraform apply -no-color -input=false tfplan 2>&1 | "$STDOUT_TO_CWLOGS_SCRIPT"
+        echo "Terraform plan for ${{ inputs.servicePath }} applied"
+      shell: bash
 
     # Ensures that orphaned, background AWS PutLogEvents invocations from using
     # "stdout-to-cwlogs.sh" are able to complete before being cleaned-up by GHA

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -157,3 +157,21 @@ runs:
     #     )
     #     echo "Terraform plan for ${{ inputs.servicePath }} applied"
     # shell: bash
+
+    - name: Await AWS put-log-events
+      if: always()
+      run: |
+        seconds_waited=0
+
+        while (( seconds_waited < 60 )); do
+          remaining_aws_processes="$(psgrep -f "put-log-events")"
+
+          if [[ $remaining_aws_processes == *"No processes found"* ]]; then
+            echo "All logs have been submitted"
+            exit 0
+          fi
+          sleep 1
+          seconds_waited=$(( seconds_waited + 1))
+        done
+
+        echo "Some log events were unable to be uploaded"

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -78,7 +78,8 @@ runs:
 
         echo "'${{inputs.cw-log-stream }}' in Log Group '${{ inputs.cw-log-group }}'" \
           "created or exists already"
-        echo "Tail the Log Stream to view Terraform output in realtime"
+        echo "Tail the Log Stream to view Terraform output in realtime:"
+        echo "aws logs tail --since 1h --follow '${{ inputs.cw-log-group }}'"
       shell: bash
 
     # Maps a given JSON object string of variable names to values, i.e.:

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -122,7 +122,7 @@ runs:
               jq -n \
                 --arg unix_ts "$(date +%s%3N)" \
                 --arg line "$line" \
-                '{ "timestamp": $unix_ts, "message": ($line | tostring) }'
+                '{ "timestamp": ($unix_ts | tonumber), "message": ($line | tostring) }'
             )" >> "${{ steps.tf-logs-file-path.outputs.raw_logs_path }}"
           done
         )
@@ -139,7 +139,7 @@ runs:
               jq -n \
                 --arg unix_ts "$(date +%s%3N)" \
                 --arg line "$line" \
-                '{ "timestamp": $unix_ts, "message": ($line | tostring) }'
+                '{ "timestamp": ($unix_ts | tonumber), "message": ($line | tostring) }'
             )" >> "${{ steps.tf-logs-file-path.outputs.raw_logs_path }}"
           done
         )

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -82,22 +82,24 @@ runs:
         echo "cur_version=$cur_version" >> $GITHUB_OUTPUT
       shell: bash
 
-    - name: Get required Terraform version
-      uses: dflook/terraform-version@v1
-      id: terraform-version
-      with:
-        path: ${{ github.workspace }}/${{ inputs.servicePath }}
+    # - name: Get required Terraform version
+    #   uses: dflook/terraform-version@v1
+    #   id: terraform-version
+    #   with:
+    #     path: ${{ github.workspace }}/${{ inputs.servicePath }}
 
     - name: Setup Terraform
       # Only install Terraform if the current runner does not have the expected version of Terraform
       # installed already
-      if: steps.check-tf-version.outputs.cur_version != steps.terraform-version.outputs.terraform
-      uses: hashicorp/setup-terraform@v3
-      with:
-        terraform_version: ${{ steps.terraform-version.outputs.terraform }}
-        # No subsequent jobs require the output of the Terraform commands, so we can stip installing
-        # the wrapper that sets the "stdout", "stderr", etc. outputs on steps running Terraform
-        terraform_wrapper: false
+      # if: steps.check-tf-version.outputs.cur_version != steps.terraform-version.outputs.terraform
+      # if: steps.check-tf-version.outputs.cur_version != "NONE"
+      # uses: hashicorp/setup-terraform@v3
+      uses: cbuschka/setup-tfvm@v1
+      # with:
+      #   terraform_version: ${{ steps.terraform-version.outputs.terraform }}
+      #   # No subsequent jobs require the output of the Terraform commands, so we can stip installing
+      #   # the wrapper that sets the "stdout", "stderr", etc. outputs on steps running Terraform
+      #   terraform_wrapper: false
 
     - name: Terraform init
       run: |

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -92,7 +92,7 @@ runs:
       # Only install Terraform if the current runner does not have the expected version of Terraform
       # installed already
       # if: steps.check-tf-version.outputs.cur_version != steps.terraform-version.outputs.terraform
-      # if: steps.check-tf-version.outputs.cur_version != "NONE"
+      if: steps.check-tf-version.outputs.cur_version == "NONE"
       # uses: hashicorp/setup-terraform@v3
       uses: cbuschka/setup-tfvm@v1
       # with:

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -74,7 +74,10 @@ runs:
       run: |
         cur_version="NONE"
         if [[ -x "$(command -v terraform)" ]]; then
-          cur_version="$(terraform --version)"
+          # Terraform emits multiple unnecessary lines when running "terraform --version" indicating
+          # the OS, arch, whether Terraform is out-of-date, etc. We don't care about anything but
+          # the version, so the grep matches on the version number and returns only the match
+          cur_version="$(terraform --version | grep -Po "(?<=Terraform v)(.*)$")"
         fi
         echo "cur_version=$cur_version" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -39,14 +39,27 @@ runs:
         fi
       shell: bash
 
-    - name: Get Terraform logs file paths
-      id: tf-logs-file-path
+    - name: Create CloudWatch Log Stream if needed
       run: |
-        uuid="$(uuidgen)"
-        raw_logs_path="${{ github.workspace }}/$uuid.raw.json"
-        echo "raw_logs_path=$raw_logs_path" >> $GITHUB_OUTPUT
-        processed_logs_path="${{ github.workspace }}/$uuid.processed.json"
-        echo "processed_logs_path=$processed_logs_path" >> $GITHUB_OUTPUT
+        # While the Log Group provided in the inputs is assumed to exist already, the Log Stream is
+        # not. Attempt to create it, swallowing any error code that is returned and also capture
+        # the stderr output so that it can be checked
+        create_log_stream_stderr="$(
+          aws logs create-log-stream --log-group-name "${{ inputs.cloudwatchLogGroup }}" \
+            --log-stream-name "${{ inputs.cloudwatchLogStream }}" 2>&1 >/dev/null || true
+        )"
+
+        # If there was an error message logged by create-log-stream and that error was not
+        # indicating that the Log Stream already exists (which is fine), then log that there was an
+        # unrecoverable error and exit
+        if [[ -n $create_log_stream_stderr && $create_log_stream_stderr != *"ResourceAlreadyExistsException"* ]]; then
+          echo "Unrecoverable error occurred when trying to create Log Stream '${{inputs.cloudwatchLogStream }}' in Log Group '${{ inputs.cloudwatchLogGroup }}' ";
+          echo "$create_log_stream_stderr"
+          exit 1
+        fi
+
+        echo "'${{inputs.cloudwatchLogStream }}' in Log Group '${{ inputs.cloudwatchLogGroup }}' created or exists already"
+        echo "Tail the Log Stream to view Terraform output in realtime"
       shell: bash
 
     # Maps a given JSON object string of variable names to values, i.e.:
@@ -103,17 +116,22 @@ runs:
         # sensitive/private information. GHA logs are available for anyone logged in with a GitHub
         # account to view, and so this information must be protected. Instead of logging to stdout,
         # all potentially sensitive Terraform log output is transformed into a format CloudWatch
-        # Logs understands and appended to a temporary file. These logs are then uploaded at the
-        # end of this action, regardless of success or failure
+        # Logs understands and uploaded to CloudWatch Logs via Bash process susbtitution
         echo "Generating Terraform plan for ${{ inputs.servicePath }}..."
         terraform plan ${{ steps.gen-tf-vars-args.outputs.tf_vars_args }} -no-color -out=tfplan &> >(
           while read line; do
-            echo "$(
+            log_event="$(
               jq -n \
                 --arg unix_ts "$(date +%s%3N)" \
                 --arg line "$line" \
-                '{ "timestamp": ($unix_ts | tonumber), "message": ($line | tostring) }'
-            )" >> "${{ steps.tf-logs-file-path.outputs.raw_logs_path }}"
+                '[{ "timestamp": ($unix_ts | tonumber), "message": ($line | tostring) }]'
+            )"
+            # Runs in a background subshell to avoid slowing down the Terraform process while
+            # trying to put the log output to CloudWatch. Errors are ignored and all output is
+            # redirected to /dev/null
+            (aws logs put-log-events --log-group-name "${{ inputs.cloudwatchLogGroup }}" \
+              --log-stream-name "${{ inputs.cloudwatchLogStream }}" \
+              --log-events "$log_event" &>/dev/null || true) &
           done
         )
         echo "Plan generated for ${{ inputs.servicePath }} successfully"
@@ -125,55 +143,17 @@ runs:
     #     cd "${{ github.workspace }}/${{ inputs.servicePath }}"
     #     echo "Applying Terraform plan for ${{ inputs.servicePath }}..."
     #     terraform apply -no-color -input=false tfplan &> >(
-    #       while read line; do
-    #         echo "$(
-    #           jq -n \
-    #             --arg unix_ts "$(date +%s%3N)" \
-    #             --arg line "$line" \
-    #             '{ "timestamp": ($unix_ts | tonumber), "message": ($line | tostring) }'
-    #         )" >> "${{ steps.tf-logs-file-path.outputs.raw_logs_path }}"
-    #       done
+          # while read line; do
+          #   log_event="$(
+          #     jq -n \
+          #       --arg unix_ts "$(date +%s%3N)" \
+          #       --arg line "$line" \
+          #       '[{ "timestamp": ($unix_ts | tonumber), "message": ($line | tostring) }]'
+          #   )"
+          #   (aws logs put-log-events --log-group-name "${{ inputs.cloudwatchLogGroup }}" \
+          #     --log-stream-name "${{ inputs.cloudwatchLogStream }}" \
+          #     --log-events "$log_event" &>/dev/null || true) &
+          # done
     #     )
     #     echo "Terraform plan for ${{ inputs.servicePath }} applied"
     # shell: bash
-
-    # This step uploads the potentially sensitive Terraform log output from previous steps to
-    # CloudWatch Logs so that BFD Engineers can still inspect the output without fear of that
-    # potentially sensitive information being exposed publicly
-    - name: Submit Terraform logs to CloudWatch
-      # Run regardless of prior step outcome
-      if: always()
-      run: |
-        if [[ -z "${{ steps.tf-logs-file-path.outputs.raw_logs_path }}" || ! -f "${{ steps.tf-logs-file-path.outputs.raw_logs_path }}" ]]; then
-          echo "No logs to submit to CloudWatch"
-          exit
-        fi
-
-        # While the Log Group provided in the inputs is assumed to exist already, the Log Stream is
-        # not. Attempt to create it, swallowing any error code that is returned and also capture
-        # the stderr output so that it can be checked
-        create_log_stream_stderr="$(
-          aws logs create-log-stream --log-group-name "${{ inputs.cloudwatchLogGroup }}" \
-            --log-stream-name "${{ inputs.cloudwatchLogStream }}" 2>&1 >/dev/null || true
-        )"
-
-        # If there was an error message logged by create-log-stream and that error was not
-        # indicating that the Log Stream already exists (which is fine), then log that there was an
-        # unrecoverable error and exit
-        if [[ -n $create_log_stream_stderr && $create_log_stream_stderr != *"ResourceAlreadyExistsException"* ]]; then
-          echo "Unrecoverable error occurred when trying to create Log Stream '${{inputs.cloudwatchLogStream }}' in Log Group '${{ inputs.cloudwatchLogGroup }}' ";
-          echo "$create_log_stream_stderr"
-          exit 1
-        fi
-
-        # Process the "raw" JSON logs from each Terraform invocation into an array of non-empty
-        # log events that CloudWatch understands
-        jq -s '. | map(select(.message != ""))' "${{ steps.tf-logs-file-path.outputs.raw_logs_path }}" > \
-          "${{ steps.tf-logs-file-path.outputs.processed_logs_path }}"
-        # Submit the "processed" logs file to CloudWatch. Capture stdout and ignore it
-        aws logs put-log-events --log-group-name "${{ inputs.cloudwatchLogGroup }}" \
-          --log-stream-name "${{ inputs.cloudwatchLogStream }}" \
-          --log-events "file://${{ steps.tf-logs-file-path.outputs.processed_logs_path }}" 1>/dev/null
-
-        echo "Terraform logs put to Log Group '${{ inputs.cloudwatchLogGroup }}' in Log Stream '${{ inputs.cloudwatchLogStream }}'"
-      shell: bash

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -153,7 +153,7 @@ runs:
       # Run regardless of prior step outcome
       if: always()
       run: |
-        if [[ -z "${{ steps.tf-logs-file-path.outputs.raw_logs_path }}" ]]; then
+        if [[ -z "${{ steps.tf-logs-file-path.outputs.raw_logs_path }}" || ! -f "${{ steps.tf-logs-file-path.outputs.raw_logs_path }}" ]]; then
           echo "No logs to submit to CloudWatch"
           exit
         fi

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -17,9 +17,6 @@ inputs:
     description: "JSON object map of variables to their values"
     required: false
     default: "{}"
-defaults:
-  run:
-    shell: bash
 runs:
   using: "composite"
   steps:
@@ -40,6 +37,7 @@ runs:
           echo "'${{ inputs.cloudwatchLogGroup }}' does not exist; was the the correct Log Group specified?"
           exit 1
         fi
+      shell: bash
 
     - name: Get Terraform logs file paths
       id: tf-logs-file-path
@@ -49,6 +47,7 @@ runs:
         echo "raw_logs_path=$raw_logs_path" >> $GITHUB_OUTPUT
         processed_logs_path="${{ github.workspace }}/$uuid.processed.json"
         echo "processed_logs_path=$processed_logs_path" >> $GITHUB_OUTPUT
+      shell: bash
 
     # Maps a given JSON object string of variable names to values, i.e.:
     # {
@@ -68,6 +67,7 @@ runs:
             join(" ")'
         )"
         echo "tf_vars_args=$tf_vars_args" >> $GITHUB_OUTPUT
+      shell: bash
 
     - name: Check existing Terraform version
       id: check-tf-version
@@ -77,6 +77,7 @@ runs:
           cur_version="$(terraform --version)"
         fi
         echo "cur_version=$cur_version" >> $GITHUB_OUTPUT
+      shell: bash
 
     - name: Get required Terraform version
       uses: dflook/terraform-version@v1
@@ -99,12 +100,14 @@ runs:
       run: |
         cd "${{ github.workspace }}/${{ inputs.servicePath }}"
         terraform init -no-color
+      shell: bash
 
     - name: Select Terraform workspace
       run: |
         cd "${{ github.workspace }}/${{ inputs.servicePath }}"
         terraform workspace new "${{ inputs.bfdEnvironment }}" 2> /dev/null || true &&\
         terraform workspace select "${{ inputs.bfdEnvironment }}" -no-color
+      shell: bash
 
     - name: Generate Terraform plan
       run: |
@@ -128,6 +131,7 @@ runs:
           done
         )
         echo "Plan generated for ${{ inputs.servicePath }} successfully"
+      shell: bash
 
     # TODO: Uncomment
     # - name: Apply Terraservice
@@ -145,6 +149,7 @@ runs:
     #       done
     #     )
     #     echo "Terraform plan for ${{ inputs.servicePath }} applied"
+    # shell: bash
 
     # This step uploads the potentially sensitive Terraform log output from previous steps to
     # CloudWatch Logs so that BFD Engineers can still inspect the output without fear of that
@@ -185,3 +190,4 @@ runs:
           --log-events "file://${{ steps.tf-logs-file-path.outputs.processed_logs_path }}"
 
         echo "Terraform logs put to Log Group '${{ inputs.cloudwatchLogGroup }}' in Log Stream '${{ inputs.cloudwatchLogStream }}'"
+      shell: bash

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -141,18 +141,22 @@ runs:
         # sensitive/private information. GHA logs are available for anyone logged in with a GitHub
         # account to view, and so this information must be protected. Instead of logging to stdout,
         # all potentially sensitive Terraform log output is instead logged to CloudWatch
-        echo "Generating Terraform plan for ${{ inputs.service-path }}..."
+        echo "Generating Terraform plan for ${{ inputs.service-path }}..." |
+          tee >(bash -c "$STDOUT_TO_CWLOGS_SCRIPT") # Log to GHA logs and CW
         terraform plan ${{ steps.gen-tf-vars-args.outputs.tf-vars-args }} -no-color \
           -out=tfplan 2>&1 | "$STDOUT_TO_CWLOGS_SCRIPT"
-        echo "Plan generated for ${{ inputs.service-path }} successfully"
+        echo "Plan generated for ${{ inputs.service-path }} successfully" |
+          tee >(bash -c "$STDOUT_TO_CWLOGS_SCRIPT")
       shell: bash
 
     - name: Apply Terraservice
       run: |
         cd "${{ github.workspace }}/${{ inputs.service-path }}"
-        echo "Applying Terraform plan for ${{ inputs.service-path }}..."
+        echo "Applying Terraform plan for ${{ inputs.service-path }}..." |
+          tee >(bash -c "$STDOUT_TO_CWLOGS_SCRIPT")
         terraform apply -no-color -input=false tfplan 2>&1 | "$STDOUT_TO_CWLOGS_SCRIPT"
-        echo "Terraform plan for ${{ inputs.service-path }} applied"
+        echo "Terraform plan for ${{ inputs.service-path }} applied" |
+          tee >(bash -c "$STDOUT_TO_CWLOGS_SCRIPT")
       shell: bash
 
     # Ensures that orphaned, background AWS PutLogEvents invocations from using

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -98,19 +98,19 @@ runs:
             map("\"-var=" + .key + "=" + (.value | tostring)+ "\"") |
             join(" ")'
         )"
-        echo "tf_vars_args=$tf_vars_args" >> $GITHUB_OUTPUT
+        echo "tf-vars-args=$tf_vars_args" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Check if tfvm is installed
       id: check-tfvm-installed
       run: |
         is_tfvm_installed="$([[ -x "$(command -v tfvm)" ]] && echo "true" || echo "false")"
-        echo "is_tfvm_installed=$is_tfvm_installed" >> $GITHUB_OUTPUT
+        echo "is-tfvm-installed=$is_tfvm_installed" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Setup Terraform
       # Only install tfvm/Terraform if the current runner does not have tfvm installed
-      if: steps.check-tfvm-installed.outputs.is_tfvm_installed == 'false'
+      if: steps.check-tfvm-installed.outputs.is-tfvm-installed == 'false'
       uses: cbuschka/setup-tfvm@v1
 
     - name: Terraform init
@@ -136,7 +136,7 @@ runs:
         # account to view, and so this information must be protected. Instead of logging to stdout,
         # all potentially sensitive Terraform log output is instead logged to CloudWatch
         echo "Generating Terraform plan for ${{ inputs.service-path }}..."
-        terraform plan ${{ steps.gen-tf-vars-args.outputs.tf_vars_args }} -no-color \
+        terraform plan ${{ steps.gen-tf-vars-args.outputs.tf-vars-args }} -no-color \
           -out=tfplan 2>&1 | "$STDOUT_TO_CWLOGS_SCRIPT"
         echo "Plan generated for ${{ inputs.service-path }} successfully"
       shell: bash

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -1,5 +1,5 @@
 name: "Deploy Terraservice"
-description: "Composite action to deploy a given Terraservice; assumes BFD repo checked-out at workspace root"
+description: "Composite action to deploy a given Terraservice"
 inputs:
   bfdEnvironment:
     description: "The BFD environment to deploy the given service to"
@@ -11,17 +11,48 @@ inputs:
     description: "JSON object map of variables to their values"
     required: false
     default: "{}"
+  cloudwatchLogGroup:
+    description: "Name of CloudWatch Log Group to submit Terraform logs to"
+    required: true
+  cloudwatchLogStream:
+    description: "Name of CloudWatch Log Stream to submit Terraform logs to"
+    required: true
 runs:
   using: "composite"
   steps:
-    - name: Validate Terraservice path
+    - name: Validate and mask inputs
       run: |
         if [[ ! -d "${{ inputs.servicePath }}"]]; then
           echo "Directory '${{ inputs.servicePath }}' does not exist; has the BFD repo been checked-out?"
           exit 1
         fi
+        # See https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_CreateLogGroup.html
+        echo "${{ inputs.cloudwatchLogGroup }}" | grep -P '^[a-zA-Z0-9_\-/\.#]+$' | grep -Pv '^/aws/'
+        # See https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_CreateLogStream.html
+        echo "${{ inputs.cloudwatchLogStream }}" | grep -Pv '[:*]'
+
+        # Mask Terraform variable JSON as it could potentially include sensitive values
+        echo "::add-mask::${{ inputs.terraformVarsJson }}"
       shell: bash
 
+    - name: Get Terraform logs file paths
+      id: tf-logs-file-path
+      run: |
+        uuid="$(uuidgen)"
+        raw_logs_path="${{ github.workspace }}/$uuid.raw.json"
+        echo "raw_logs_path=$raw_logs_path" >> $GITHUB_OUTPUT
+        processed_logs_path="${{ github.workspace }}/$uuid.processed.json"
+        echo "processed_logs_path=$processed_logs_path" >> $GITHUB_OUTPUT
+      shell: bash
+
+    # Maps a given JSON object string of variable names to values, i.e.:
+    # {
+    #   "var1": "val1",
+    #   "var2": 123,
+    #   "var3": true
+    # }
+    # into a space-delimited argument list that the Terraform CLI understands:
+    # -var=var1=val1 -var=var2=123 -var=var3=true
     - name: Generate Terraform vars args
       id: gen-tf-vars-args
       run: |
@@ -51,12 +82,14 @@ runs:
         path: ${{ github.workspace }}/${{ inputs.servicePath }}
 
     - name: Setup Terraform
+      # Only install Terraform if the current runner does not have the expected version of Terraform
+      # installed already
       if: steps.check-tf-version.outputs.cur_version != steps.terraform-version.outputs.terraform
       uses: hashicorp/setup-terraform@v3
       with:
         terraform_version: ${{ steps.terraform-version.outputs.terraform }}
         # No subsequent jobs require the output of the Terraform commands, so we can stip installing
-        # the wrapper
+        # the wrapper that sets the "stdout", "stderr", etc. outputs on steps running Terraform
         terraform_wrapper: false
 
     - name: Terraform init
@@ -75,11 +108,62 @@ runs:
     - name: Generate Terraform plan
       run: |
         cd "${{ github.workspace }}/${{ inputs.servicePath }}"
-        terraform plan ${{ steps.gen-tf-vars-args.outputs.tf_vars_args }} -no-color -out=tfplan
+
+        # Often the terraform plan logged to stdout as well as the errors logged to stderr include
+        # sensitive/private information. GHA logs are available for anyone logged in with a GitHub
+        # account to view, and so this information must be protected. Instead of logging to stdout,
+        # all potentially sensitive Terraform log output is transformed into a format CloudWatch
+        # Logs understands and appended to a temporary file. These logs are then uploaded at the
+        # end of this action, regardless of success or failure
+        echo "Generating Terraform plan for ${{ inputs.servicePath }}..."
+        terraform plan ${{ steps.gen-tf-vars-args.outputs.tf_vars_args }} -no-color -out=tfplan &> >(
+          while read line; do
+            echo "$(
+              jq -n \
+                --arg unix_ts "$(date +%s%3N)" \
+                --arg line "$line" \
+                '{ "timestamp": $unix_ts, "message": ($line | tostring) }'
+            )" >> "${{ steps.tf-logs-file-path.outputs.raw_logs_path }}"
+          done
+        )
+        echo "Plan generated for ${{ inputs.servicePath }} successfully"
       shell: bash
 
     - name: Apply Terraservice
       run: |
         cd "${{ github.workspace }}/${{ inputs.servicePath }}"
-        terraform apply -no-color -input=false tfplan
+        echo "Applying Terraform plan for ${{ inputs.servicePath }}..."
+        terraform apply -no-color -input=false tfplan &> >(
+          while read line; do
+            echo "$(
+              jq -n \
+                --arg unix_ts "$(date +%s%3N)" \
+                --arg line "$line" \
+                '{ "timestamp": $unix_ts, "message": ($line | tostring) }'
+            )" >> "${{ steps.tf-logs-file-path.outputs.raw_logs_path }}"
+          done
+        )
+        echo "Terraform plan for ${{ inputs.servicePath }} applied"
+      shell: bash
+
+    # This step uploads the potentially sensitive Terraform log output from previous steps to
+    # CloudWatch Logs so that BFD Engineers can still inspect the output without fear of that
+    # potentially sensitive information being exposed publicly
+    - name: Submit Terraform logs to CloudWatch
+      # Run regardless of prior step outcome
+      if: always()
+      run: |
+        if [[ -z "${{ steps.tf-logs-file-path.outputs.raw_logs_path }}" ]]; then
+          echo "No logs to submit to CloudWatch"
+          exit
+        fi
+
+        # Process the "raw" JSON logs from each Terraform invocation into an array of non-empty
+        # log events that CloudWatch understands
+        jq '. | map(select(.message != ""))' "${{ steps.tf-logs-file-path.outputs.raw_logs_path }}" > \
+          "${{ steps.tf-logs-file-path.outputs.processed_logs_path }}"
+        # Submit the "processed" logs file to CloudWatch
+        aws logs put-log-events --log-group-name "${{ inputs.cloudwatchLogGroup }}" \
+          --log-stream-name "${{ inputs.cloudwatchLogStream }}" \
+          --log-events "file://${{ steps.tf-logs-file-path.outputs.processed_logs_path }}"
       shell: bash

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -110,7 +110,7 @@ runs:
           else
             echo "false"
           fi
-         )"
+        )"
         echo "is-tfvm-installed=$is_tfvm_installed" >> $GITHUB_OUTPUT
       shell: bash
 

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -129,21 +129,22 @@ runs:
         )
         echo "Plan generated for ${{ inputs.servicePath }} successfully"
 
-    - name: Apply Terraservice
-      run: |
-        cd "${{ github.workspace }}/${{ inputs.servicePath }}"
-        echo "Applying Terraform plan for ${{ inputs.servicePath }}..."
-        terraform apply -no-color -input=false tfplan &> >(
-          while read line; do
-            echo "$(
-              jq -n \
-                --arg unix_ts "$(date +%s%3N)" \
-                --arg line "$line" \
-                '{ "timestamp": ($unix_ts | tonumber), "message": ($line | tostring) }'
-            )" >> "${{ steps.tf-logs-file-path.outputs.raw_logs_path }}"
-          done
-        )
-        echo "Terraform plan for ${{ inputs.servicePath }} applied"
+    # TODO: Uncomment
+    # - name: Apply Terraservice
+    #   run: |
+    #     cd "${{ github.workspace }}/${{ inputs.servicePath }}"
+    #     echo "Applying Terraform plan for ${{ inputs.servicePath }}..."
+    #     terraform apply -no-color -input=false tfplan &> >(
+    #       while read line; do
+    #         echo "$(
+    #           jq -n \
+    #             --arg unix_ts "$(date +%s%3N)" \
+    #             --arg line "$line" \
+    #             '{ "timestamp": ($unix_ts | tonumber), "message": ($line | tostring) }'
+    #         )" >> "${{ steps.tf-logs-file-path.outputs.raw_logs_path }}"
+    #       done
+    #     )
+    #     echo "Terraform plan for ${{ inputs.servicePath }} applied"
 
     # This step uploads the potentially sensitive Terraform log output from previous steps to
     # CloudWatch Logs so that BFD Engineers can still inspect the output without fear of that

--- a/.github/actions/deploy-terraservice/action.yml
+++ b/.github/actions/deploy-terraservice/action.yml
@@ -17,6 +17,9 @@ inputs:
   cloudwatchLogStream:
     description: "Name of CloudWatch Log Stream to submit Terraform logs to; will be created if necessary"
     required: true
+defaults:
+  run:
+    shell: bash
 runs:
   using: "composite"
   steps:
@@ -40,7 +43,6 @@ runs:
 
         # Mask Terraform variable JSON as it could potentially include sensitive values
         echo "::add-mask::${{ inputs.terraformVarsJson }}"
-      shell: bash
 
     - name: Get Terraform logs file paths
       id: tf-logs-file-path
@@ -50,7 +52,6 @@ runs:
         echo "raw_logs_path=$raw_logs_path" >> $GITHUB_OUTPUT
         processed_logs_path="${{ github.workspace }}/$uuid.processed.json"
         echo "processed_logs_path=$processed_logs_path" >> $GITHUB_OUTPUT
-      shell: bash
 
     # Maps a given JSON object string of variable names to values, i.e.:
     # {
@@ -70,7 +71,6 @@ runs:
             join(" ")'
         )"
         echo "tf_vars_args=$tf_vars_args" >> $GITHUB_OUTPUT
-      shell: bash
 
     - name: Check existing Terraform version
       id: check-tf-version
@@ -80,7 +80,6 @@ runs:
           cur_version="$(terraform --version)"
         fi
         echo "cur_version=$cur_version" >> $GITHUB_OUTPUT
-      shell: bash
 
     - name: Get required Terraform version
       uses: dflook/terraform-version@v1
@@ -103,14 +102,12 @@ runs:
       run: |
         cd "${{ github.workspace }}/${{ inputs.servicePath }}"
         terraform init -no-color
-      shell: bash
 
     - name: Select Terraform workspace
       run: |
         cd "${{ github.workspace }}/${{ inputs.servicePath }}"
         terraform workspace new "${{ inputs.bfdEnvironment }}" 2> /dev/null || true &&\
         terraform workspace select "${{ inputs.bfdEnvironment }}" -no-color
-      shell: bash
 
     - name: Generate Terraform plan
       run: |
@@ -134,7 +131,6 @@ runs:
           done
         )
         echo "Plan generated for ${{ inputs.servicePath }} successfully"
-      shell: bash
 
     - name: Apply Terraservice
       run: |
@@ -151,7 +147,6 @@ runs:
           done
         )
         echo "Terraform plan for ${{ inputs.servicePath }} applied"
-      shell: bash
 
     # This step uploads the potentially sensitive Terraform log output from previous steps to
     # CloudWatch Logs so that BFD Engineers can still inspect the output without fear of that
@@ -190,4 +185,5 @@ runs:
         aws logs put-log-events --log-group-name "${{ inputs.cloudwatchLogGroup }}" \
           --log-stream-name "${{ inputs.cloudwatchLogStream }}" \
           --log-events "file://${{ steps.tf-logs-file-path.outputs.processed_logs_path }}"
-      shell: bash
+
+        echo "Terraform logs put to Log Group '${{ inputs.cloudwatchLogGroup }}' in Log Stream '${{ inputs.cloudwatchLogStream }}'"

--- a/.github/scripts/stdout-to-cwlogs.sh
+++ b/.github/scripts/stdout-to-cwlogs.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Helper script intended to be used in GHA steps which may log _dynamic_ sensitive data and are thus
+# unable to be masked using GHA's built-in _static_ masking. By piping the stdout from the command
+# that emits sensitive log output to this script the log output can instead be logged to CloudWatch.
+# Requires the Log Group and Log Stream to exist prior to use, as well as a valid AWS session with
+# permission to PutLogEvents to the Log Group and Stream.
+# Environment Variables:
+#   CLOUDWATCH_LOG_GROUP: The Log Group to log to
+#   CLOUDWATCH_LOG_STREAM: The Log Stream to log to
+# Usage Notes:
+#   If this script is used in GHA, the companion Composite Action "await-cw-logging" should be
+#   appended to the end of the Workflow/Action as an "always" step to ensure that orphaned
+#   background AWS PutLogEvents processes are able to complete without being cleaned up
+
+set -eou pipefail
+
+# Ensure that the CLOUDWATCH_LOG_GROUP environment variable is set
+trimmed_log_group="$(echo "$CLOUDWATCH_LOG_GROUP" | tr -d '[:space:]')"
+if [[ -z $trimmed_log_group ]]; then
+  echo "CLOUDWATCH_LOG_GROUP must not be an empty string or whitespace"
+  exit 1
+fi
+
+# Ensure that the CLOUDWATCH_LOG_STREAM environment variable is set
+trimmed_log_stream="$(echo "$CLOUDWATCH_LOG_STREAM" | tr -d '[:space:]')"
+if [[ -z $trimmed_log_stream ]]; then
+  echo "CLOUDWATCH_LOG_STREAM must not be an empty string or whitespace"
+  exit 1
+fi
+
+while read -r line; do
+  log_event="$(
+    jq -n \
+      --arg unix_ts "$(date +%s%3N)" \
+      --arg line "$line" \
+      '[{ "timestamp": ($unix_ts | tonumber), "message": ($line | tostring) }]'
+  )"
+  # Runs in a background subshell to avoid slowing down the Terraform process while
+  # trying to put the log output to CloudWatch. Errors are ignored and all output is
+  # redirected to /dev/null
+  (aws logs put-log-events --log-group-name "$trimmed_log_group" \
+    --log-stream-name "$trimmed_log_stream" \
+    --log-events "$log_event" &>/dev/null || true) &
+done

--- a/.github/scripts/stdout-to-cwlogs.sh
+++ b/.github/scripts/stdout-to-cwlogs.sh
@@ -35,8 +35,8 @@ while read -r line; do
       --arg line "$line" \
       '[{ "timestamp": ($unix_ts | tonumber), "message": ($line | tostring) }]'
   )"
-  # Runs in a background subshell to avoid slowing down the Terraform process while
-  # trying to put the log output to CloudWatch. Errors are ignored and all output is
+  # Runs in a background subshell to avoid slowing down the process that is piping to this script
+  # while trying to put the log output to CloudWatch. Errors are ignored and all output is
   # redirected to /dev/null
   (aws logs put-log-events --log-group-name "$trimmed_log_group" \
     --log-stream-name "$trimmed_log_stream" \

--- a/.github/workflows/ci-static-site.yml
+++ b/.github/workflows/ci-static-site.yml
@@ -1,4 +1,3 @@
-
 name: "CI - Deploy Static Site"
 on:
   workflow_call:
@@ -14,17 +13,18 @@ on:
         default: us-east-1
         type: string
         required: true
+      bfdRelease:
+        description: >-
+          Version string of the BFD release from which the data dictionaries will be pulled.
+          If omitted, the latest GitHub release version will be used
+        required: false
+        type: string
   workflow_dispatch:
     inputs:
       bfdEnvironment:
         description: "The BFD environment to deploy the Static Site to"
         required: true
         type: string
-      branch:
-        description: >-
-          Override the branch on which the build is based.
-          Default to selected reference in the `Use workflow from` drop-down when empty.
-        required: false
       awsRegion:
         description: >-
           Override the AWS Region destination for uploaded artifacts.
@@ -32,15 +32,31 @@ on:
         default: us-east-1
         type: choice
         options:
-         - us-east-1
-         - us-west-2
+          - us-east-1
+          - us-west-2
         required: true
+      bfdRelease:
+        description: >-
+          Version string of the BFD release from which the data dictionaries will be pulled.
+          If omitted, the latest GitHub release version will be used
+        required: false
+        type: string
+      branch:
+        description: >-
+          Override the branch on which the build is based.
+          Default to selected reference in the `Use workflow from` drop-down when empty.
+        required: false
 permissions:
   id-token: write # This is required for requesting the AWS IAM OIDC JWT
   contents: write # This is required for actions/checkout
 defaults:
   run:
     shell: bash
+env:
+  # AWS Code Artifact Repository
+  CA_REPOSITORY: bfd-mgmt
+  CA_DOMAIN: bfd-mgmt
+  AWS_REGION: ${{ inputs.awsRegion }}
 jobs:
   deploy-static-site:
     runs-on: ubuntu-latest
@@ -51,6 +67,25 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.branch || github.ref_name }}
+
+      - name: Determine latest release version
+        id: determine-latest-release
+        if: !inputs.bfdRelease
+        uses: pozetroninc/github-action-get-latest-release@v0.8.0
+        with:
+          repository: ${{ github.repository }}
+
+      - name: Set environment variables
+        run: |
+          release_version="${{ inputs.bfdRelease || steps.determine-latest-release.outputs.release }}"
+          if [[ -z $release_version ]]; then
+            echo "Release version unspecified or unable to be determined"
+            echo 1
+          fi
+
+          # Strip leading "v" from the returned version if the latest version is chosen
+          release_version="$(echo "$release_version" | sed "s/^v//g")"
+          echo "BFD_RELEASE=$release_version" >> $GITHUB_ENV
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -78,3 +113,54 @@ jobs:
           # TODO: Replace
           cloudwatchLogGroup: "/bfd-3465/testing"
           cloudwatchLogStream: "ci-static-site-${{ github.run_number }}"
+
+      - name: Pull data dictionaries
+        run: |
+          mkdir -p "${{ github.workspace }}/dist"
+          cd "${{ github.workspace }}/dist"
+
+          readarray -t assets < <(echo "$CA_ASSETS" | jq -r -c '.[]')
+          for asset in "${assets[@]}"
+          do
+            aws codeartifact get-package-version-asset \
+              --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} \
+              --domain "$CA_DOMAIN" \
+              --repository "$CA_REPOSITORY" \
+              --asset "$asset" \
+              --package-version "$BFD_RELEASE" \
+              --package "$CA_PACKAGE" \
+              --namespace "$CA_NAMESPACE" \
+              --format maven \
+              --region "$AWS_REGION" \
+              "${asset/$CA_PACKAGE-${BFD_RELEASE}-v/V}" 1>/dev/null
+          done
+        env:
+          BFD_RELEASE: ${{ inputs.bfdRelease }}
+          CA_NAMESPACE: gov.cms.bfd
+          CA_PACKAGE: bfd-server-war
+          CA_ASSETS: |
+            [
+              "bfd-server-war-${{ inputs.bfdRelease }}-v1-data-dictionary.json",
+              "bfd-server-war-${{ inputs.bfdRelease }}-v2-data-dictionary.json",
+            ]
+
+      # Use GitHub Actions' cache to shorten build times and decrease load on servers
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+
+      - name: Build Jekyll static site
+        run: |
+          cd "${{ github.workspace }}/static-site"
+          bundle config path vendor/bundle
+          bundle install
+
+          bundle exec jekyll build
+
+      - name: Sync static site to S3
+        run: |
+          # aws s3 sync "${{ github.workspace }}/static-site" s3://bfd-${{ inputs.bfdEnvironment }} --delete

--- a/.github/workflows/ci-static-site.yml
+++ b/.github/workflows/ci-static-site.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Determine latest release version
         id: determine-latest-release
-        if: !inputs.bfdRelease
+        if: inputs.bfdRelease == ''
         uses: pozetroninc/github-action-get-latest-release@v0.8.0
         with:
           repository: ${{ github.repository }}

--- a/.github/workflows/ci-static-site.yml
+++ b/.github/workflows/ci-static-site.yml
@@ -1,0 +1,83 @@
+
+name: "CI - Deploy Static Site"
+on:
+  push:
+  # workflow_call:
+  #   inputs:
+  #     bfdEnvironment:
+  #       description: "The BFD environment to deploy the Static Site to"
+  #       required: true
+  #       type: string
+  #     awsRegion:
+  #       description: >-
+  #         Override the AWS Region destination for uploaded artifacts.
+  #         Default to `us-east-1`.
+  #       default: us-east-1
+  #       type: string
+  #       required: true
+  # workflow_dispatch:
+  #   inputs:
+  #     bfdEnvironment:
+  #       description: "The BFD environment to deploy the Static Site to"
+  #       required: true
+  #       type: string
+  #     branch:
+  #       description: >-
+  #         Override the branch on which the build is based.
+  #         Default to selected reference in the `Use workflow from` drop-down when empty.
+  #       required: false
+  #     awsRegion:
+  #       description: >-
+  #         Override the AWS Region destination for uploaded artifacts.
+  #         Default to `us-east-1`.
+  #       default: us-east-1
+  #       type: choice
+  #       options:
+  #        - us-east-1
+  #        - us-west-2
+  #       required: true
+permissions:
+  id-token: write # This is required for requesting the AWS IAM OIDC JWT
+  contents: write # This is required for actions/checkout
+defaults:
+  run:
+    shell: bash
+jobs:
+  deploy-static-site:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "test"
+
+      # - name: Checkout
+      #   if: github.event_name == 'workflow_dispatch'
+      #   uses: actions/checkout@v4
+      #   with:
+      #     fetch-depth: 0
+      #     ref: ${{ inputs.branch || github.ref_name }}
+
+      # - name: Configure AWS credentials
+      #   uses: aws-actions/configure-aws-credentials@v4
+      #   with:
+      #     role-to-assume: ${{ secrets.GHA_AWS_IAM_ROLE_ARN }}
+      #     role-session-name: ci-static-site
+      #     aws-region: ${{ inputs.awsRegion }}
+
+      # - name: Mask sensitive AWS data
+      #   run: |
+      #     caller_id="$(aws sts get-caller-identity)"
+      #     account_num="$(jq -r '.Account' <<<$caller_id)"
+      #     role_arn="$(jq -r '.Arn' <<<$caller_id)"
+      #     user_id="$(jq -r '.UserId' <<<$caller_id)"
+
+      #     echo "::add-mask::$account_num"
+      #     echo "::add-mask::$role_arn"
+      #     echo "::add-mask::$user_id"
+
+      # - name: Deploy static-site Terraservice
+      #   uses: ./.github/actions/deploy-terraservice
+      #   with:
+      #     bfdEnvironment: ${{ inputs.bfdEnvironment }}
+      #     servicePath: ops/terraform/services/static-site
+      #     # TODO
+      #     cloudwatchLogGroup: "/bfd-3465/testing"
+      #     cloudwatchLogStream: "ci-static-site-${{ github.run_number }}"

--- a/.github/workflows/ci-static-site.yml
+++ b/.github/workflows/ci-static-site.yml
@@ -1,41 +1,40 @@
 
 name: "CI - Deploy Static Site"
 on:
-  push:
-  # workflow_call:
-  #   inputs:
-  #     bfdEnvironment:
-  #       description: "The BFD environment to deploy the Static Site to"
-  #       required: true
-  #       type: string
-  #     awsRegion:
-  #       description: >-
-  #         Override the AWS Region destination for uploaded artifacts.
-  #         Default to `us-east-1`.
-  #       default: us-east-1
-  #       type: string
-  #       required: true
-  # workflow_dispatch:
-  #   inputs:
-  #     bfdEnvironment:
-  #       description: "The BFD environment to deploy the Static Site to"
-  #       required: true
-  #       type: string
-  #     branch:
-  #       description: >-
-  #         Override the branch on which the build is based.
-  #         Default to selected reference in the `Use workflow from` drop-down when empty.
-  #       required: false
-  #     awsRegion:
-  #       description: >-
-  #         Override the AWS Region destination for uploaded artifacts.
-  #         Default to `us-east-1`.
-  #       default: us-east-1
-  #       type: choice
-  #       options:
-  #        - us-east-1
-  #        - us-west-2
-  #       required: true
+  workflow_call:
+    inputs:
+      bfdEnvironment:
+        description: "The BFD environment to deploy the Static Site to"
+        required: true
+        type: string
+      awsRegion:
+        description: >-
+          Override the AWS Region destination for uploaded artifacts.
+          Default to `us-east-1`.
+        default: us-east-1
+        type: string
+        required: true
+  workflow_dispatch:
+    inputs:
+      bfdEnvironment:
+        description: "The BFD environment to deploy the Static Site to"
+        required: true
+        type: string
+      branch:
+        description: >-
+          Override the branch on which the build is based.
+          Default to selected reference in the `Use workflow from` drop-down when empty.
+        required: false
+      awsRegion:
+        description: >-
+          Override the AWS Region destination for uploaded artifacts.
+          Default to `us-east-1`.
+        default: us-east-1
+        type: choice
+        options:
+         - us-east-1
+         - us-west-2
+        required: true
 permissions:
   id-token: write # This is required for requesting the AWS IAM OIDC JWT
   contents: write # This is required for actions/checkout
@@ -46,38 +45,36 @@ jobs:
   deploy-static-site:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "test"
+      - name: Checkout
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.branch || github.ref_name }}
 
-      # - name: Checkout
-      #   if: github.event_name == 'workflow_dispatch'
-      #   uses: actions/checkout@v4
-      #   with:
-      #     fetch-depth: 0
-      #     ref: ${{ inputs.branch || github.ref_name }}
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.GHA_AWS_IAM_ROLE_ARN }}
+          role-session-name: ci-static-site
+          aws-region: ${{ inputs.awsRegion }}
 
-      # - name: Configure AWS credentials
-      #   uses: aws-actions/configure-aws-credentials@v4
-      #   with:
-      #     role-to-assume: ${{ secrets.GHA_AWS_IAM_ROLE_ARN }}
-      #     role-session-name: ci-static-site
-      #     aws-region: ${{ inputs.awsRegion }}
+      - name: Mask sensitive AWS data
+        run: |
+          caller_id="$(aws sts get-caller-identity)"
+          account_num="$(jq -r '.Account' <<<$caller_id)"
+          role_arn="$(jq -r '.Arn' <<<$caller_id)"
+          user_id="$(jq -r '.UserId' <<<$caller_id)"
 
-      # - name: Mask sensitive AWS data
-      #   run: |
-      #     caller_id="$(aws sts get-caller-identity)"
-      #     account_num="$(jq -r '.Account' <<<$caller_id)"
-      #     role_arn="$(jq -r '.Arn' <<<$caller_id)"
-      #     user_id="$(jq -r '.UserId' <<<$caller_id)"
+          echo "::add-mask::$account_num"
+          echo "::add-mask::$role_arn"
+          echo "::add-mask::$user_id"
 
-      #     echo "::add-mask::$account_num"
-      #     echo "::add-mask::$role_arn"
-      #     echo "::add-mask::$user_id"
-
-      # - name: Deploy static-site Terraservice
-      #   uses: ./.github/actions/deploy-terraservice
-      #   with:
-      #     bfdEnvironment: ${{ inputs.bfdEnvironment }}
-      #     servicePath: ops/terraform/services/static-site
-      #     # TODO
-      #     cloudwatchLogGroup: "/bfd-3465/testing"
-      #     cloudwatchLogStream: "ci-static-site-${{ github.run_number }}"
+      - name: Deploy static-site Terraservice
+        uses: ./.github/actions/deploy-terraservice
+        with:
+          bfdEnvironment: ${{ inputs.bfdEnvironment }}
+          servicePath: ops/terraform/services/static-site
+          # TODO
+          cloudwatchLogGroup: "/bfd-3465/testing"
+          cloudwatchLogStream: "ci-static-site-${{ github.run_number }}"

--- a/.github/workflows/ci-static-site.yml
+++ b/.github/workflows/ci-static-site.yml
@@ -141,7 +141,7 @@ jobs:
           CA_ASSETS: |
             [
               "bfd-server-war-${{ inputs.bfdRelease }}-v1-data-dictionary.json",
-              "bfd-server-war-${{ inputs.bfdRelease }}-v2-data-dictionary.json",
+              "bfd-server-war-${{ inputs.bfdRelease }}-v2-data-dictionary.json"
             ]
 
       - name: Setup Ruby and install dependencies

--- a/.github/workflows/ci-static-site.yml
+++ b/.github/workflows/ci-static-site.yml
@@ -75,6 +75,6 @@ jobs:
         with:
           bfdEnvironment: ${{ inputs.bfdEnvironment }}
           servicePath: ops/terraform/services/static-site
-          # TODO
+          # TODO: Replace
           cloudwatchLogGroup: "/bfd-3465/testing"
           cloudwatchLogStream: "ci-static-site-${{ github.run_number }}"

--- a/.github/workflows/ci-static-site.yml
+++ b/.github/workflows/ci-static-site.yml
@@ -1,5 +1,7 @@
 name: "CI - Deploy Static Site"
 on:
+  # Unfortunately, there is no way to reduce duplication between inputs. They must be specified
+  # seperately for each trigger
   workflow_call:
     inputs:
       bfdEnvironment:
@@ -17,6 +19,16 @@ on:
         description: >-
           Version string of the BFD release from which the data dictionaries will be pulled.
           If omitted, the latest GitHub release version will be used
+        required: false
+        type: string
+      cloudwatchLogGroupOverride:
+        description: "Overrides the CloudWatch Log Group to submit Terraform logs to; must exist"
+        required: false
+        type: string
+      cloudwatchLogStreamOverride:
+        description: >-
+          Overrides the the CloudWatch Log Stream to submit Terraform logs to; will be created if
+          necessary
         required: false
         type: string
   workflow_dispatch:
@@ -46,6 +58,16 @@ on:
           Override the branch on which the build is based.
           Default to selected reference in the `Use workflow from` drop-down when empty.
         required: false
+      cloudwatchLogGroupOverride:
+        description: "Overrides the CloudWatch Log Group to submit Terraform logs to; must exist"
+        required: false
+        type: string
+      cloudwatchLogStreamOverride:
+        description: >-
+          Overrides the the CloudWatch Log Stream to submit Terraform logs to; will be created if
+          necessary
+        required: false
+        type: string
 permissions:
   id-token: write # This is required for requesting the AWS IAM OIDC JWT
   contents: write # This is required for actions/checkout
@@ -57,6 +79,8 @@ env:
   CA_REPOSITORY: bfd-mgmt
   CA_DOMAIN: bfd-mgmt
   AWS_REGION: ${{ inputs.awsRegion }}
+  DEFAULT_LOG_GROUP: "/bfd/${{ inputs.bfdEnvironment }}/gha/ci-static-site"
+  DEFAULT_LOG_STREAM: "deploy-terraservice_${{ github.run_number }}"
 jobs:
   deploy-static-site:
     runs-on: ubuntu-latest
@@ -68,8 +92,8 @@ jobs:
           ref: ${{ inputs.branch || github.ref_name }}
 
       - name: Determine latest release version
-        id: determine-latest-release
         if: inputs.bfdRelease == ''
+        id: determine-latest-release
         uses: pozetroninc/github-action-get-latest-release@v0.8.0
         with:
           repository: ${{ github.repository }}
@@ -107,9 +131,8 @@ jobs:
         with:
           bfdEnvironment: ${{ inputs.bfdEnvironment }}
           servicePath: ops/terraform/services/static-site
-          # TODO: Replace
-          cloudwatchLogGroup: "/bfd-3465/testing"
-          cloudwatchLogStream: "ci-static-site-${{ github.run_number }}"
+          cloudwatchLogGroup: ${{ inputs.cloudwatchLogGroupOverride || env.DEFAULT_LOG_GROUP }}
+          cloudwatchLogStream: ${{ inputs.cloudwatchLogStreamOverride || env.DEFAULT_LOG_STREAM }}
 
       - name: Pull data dictionaries
         run: |

--- a/.github/workflows/ci-static-site.yml
+++ b/.github/workflows/ci-static-site.yml
@@ -155,4 +155,4 @@ jobs:
 
       - name: Sync static site to S3
         run: |
-          # aws s3 sync "${{ github.workspace }}/static-site" s3://bfd-${{ inputs.bfdEnvironment }} --delete
+          aws s3 sync "${{ github.workspace }}/static-site/_site" s3://bfd-${{ inputs.bfdEnvironment }}-static --delete

--- a/.github/workflows/ci-static-site.yml
+++ b/.github/workflows/ci-static-site.yml
@@ -153,6 +153,7 @@ jobs:
 
       - name: Build Jekyll static site
         run: |
+          cd "${{ github.workspace }}/static-site"
           bundle exec jekyll build
 
       - name: Sync static site to S3

--- a/.github/workflows/ci-static-site.yml
+++ b/.github/workflows/ci-static-site.yml
@@ -83,8 +83,6 @@ jobs:
             echo 1
           fi
 
-          # Strip leading "v" from the returned version if the latest version is chosen
-          release_version="$(echo "$release_version" | sed "s/^v//g")"
           echo "BFD_RELEASE=$release_version" >> $GITHUB_ENV
 
       - name: Configure AWS credentials

--- a/.github/workflows/ci-static-site.yml
+++ b/.github/workflows/ci-static-site.yml
@@ -144,6 +144,11 @@ jobs:
               "bfd-server-war-${{ inputs.bfdRelease }}-v2-data-dictionary.json",
             ]
 
+      - name: setup ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 3.1.3 # Version recommended by Jekyll install instructions
+
       # Use GitHub Actions' cache to shorten build times and decrease load on servers
       - name: Cache dependencies
         uses: actions/cache@v3
@@ -156,8 +161,8 @@ jobs:
       - name: Build Jekyll static site
         run: |
           cd "${{ github.workspace }}/static-site"
-          bundle config path vendor/bundle
-          bundle install
+          bundle install --path=vendor/bundle --jobs 4 --retry 3
+          bundle clean
 
           bundle exec jekyll build
 

--- a/.github/workflows/ci-static-site.yml
+++ b/.github/workflows/ci-static-site.yml
@@ -133,13 +133,12 @@ jobs:
               "${asset/$CA_PACKAGE-${BFD_RELEASE}-v/V}" 1>/dev/null
           done
         env:
-          BFD_RELEASE: ${{ inputs.bfdRelease }}
           CA_NAMESPACE: gov.cms.bfd
           CA_PACKAGE: bfd-server-war
           CA_ASSETS: |
             [
-              "bfd-server-war-${{ inputs.bfdRelease }}-v1-data-dictionary.json",
-              "bfd-server-war-${{ inputs.bfdRelease }}-v2-data-dictionary.json"
+              "bfd-server-war-${{ env.BFD_RELEASE }}-v1-data-dictionary.json",
+              "bfd-server-war-${{ env.BFD_RELEASE }}-v2-data-dictionary.json"
             ]
 
       - name: Setup Ruby and install dependencies

--- a/.github/workflows/ci-static-site.yml
+++ b/.github/workflows/ci-static-site.yml
@@ -62,7 +62,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        if: github.event_name == 'workflow_dispatch'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/ci-static-site.yml
+++ b/.github/workflows/ci-static-site.yml
@@ -4,28 +4,28 @@ on:
   # seperately for each trigger
   workflow_call:
     inputs:
-      bfdEnvironment:
+      bfd-env:
         description: "The BFD environment to deploy the Static Site to"
         required: true
         type: string
-      awsRegion:
+      aws-region:
         description: >-
           Override the AWS Region destination for uploaded artifacts.
           Default to `us-east-1`.
         default: us-east-1
         type: string
         required: true
-      bfdRelease:
+      bfd-release:
         description: >-
           Version string of the BFD release from which the data dictionaries will be pulled.
           If omitted, the latest GitHub release version will be used
         required: false
         type: string
-      cloudwatchLogGroupOverride:
+      cw-log-group-override:
         description: "Overrides the CloudWatch Log Group to submit Terraform logs to; must exist"
         required: false
         type: string
-      cloudwatchLogStreamOverride:
+      cw-log-stream-override:
         description: >-
           Overrides the the CloudWatch Log Stream to submit Terraform logs to; will be created if
           necessary
@@ -33,11 +33,11 @@ on:
         type: string
   workflow_dispatch:
     inputs:
-      bfdEnvironment:
+      bfd-env:
         description: "The BFD environment to deploy the Static Site to"
         required: true
         type: string
-      awsRegion:
+      aws-region:
         description: >-
           Override the AWS Region destination for uploaded artifacts.
           Default to `us-east-1`.
@@ -47,7 +47,7 @@ on:
           - us-east-1
           - us-west-2
         required: true
-      bfdRelease:
+      bfd-release:
         description: >-
           Version string of the BFD release from which the data dictionaries will be pulled.
           If omitted, the latest GitHub release version will be used
@@ -58,11 +58,11 @@ on:
           Override the branch on which the build is based.
           Default to selected reference in the `Use workflow from` drop-down when empty.
         required: false
-      cloudwatchLogGroupOverride:
+      cw-log-group-override:
         description: "Overrides the CloudWatch Log Group to submit Terraform logs to; must exist"
         required: false
         type: string
-      cloudwatchLogStreamOverride:
+      cw-log-stream-override:
         description: >-
           Overrides the the CloudWatch Log Stream to submit Terraform logs to; will be created if
           necessary
@@ -78,8 +78,8 @@ env:
   # AWS Code Artifact Repository
   CA_REPOSITORY: bfd-mgmt
   CA_DOMAIN: bfd-mgmt
-  AWS_REGION: ${{ inputs.awsRegion }}
-  DEFAULT_LOG_GROUP: "/bfd/${{ inputs.bfdEnvironment }}/gha/ci-static-site"
+  AWS_REGION: ${{ inputs.aws-region }}
+  DEFAULT_LOG_GROUP: "/bfd/${{ inputs.bfd-env }}/gha/ci-static-site"
   DEFAULT_LOG_STREAM: "deploy-terraservice_${{ github.run_number }}"
 jobs:
   deploy-static-site:
@@ -92,7 +92,7 @@ jobs:
           ref: ${{ inputs.branch || github.ref_name }}
 
       - name: Determine latest release version
-        if: inputs.bfdRelease == ''
+        if: inputs.bfd-release == ''
         id: determine-latest-release
         uses: pozetroninc/github-action-get-latest-release@v0.8.0
         with:
@@ -100,7 +100,7 @@ jobs:
 
       - name: Set environment variables
         run: |
-          release_version="${{ inputs.bfdRelease || steps.determine-latest-release.outputs.release }}"
+          release_version="${{ inputs.bfd-release || steps.determine-latest-release.outputs.release }}"
           if [[ -z $release_version ]]; then
             echo "Release version unspecified or unable to be determined"
             echo 1
@@ -113,7 +113,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.GHA_AWS_IAM_ROLE_ARN }}
           role-session-name: ci-static-site
-          aws-region: ${{ inputs.awsRegion }}
+          aws-region: ${{ inputs.aws-region }}
 
       - name: Mask sensitive AWS data
         run: |
@@ -129,10 +129,10 @@ jobs:
       - name: Deploy static-site Terraservice
         uses: ./.github/actions/deploy-terraservice
         with:
-          bfdEnvironment: ${{ inputs.bfdEnvironment }}
-          servicePath: ops/terraform/services/static-site
-          cloudwatchLogGroup: ${{ inputs.cloudwatchLogGroupOverride || env.DEFAULT_LOG_GROUP }}
-          cloudwatchLogStream: ${{ inputs.cloudwatchLogStreamOverride || env.DEFAULT_LOG_STREAM }}
+          bfd-env: ${{ inputs.bfd-env }}
+          service-path: ops/terraform/services/static-site
+          cw-log-group: ${{ inputs.cw-log-group-override || env.DEFAULT_LOG_GROUP }}
+          cw-log-stream: ${{ inputs.cw-log-stream-override || env.DEFAULT_LOG_STREAM }}
 
       - name: Pull data dictionaries
         run: |
@@ -177,4 +177,4 @@ jobs:
 
       - name: Sync static site to S3
         run: |
-          aws s3 sync "${{ github.workspace }}/static-site/_site" s3://bfd-${{ inputs.bfdEnvironment }}-static --delete
+          aws s3 sync "${{ github.workspace }}/static-site/_site" s3://bfd-${{ inputs.bfd-env }}-static --delete

--- a/.github/workflows/ci-static-site.yml
+++ b/.github/workflows/ci-static-site.yml
@@ -144,26 +144,15 @@ jobs:
               "bfd-server-war-${{ inputs.bfdRelease }}-v2-data-dictionary.json",
             ]
 
-      - name: setup ruby
-        uses: actions/setup-ruby@v1
+      - name: Setup Ruby and install dependencies
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1.3 # Version recommended by Jekyll install instructions
-
-      # Use GitHub Actions' cache to shorten build times and decrease load on servers
-      - name: Cache dependencies
-        uses: actions/cache@v3
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: ${{ github.workspace }}/static-site
 
       - name: Build Jekyll static site
         run: |
-          cd "${{ github.workspace }}/static-site"
-          bundle install --path=vendor/bundle --jobs 4 --retry 3
-          bundle clean
-
           bundle exec jekyll build
 
       - name: Sync static site to S3

--- a/ops/terraform/services/common/cloudwatch-logs.tf
+++ b/ops/terraform/services/common/cloudwatch-logs.tf
@@ -9,3 +9,9 @@ resource "aws_cloudwatch_log_group" "var_log_secure" {
   name       = "/bfd/${local.env}/var/log/secure"
   kms_key_id = data.aws_kms_key.cmk.arn
 }
+
+# CloudWatch Log Group for the "CI - Deploy Static Site" Terraform plan/apply logs
+resource "aws_cloudwatch_log_group" "gha_ci_static_site" {
+  name       = "/bfd/${local.env}/gha/ci-static-site"
+  kms_key_id = data.aws_kms_key.cmk.arn
+}

--- a/static-site/_plugins/copy_data_dictionary.rb
+++ b/static-site/_plugins/copy_data_dictionary.rb
@@ -10,7 +10,7 @@ Jekyll::Hooks.register :site, :after_init do ||
 def copy_data_dictionary(version)
     current_dir = File.dirname(__FILE__)
     # find the latest copy of the data dictionary (sorted by filename)
-    dd_source = Dir[File.join(current_dir,"../../dist/V#{version}-data-dictionary-*json")].sort[-1]
+    dd_source = Dir[File.join(current_dir,"../../dist/V#{version}-data-dictionary*json")].sort[-1]
     contents = File.read(dd_source)
     # un-escape extra newlines in the example json so it renders properly on the site
     replaced = contents.gsub(/\\\\n/, "\\n")


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
BFD-3465

### What Does This PR Do?

<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

:warning: NOTE: The `CI - Deploy Static Site` Workflow (and helper Composite Actions) work as expected, but there are a few caveats:

- The IAM Role assumed by GitHub Actions will not have the required permissions to apply the `static-site` Terraservice upon merging this PR. We intend to grant these permissions _correctly_ in BFD-3583
- The `static-site` Terraservice creates a Cloudfront distribution that is not configured properly for use with `SSE-KMS` (customer-managed KMS keys) with the backing S3 Bucket. So, while the `CI - Deploy Static Site` Workflow _does_ correctly deploy the built Jekyll static site it is not able to be viewed unless the uploaded objects are re-encrypted with AWS-managed keys. This, and other deficiencies, will be resolved in BFD-3582
- While the Workflow introduced by these changes is prefixed with `CI`, it is not yet automatically invoked or integrated with our `Build Release` Workflow. This is intentional until the aformentioned issues are resolved and the Static Site works as expected. Regardless, the Workflow can be executed manually with the `workflow_dispatch` trigger

---

This PR introduces a new Workflow, `CI - Deploy Static Site`, that deploys the BFD Static Site to the provided BFD SDLC environment. This Workflow will `terraform apply` the `static-site` Terraservice, download the Data Dictionaries corresponding to the specified release version (or the latest release, if unspecified), build the Jekyll static site, and then deploy the built site to the corresponding BFD Static Site S3 Bucket.

In more detail, this PR:

- Adds the `CI - Deploy Static Site` Workflow which deploys the BFD Static Site to the given BFD SDLC environment in full
  - This Workflow is configured to be triggered manually via `workflow_dispatch` or as part of another Workflow via `workflow_call`
  - This Workflow surfaces various inputs that control its behavior:
    - `bfd-env`: The BFD environment to deploy the Static Site to
    - `aws-region`: Override the AWS Region destination for uploaded artifacts. Default to `us-east-1`.
    - `bfd-release`: Version string of the BFD release from which the data dictionaries will be pulled. If omitted, the latest GitHub release version will be used
    - `cw-log-group-override`: Overrides the CloudWatch Log Group to submit Terraform logs to; must exist
    - `cw-log-stream-override`: Overrides the the CloudWatch Log Stream to submit Terraform logs to; will be created if necessary
  - This Workflow deploys the `static-site` Terraservice which could emit sensitive information. The `deploy-terraservice` Composite Action (see below) will redirect the `stdout` and `stderr` from `terraform apply` and `terraform plan` commands to (by default) a CloudWatch Log Group named `/bfd/${env}/gha/ci-static-site` and Log Stream `deploy-terraservice_${run_number}` where `env` is the BFD SDLC environment deployed to and `run_number` is the run number of the `CI - Deploy Static Site` Workflow
- Adds the `Deploy Terraservice` (`.github/actions/deploy-terraservice/action.yml`) Composite Action which roughly re-implements the `deployTerraservice` function from `ops/jenkins/global-pipeline-libraries/vars/terraform.groovy` which is used in our Jenkins pipelines that deploy our Terraservices
  - Terraform commands that could potentially emit sensitive log output are redirected to a user-specified CloudWatch Log Stream
- Adds the `stdout-to-cwlogs.sh` script and corresponding `Await Background CloudWatch Logging` (`.github/actions/await-cw-logging/action.yml`) Composite Action
  - The `stdout-to-cwlogs.sh` script takes `stdout` piped to it and uploads that output, line-by-line, to a CloudWatch Log Stream and Group specified by environment variables. A background subshell is used when invoking the AWS CLI to ensure that the CloudWatch logging does not interfere with the command being piped and so that logs can arrive in near realtime to CloudWatch Logs
  - The `Await Background CloudWatch Logging` Action is intended to be used as an `always()` step in any GHA Job that uses the `stdout-to-cwlogs.sh` script. As the `stdout-to-cwlogs.sh` script invokes the AWS CLI as a background subshell, the CLI invocations may linger after the command from which `stdout` was read due to throttling or other bottlenecking. GHA will automatically cleanup these "orphaned" processes after all Job steps are executed, which _may_ caused these lingering `PutLogEvents` AWS CLI invocations to be terminated before they are able to submit logs. This Composite Action avoids that scenario by simply waiting until all `aws logs put-log-events` invocations are finished before letting the automatic cleanup run
- Adds a new CloudWatch Log Group `resource` definition to `ops/terraform/services/common/cloudwatch-logs.tf` named `/bfd/${local.env}/gha/ci-static-site` corresponding to the Log Group needed by the `CI - Deploy Static Site` Workflow
- Fixes the file globbing pattern in `static-site/_plugins/copy_data_dictionary.rb` so that the Data Dictionaries downloaded from CodeArtifact in the `CI - Deploy Static Site` Workflow can be easily renamed to conform to the pattern

### What Should Reviewers Watch For?

<!--
Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:

<!-- Add some items here -->

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:

- Adds any new software dependencies
- Modifies any security controls
- Adds new transmission or storage of data
- Any other changes that could possibly affect security?

- [x] I have considered the above security implications as it relates to this PR. (If one or more of the above apply, it cannot be merged without the ISSO or team security engineer's (`@sb-benohe`) approval.)

### Validation

Have you fully verified and tested these changes? Is the acceptance criteria met? Please provide reproducible testing instructions, code snippets, or screenshots as applicable.

- Running the `CI - Deploy Static Site` Workflow with the GHA IAM Role **temporarily** modified to be _overly-permissive_, _verifying that_:
  - The Workflow succeeds (see [run #43](https://github.com/CMSgov/beneficiary-fhir-data/actions/runs/10391099406))
  - All Terraform logs are logged to CloudWatch Logs (view the `/bfd-3465/testing` Log Group for more details) in near realtime (verified using `aws logs tail`)
  - Jekyll static site is built correctly and can be viewed at the Cloudfront Distribution URL _after re-encrypting the S3 objects and re-configuring the error page (see NOTEs above)_