### PR TITLE
BFD-3505: Script load dataset functionality

### DIFF
--- a/ops/ccs-ops-misc/synthetic-data/scripts/synthea-manual/load-dataset.sh
+++ b/ops/ccs-ops-misc/synthetic-data/scripts/synthea-manual/load-dataset.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Sync a simple synthea-generated dataset from s3://bfd-mgmt-synthea to an ETL bucket.
+#
+# **NOTE** This only works for single-datasets and needs enhancement to support
+#          recurring datasets.
+shopt -s expand_aliases
+set -euo pipefail
+
+usage="$(basename "$0") <target_bucket> <dataset>
+
+Example:
+  ./load-dataset.sh bfd-3460-prod-etl20240603193725757700000001 generated-2024-08-06_12-07-34/
+
+Sync a simple synthea-generated dataset from s3://bfd-mgmt-synthea to an ETL bucket.
+This script provides an interactive validation preview (dryrun) that requires user-input to execute the sync.
+
+Requires 'awscli'. Preference toward GNU 'awk' and GNU 'sed'.
+See output of 'aws s3 ls s3://bfd-mgmt-synthea/generated/' for valid <dataset> inputs."
+
+# Display usage string if there aren't exactly 2 arguments
+if [ "$#" -ne 2 ]; then
+    echo "$usage"
+    exit 1
+fi
+
+# Gently nudge toward GNU utilities...
+if [ "$(uname)" = 'Darwin' ]; then
+    command -v gawk >/dev/null && alias "awk=gawk" || echo "'gawk' not found; try 'brew install gawk'"
+    command -v gsed >/dev/null && alias "sed=gsed" || echo "'gsed' not found; try 'brew install gnu-sed'"
+fi
+
+target_bucket="$1"
+dataset="${2//\/}" # Remove any potential '/' characters from the dataset
+source_bucket="bfd-mgmt-synthea"
+
+# The manifest_timestamp depends on manifest.xml structure of the <dataManifest xmlns="[..]" timestamp="[..]" [..]> key
+manifest_timestamp="$(aws s3 cp "s3://${source_bucket}/generated/${dataset}/output/bfd/manifest.xml" - | grep timestamp | awk '{print $3}' | sed s/timestamp=// | tr -d '"')"
+
+echo "Previewing load of dataset ${dataset} with timestamp of ${manifest_timestamp} FROM ${source_bucket} TO ${target_bucket} ..."
+
+aws s3 sync "s3://${source_bucket}/generated/${dataset}/output/bfd/" \
+    "s3://${target_bucket}/Synthetic/Incoming/${manifest_timestamp}" \
+    --exclude "end_state*" \
+    --exclude "missing_codes.csv" \
+    --exclude "npi.tsv" \
+    --exclude "export_summary.csv" \
+    --dryrun
+
+echo
+
+read -p "Does the preview above look correct (y/n)? " -n 1 -r
+
+echo
+
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    echo "Loading..."
+    aws s3 sync "s3://${source_bucket}/generated/${dataset}/output/bfd/" \
+    "s3://${target_bucket}/Synthetic/Incoming/${manifest_timestamp}" \
+    --exclude "end_state*" \
+    --exclude "missing_codes.csv" \
+    --exclude "npi.tsv" \
+    --exclude "export_summary.csv"
+
+    # Rename manifest to begin load...
+    aws s3 mv "s3://${target_bucket}/Synthetic/Incoming/${manifest_timestamp}/manifest.xml" \
+        "s3://${target_bucket}/Synthetic/Incoming/${manifest_timestamp}/0_manifest.xml";
+else
+    echo "Preview rejected. Doing nothing and exiting."
+fi


### PR DESCRIPTION
**JIRA Ticket:**
BFD-3505

### What Does This PR Do?
This scripts the manual steps for generating (and loading) a dataset as described under item seven of the [How to Run Synthea Automation runbook](https://github.com/CMSgov/beneficiary-fhir-data/wiki/How-to-Run-Synthea-Automation).

This syncs a given dataset's critical files (ignoring metadata and synthea-specific files) from `bfd-mgmt-synthea` to the targeted ETL bucket, by placing the data in a _folder_ so-named after the dataset's manifested timestamp (from the `manifest.xml` file). Finally, it renames the `manifest.xml` to the expected `0_manifest.xml` for the environment's ETL pipeline to begin loading this data.

#### Future Work
- Upon acceptance, the aforementioned [How to Run Synthea Automation runbook](https://github.com/CMSgov/beneficiary-fhir-data/wiki/How-to-Run-Synthea-Automation) can be updated to reference this script instead of outlining the 5-point _clickops_ process.
- As noted within the script's comments, this only supports simple datasets. To support so-called recurring datasets, this will need some modest enhancements.

### What Should Reviewers Watch For?
While this is a simple script, there was at least _some_ thought toward safety built-in. Please follow-along with the logic and identify potential footguns.

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:  

- Adds any new software dependencies
- Modifies any security controls
- Adds new transmission or storage of data
- Any other changes that could possibly affect security? 

* [x] I have considered the above security implications as it relates to this PR. (If one or more of the above apply, it cannot be merged without the ISSO or team security engineer's (`@sb-benohe`) approval.) 

### Validation
This was validated by using it to load the five-part 1MM beneficiary dataset from `s3://bfd-mgmt-synthea` into both a `3505-prod-sbx` ETL bucket as well as the `prod-sbx` ETL bucket, including:
- generated-2024-08-06_12-07-34/
- generated-2024-08-06_20-01-50/
- generated-2024-08-07_03-05-32/
- generated-2024-08-07_18-07-16/
- generated-2024-08-08_03-27-04/
