### PR TITLE
BFD-3573: manage-disk-alarms Lambda(s) are failing due to incorrect Terraform apply ordering

### DIFF
--- a/ops/terraform/services/server/README.md
+++ b/ops/terraform/services/server/README.md
@@ -24,7 +24,7 @@ terraform apply
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.22 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.53.0 |
 
 <!-- GENERATED WITH `terraform-docs .`
      Manually updating the README.md will be overwritten.
@@ -45,7 +45,7 @@ terraform apply
 | <a name="input_force_create_server_log_alarms"></a> [force\_create\_server\_log\_alarms](#input\_force\_create\_server\_log\_alarms) | Forces the creation of bfd\_server\_log\_alarms for ephemeral environments | `bool` | `false` | no |
 | <a name="input_force_create_server_metrics"></a> [force\_create\_server\_metrics](#input\_force\_create\_server\_metrics) | Forces the creation of bfd\_server\_metrics for ephemeral environments | `bool` | `false` | no |
 | <a name="input_force_create_server_slo_alarms"></a> [force\_create\_server\_slo\_alarms](#input\_force\_create\_server\_slo\_alarms) | Forces the creation of bfd\_server\_slo\_alarms for ephemeral environments | `bool` | `false` | no |
-| <a name="input_jdbc_suffix"></a> [jdbc\_suffix](#input\_jdbc\_suffix) | boolean controlling logging of detail SQL values if a BatchUpdateException occurs; false disables detail logging | `string` | `"?logServerErrorDetail=false"` | no |
+| <a name="input_jdbc_suffix"></a> [jdbc\_suffix](#input\_jdbc\_suffix) | Suffix added to the Database JDBC URL to set various JDBC parameters | `string` | `"?logServerErrorDetail=false"` | no |
 
 <!-- GENERATED WITH `terraform-docs .`
      Manually updating the README.md will be overwritten.

--- a/ops/terraform/services/server/main.tf
+++ b/ops/terraform/services/server/main.tf
@@ -216,7 +216,7 @@ module "bfd_server_log_alarms" {
   source = "./modules/bfd_server_log_alarms"
 }
 
-## This is where cloudwatch dashboards are managed. 
+## This is where cloudwatch dashboards are managed.
 #
 module "bfd_dashboards" {
   count = local.create_server_dashboards ? 1 : 0
@@ -228,6 +228,8 @@ module "disk_usage_alarms" {
   count = local.create_server_disk_alarms ? 1 : 0
 
   source = "./modules/bfd_server_disk_alarms"
+
+  asg_name = module.fhir_asg.asg_id
 }
 
 module "bfd_server_error_alerts" {

--- a/ops/terraform/services/server/modules/bfd_server_disk_alarms/data-sources.tf
+++ b/ops/terraform/services/server/modules/bfd_server_disk_alarms/data-sources.tf
@@ -4,16 +4,6 @@ data "aws_kms_key" "mgmt_cmk" {
   key_id = "alias/bfd-mgmt-cmk"
 }
 
-# TODO: Consolidate the two data sources (and related resources in main.tf) with similar resources
-# in server-load
-data "aws_launch_template" "template" {
-  name = "bfd-${local.env}-fhir"
-}
-
-data "aws_autoscaling_group" "asg" {
-  name = "${data.aws_launch_template.template.name}-${data.aws_launch_template.template.latest_version}"
-}
-
 data "aws_sns_topic" "alarms_action_sns" {
   count = local.alarm_action_sns != null ? 1 : 0
   name  = local.alarm_action_sns

--- a/ops/terraform/services/server/modules/bfd_server_disk_alarms/lambda_src/manage_disk_usage_alarms.py
+++ b/ops/terraform/services/server/modules/bfd_server_disk_alarms/lambda_src/manage_disk_usage_alarms.py
@@ -155,8 +155,8 @@ def handler(event, context):
                 Unit="Percent",
                 TreatMissingData="notBreaching",
                 ActionsEnabled=True,
-                AlarmActions=[ALARM_ACTION_ARN] if ALARM_ACTION_ARN else None,
-                OKActions=[OK_ACTION_ARN] if OK_ACTION_ARN else None,
+                AlarmActions=[ALARM_ACTION_ARN] if ALARM_ACTION_ARN else [],
+                OKActions=[OK_ACTION_ARN] if OK_ACTION_ARN else [],
             )
 
             print(f"Alarm {alarm_name} successfully created")

--- a/ops/terraform/services/server/modules/bfd_server_disk_alarms/main.tf
+++ b/ops/terraform/services/server/modules/bfd_server_disk_alarms/main.tf
@@ -25,19 +25,14 @@ locals {
   alarms_ok_sns = var.alarm_ok_sns_override
 }
 
-# TODO: This SNS topic (and related resources below) mostly duplicates a similar topic used for
-# server-load; consolidate these in the future
 resource "aws_sns_topic" "this" {
   name              = local.topic_name
   kms_master_key_id = local.kms_key_id
 }
 
 resource "aws_autoscaling_notification" "this" {
-  topic_arn = aws_sns_topic.this.arn
-
-  group_names = [
-    data.aws_autoscaling_group.asg.name,
-  ]
+  topic_arn   = aws_sns_topic.this.arn
+  group_names = [var.asg_name]
 
   notifications = [
     "autoscaling:EC2_INSTANCE_LAUNCH",

--- a/ops/terraform/services/server/modules/bfd_server_disk_alarms/variables.tf
+++ b/ops/terraform/services/server/modules/bfd_server_disk_alarms/variables.tf
@@ -1,3 +1,9 @@
+variable "asg_name" {
+  description = "Name of the ASG to attach notifications to"
+  type        = string
+  default     = null
+}
+
 variable "alarm_action_sns_override" {
   description = "Overrides the SNS topic that the alarms created by this module's Lambda will post to when transitioning to the ALARM state"
   type        = string


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
BFD-3573

### What Does This PR Do?

<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

This PR fixes the `manage-disk-alarms` Lambdas and supporting infrastructure by:

- Refactoring the `bfd_server_disk_alarms` module in the `server` Terraservice to use the `asg_id` output of the `bfd_server_asg` module instead of looking up the ASG name using a `data` resource. As the ASG name changes each time we apply `server`, the `data` resources were returning the name of the _outgoing_ ASG instead of the incoming ASG which was causing the `aws_autoscaling_notifications` resource to be attached to the wrong ASG. Using variables and outputs resolves this by forcing Terraform to wait to apply the `bfd_server_disk_alarms` module until the `bfd_server_asg` module is fully applied and the value of `asg_id` is known
- Fixing the usage of `None` when there is no `OK` or `ALARM` actions defined for the resulting disk usage CloudWatch Alarms. `boto3.put_metric_alarm` expects an empty list (`[]`) instead of `None` when no `OK` or `ALARM` action should be specified

### What Should Reviewers Watch For?

<!--
Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:

<!-- Add some items here -->

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:

- Adds any new software dependencies
- Modifies any security controls
- Adds new transmission or storage of data
- Any other changes that could possibly affect security?

- [x] I have considered the above security implications as it relates to this PR. (If one or more of the above apply, it cannot be merged without the ISSO or team security engineer's (`@sb-benohe`) approval.)

### Validation

Have you fully verified and tested these changes? Is the acceptance criteria met? Please provide reproducible testing instructions, code snippets, or screenshots as applicable.

- Running a `terraform plan` for `server` in `test` with an explicit `ami_id_override` set, _verifying that_:
  - There are no errors or unexpected changes
  - The `aws_autsocaling_notification` resource is indicating that `group_names` will be known after apply instead of showing the _current_ (not incoming) ASG
- Running type checking on `manage_disk_usage_alarms.py`, _verifying that_:
  - Pyright no longer complains about mismatched types for the `AlarmActions` and `OKActions` arguments of `boto3.put_metric_alarm`