### PR TITLE
BFD-3625: Add gitleaks to build-release

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -82,6 +82,16 @@ jobs:
           sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq
           sudo chmod +x /usr/bin/yq
 
+      - name: Install gitleaks
+        run: |
+          curl -s https://api.github.com/repos/gitleaks/gitleaks/releases/latest \
+            | grep "browser_download_url.*linux_x64.tar.gz" \
+            | cut -d : -f 2,3 \
+            | tr -d \" \
+            | wget -qi -
+          sudo tar -xzf "$(find -iname 'gitleaks*.tar.gz')" -C /usr/bin gitleaks
+          sudo chmod +x /usr/bin/gitleaks
+
       - name: Set and Validate Version Strings
         id: bfd-version-strings
         run: |


### PR DESCRIPTION
**JIRA Ticket:**
BFD-3625


### What Does This PR Do?
This effectively installs `gitleaks` from the latest [gitleaks/gitleaks](https://github.com/gitleaks/gitleaks/releases/latest) release archive inside the build-release workflow.

While `gitleaks` itself is MIT licensed, the _official_ gitleaks action appears to require a _free_ license when executing as part of a GitHub organization. I don't believe this flouts any specific licenses at issues as I've simply implemented a step to download/install the MIT-licensed gitleaks archive–I'd just rather not go through any additional steps to allow gitleaks executions to proceed as part of the build-release workflow.

### What Should Reviewers Watch For?
<!--
Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items here -->

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:  

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security? 

* [x] I have considered the above security implications as it relates to this PR. (If one or more of the above apply, it cannot be merged without the ISSO or team security engineer's (`@sb-benohe`) approval.) 


### Validation

Have you fully verified and tested these changes? Is the acceptance criteria met? Please provide reproducible testing instructions, code snippets, or screenshots as applicable.

I'm [running the build-release workflow on the branch](https://github.com/CMSgov/beneficiary-fhir-data/actions/runs/10724768102/job/29741155426) that backs this PR– ~it's already beyond the `gitleaks` step, but I'll be keeping this in draft until I've removed the automated commits from the history.~ ✅ Success!