### PR TITLE
BFD-2558: Avoid BFD-Server ASG Destruction with each release

### DIFF
--- a/ops/terraform/services/server/modules/bfd_server_asg/main.tf
+++ b/ops/terraform/services/server/modules/bfd_server_asg/main.tf
@@ -164,13 +164,13 @@ resource "aws_autoscaling_group" "main" {
   ##### Generate a new group on every revision of the launch template.
   ##### This does a simple version of a blue/green deployment
   # BFD-2588: reuse ASG instead
-  name             = "${aws_launch_template.main.name}" ##  -${aws_launch_template.main.latest_version}"
+  name             = aws_launch_template.main.name ##  -${aws_launch_template.main.latest_version}"
   desired_capacity = var.asg_config.desired
   max_size         = var.asg_config.max
   min_size         = var.asg_config.min
 
   # If an lb is defined, wait for the ELB
-  min_elb_capacity          = var.lb_config == null ? null : var.asg_config.min
+  min_elb_capacity = var.lb_config == null ? null : var.asg_config.min
   # BFD-2588 increase capacity timeout from 20m to 30m
   wait_for_capacity_timeout = var.lb_config == null ? null : "30m"
 
@@ -232,7 +232,7 @@ resource "aws_autoscaling_group" "main" {
   lifecycle {
     create_before_destroy = true
     # BFD-2588
-    ignore_changes        = [desired_capacity, min_size, max_size]
+    ignore_changes = [desired_capacity, min_size, max_size]
   }
 }
 


### PR DESCRIPTION
**JIRA Ticket:**
BFD-2558

### What Does This PR Do?

BFD-2558 removes the BFD Server launch template version as a suffix for the ASG name, thereby allowing reuse across launch template versions. In doing so, additional resource attributes are introduced (instance_refresh, termination_policies, lifecycle.ignore_changes) to manage scaling group membership consistently.
Addressing recent release cycle complications, attribute wait_for_capacity_timeout has been extended from 20m to 30m.
 
### What Should Reviewers Watch For?

If you're reviewing this PR, please check for these things in particular:

* does instance_refresh policy define behavior as desired?

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:  

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security? 

* [x] I have considered the above security implications as it relates to this PR; no security implications apply.

### Validation

Have you fully verified and tested these changes? Is the acceptance criteria met? Please provide reproducible testing instructions, code snippets, or screenshots as applicable.
    
https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#AutoScalingGroupDetails:id=bfd-2558-prod-sbx-fhir;view=activity shows latest refresh cycle completed 2024-09-24T13:50:09.000Z based on terraform apply at 2024-09-24T13:12:05.000Z that updated launch template version. 

Follow-up terraform apply that added instance_refresh.skip_matching and termination_policies attributes at 2024-09-24T13:56:00.000Z generated no behavioral changes to ASG.