### PR TITLE
BFD-3679: Temporarily, correctly disable PAC endpoints during SAMHSA Incident

### DIFF
--- a/ops/terraform/services/base/values/prod.yaml
+++ b/ops/terraform/services/base/values/prod.yaml
@@ -224,7 +224,7 @@
 /bfd/${env}/server/nonsensitive/data_server_dir: /usr/local/bfd-server
 /bfd/${env}/server/nonsensitive/data_server_new_relic_metric_host: https://gov-metric-api.newrelic.com
 /bfd/${env}/server/nonsensitive/data_server_new_relic_metric_path: /metric/v1
-/bfd/${env}/server/nonsensitive/pac_resources_enabled: "true"
+/bfd/${env}/server/nonsensitive/pac_resources_enabled: "false"
 /bfd/${env}/server/nonsensitive/pac_claim_source_types: fiss,mcs
 /bfd/${env}/server/nonsensitive/lb_is_public: "false"
 /bfd/${env}/server/nonsensitive/lb_ingress_port: "443"


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
BFD-3679

### What Does This PR Do?

<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

This PR _correctly_ disables the PAC endpoints by setting the `pac_resources_enabled` SSM parameter to `false` rather than the `pac/enabled` SSM parameter.

Until BFD-3045 is merged the former parameter controls whether or not the PAC endpoints are enabled.

#### Additional Context

For context, the Java source looks for a configuration value named `pac/enabled` but the BFD Server does not yet self-configure from SSM. So, this value needs to be provided to the BFD Server in the form of an environment variable named `BFD_PAC_ENABLED` (`BFD_`-prefixed environment variables are converted to configuration paths by removing the `BFD_` prefix, lowercasing, and then replacing underscores with slashes). Unfortunately, the value of `BFD_PAC_ENABLED` is provided by `pac_resources_enabled` in `ops/ansible/roles/bfd-server/templates/bfd-server.sh.j2:57` rather than `pac/enabled`. Thus, when I checked the Java code to confirm the parameter to modify, I saw that the path was `pac/enabled` which matched the corresponding SSM parameter and assumed that the value of said parameter was being used. Obviously, this was not the case.

### What Should Reviewers Watch For?

<!--
Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:

<!-- Add some items here -->

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:

- Adds any new software dependencies
- Modifies any security controls
- Adds new transmission or storage of data
- Any other changes that could possibly affect security?

- [x] I have considered the above security implications as it relates to this PR. (If one or more of the above apply, it cannot be merged without the ISSO or team security engineer's (`@sb-benohe`) approval.)

### Validation

Have you fully verified and tested these changes? Is the acceptance criteria met? Please provide reproducible testing instructions, code snippets, or screenshots as applicable.

- `terraform plan`ning `base` in `prod`, _verifying that_ the `pac_resources_enabled` SSM parameter does not have any unexpected changes (that is, its value remains `false` due to out-of-band changes)
- Setting `pac_resources_enabled` to `false` in `prod` out-of-band and re-running the user data scripts on all `prod` instances, _verifying that_ the PAC endpoints are properly disabled (that is, the value of `pac_resources_enabled` is respected)
