### PR TITLE
BFD-3688: Log nonsensitive MBI identifiers to MDC for Claim and ClaimResponse requests

### DIFF
--- a/apps/bfd-server/bfd-server-shared-utils/src/main/java/gov/cms/bfd/server/sharedutils/BfdMDC.java
+++ b/apps/bfd-server/bfd-server-shared-utils/src/main/java/gov/cms/bfd/server/sharedutils/BfdMDC.java
@@ -262,6 +262,12 @@ public class BfdMDC {
   /** MDC key for the resources returned. */
   public static final String RESOURCES_RETURNED = computeMDCKey("resources_returned_count");
 
+  /** MDC key for MBI Hash. */
+  public static final String MBI_HASH = "mbi_hash";
+
+  /** MDC key for MBI Id. */
+  public static final String MBI_ID = "mbi_id";
+
   /**
    * Set the MDC Adapter. Normally this is not needed, but it can be useful in testing.
    *

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/TransformerUtilsV2.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/TransformerUtilsV2.java
@@ -34,7 +34,6 @@ import gov.cms.bfd.model.rif.entities.SNFClaim;
 import gov.cms.bfd.model.rif.entities.SNFClaimColumn;
 import gov.cms.bfd.model.rif.entities.SNFClaimLine;
 import gov.cms.bfd.model.rif.parse.InvalidRifValueException;
-import gov.cms.bfd.server.sharedutils.BfdMDC;
 import gov.cms.bfd.server.war.commons.C4BBInstutionalClaimSubtypes;
 import gov.cms.bfd.server.war.commons.CCWProcedure;
 import gov.cms.bfd.server.war.commons.CCWUtils;
@@ -4056,17 +4055,6 @@ public final class TransformerUtilsV2 {
             .setIdentifier(
                 TransformerUtilsV2.createIdentifier(
                     CcwCodebookVariable.PRVDR_NUM, providerNumber)));
-  }
-
-  /**
-   * Logs the mbi hash to mdc.
-   *
-   * @param mbiHash the mbi hash to log
-   */
-  public static void logMbiHashToMdc(String mbiHash) {
-    if (!Strings.isNullOrEmpty(mbiHash)) {
-      BfdMDC.put("mbi_hash", mbiHash);
-    }
   }
 
   /**

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/pac/AbstractR4ResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/pac/AbstractR4ResourceProvider.java
@@ -236,6 +236,9 @@ public abstract class AbstractR4ResourceProvider<T extends IBaseResource>
       throw new ResourceNotFoundException(claimId);
     }
 
+    Mbi claimEntityMbi = getClaimEntityMbi(claimIdObj.getRight(), claimEntity);
+    if (claimEntityMbi != null) logMbiIdentifiersToMdc(claimEntityMbi);
+
     return transformEntity(claimIdObj.getRight(), claimEntity, includeTaxNumbers);
   }
 

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/pac/AbstractR4ResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/pac/AbstractR4ResourceProvider.java
@@ -298,15 +298,17 @@ public abstract class AbstractR4ResourceProvider<T extends IBaseResource>
    *     or mcs)
    * @param claimEntity the claim entity itself; either a {@link RdaFissClaim} or {@link
    *     RdaMcsClaim}
-   * @return the {@link Mbi} associated with the given claim entity, or <code>null</code> if not
-   *     found
+   * @return the {@link Mbi} associated with the given claim entity
+   * @throws IllegalArgumentException if the given {@link ResourceTypeV2} does not indicate either a
+   *     FISS or MCS claim ID type
    */
   private <T extends IBaseResource> @Nullable Mbi getClaimEntityMbi(
       ResourceTypeV2<T, ?> claimIdType, Object claimEntity) {
     return switch (claimIdType.getTypeLabel()) {
       case "fiss" -> ((RdaFissClaim) claimEntity).getMbiRecord();
       case "mcs" -> ((RdaMcsClaim) claimEntity).getMbiRecord();
-      default -> null;
+      default -> throw new IllegalArgumentException(
+          "Invalid claim ID type '" + claimIdType.getTypeLabel() + "', cannot get claim data");
     };
   }
 

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/pac/AbstractR4ResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/pac/AbstractR4ResourceProvider.java
@@ -315,8 +315,8 @@ public abstract class AbstractR4ResourceProvider<T extends IBaseResource>
   private void logMbiIdentifiersToMdc(Mbi mbi) {
     requireNonNull(mbi);
 
-    BfdMDC.put("mbi_hash", mbi.getHash());
-    BfdMDC.put("mbi_id", mbi.getMbiId().toString());
+    BfdMDC.put(BfdMDC.MBI_HASH, mbi.getHash());
+    BfdMDC.put(BfdMDC.MBI_ID, mbi.getMbiId().toString());
   }
 
   /**

--- a/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/pac/AbstractR4ResourceProvider.java
+++ b/apps/bfd-server/bfd-server-war/src/main/java/gov/cms/bfd/server/war/r4/providers/pac/AbstractR4ResourceProvider.java
@@ -34,6 +34,7 @@ import gov.cms.bfd.server.war.r4.providers.pac.common.ClaimDao;
 import gov.cms.bfd.server.war.r4.providers.pac.common.ResourceTransformer;
 import gov.cms.bfd.server.war.r4.providers.pac.common.ResourceTypeV2;
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import jakarta.annotation.PostConstruct;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.NoResultException;
@@ -58,7 +59,6 @@ import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.ClaimResponse;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Resource;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * Allows for generic processing of resource using common logic. Claims and ClaimResponses have the

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/CoverageE2EBase.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/CoverageE2EBase.java
@@ -389,7 +389,7 @@ public abstract class CoverageE2EBase extends ServerRequiredTest {
     List<String> additionalExpectedMdcKeys =
         List.of(BfdMDC.HTTP_ACCESS_RESPONSE_HEADER_CONTENT_LOCATION);
 
-    ServerTestUtils.assertAccessJsonHasMdcKeys(
+    ServerTestUtils.assertDefaultAndAdditionalMdcKeys(
         requestAuth, requestString, additionalExpectedMdcKeys);
   }
 
@@ -406,7 +406,7 @@ public abstract class CoverageE2EBase extends ServerRequiredTest {
 
     List<String> additionalExpectedMdcKeys = List.of(BfdMDC.HTTP_ACCESS_RESPONSE_DURATION_PER_KB);
 
-    ServerTestUtils.assertAccessJsonHasMdcKeys(
+    ServerTestUtils.assertDefaultAndAdditionalMdcKeys(
         requestAuth, requestString, additionalExpectedMdcKeys);
   }
 

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/ExplanationOfBenefitE2EBase.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/ExplanationOfBenefitE2EBase.java
@@ -1013,7 +1013,7 @@ public abstract class ExplanationOfBenefitE2EBase extends ServerRequiredTest {
             BfdMDC.HTTP_ACCESS_REQUEST_HEADER_ADDRESS_FIELDS,
             BfdMDC.HTTP_ACCESS_REQUEST_HEADER_ACCEPT_CHARSET);
 
-    ServerTestUtils.assertAccessJsonHasMdcKeys(
+    ServerTestUtils.assertDefaultAndAdditionalMdcKeys(
         requestAuth, requestString, additionalExpectedMdcKeys, headers);
   }
 
@@ -1036,7 +1036,7 @@ public abstract class ExplanationOfBenefitE2EBase extends ServerRequiredTest {
             BfdMDC.HTTP_ACCESS_REQUEST_HEADER_TAX_NUMBERS,
             BfdMDC.HTTP_ACCESS_REQUEST_HEADER_ADDRESS_FIELDS);
 
-    ServerTestUtils.assertAccessJsonHasMdcKeys(
+    ServerTestUtils.assertDefaultAndAdditionalMdcKeys(
         requestAuth, requestString, additionalExpectedMdcKeys, headers);
   }
 

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/PatientE2EBase.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/PatientE2EBase.java
@@ -834,7 +834,7 @@ public abstract class PatientE2EBase extends ServerRequiredTest {
     List<String> additionalExpectedMdcKeys = new ArrayList<>();
     additionalExpectedMdcKeys.add(BfdMDC.HTTP_ACCESS_RESPONSE_DURATION_PER_KB);
 
-    ServerTestUtils.assertAccessJsonHasMdcKeys(
+    ServerTestUtils.assertDefaultAndAdditionalMdcKeys(
         requestAuth, requestString, additionalExpectedMdcKeys);
   }
 
@@ -850,7 +850,7 @@ public abstract class PatientE2EBase extends ServerRequiredTest {
     List<String> additionalExpectedMdcKeys = new ArrayList<>();
     additionalExpectedMdcKeys.add(BfdMDC.HTTP_ACCESS_RESPONSE_HEADER_CONTENT_LOCATION);
 
-    ServerTestUtils.assertAccessJsonHasMdcKeys(
+    ServerTestUtils.assertDefaultAndAdditionalMdcKeys(
         requestAuth, requestString, additionalExpectedMdcKeys);
   }
 
@@ -866,7 +866,7 @@ public abstract class PatientE2EBase extends ServerRequiredTest {
     List<String> additionalExpectedMdcKeys = new ArrayList<>();
     additionalExpectedMdcKeys.add(BfdMDC.HTTP_ACCESS_RESPONSE_DURATION_PER_KB);
 
-    ServerTestUtils.assertAccessJsonHasMdcKeys(
+    ServerTestUtils.assertDefaultAndAdditionalMdcKeys(
         requestAuth, requestString, additionalExpectedMdcKeys);
   }
 

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/ServerTestUtils.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/ServerTestUtils.java
@@ -80,6 +80,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.management.MBeanServer;
 import javax.net.ssl.SSLContext;
 import javax.sql.DataSource;
@@ -100,6 +101,41 @@ import org.testcontainers.shaded.org.awaitility.Awaitility;
 /** Contains test utilities. */
 public final class ServerTestUtils {
   private static final Logger LOGGER = LoggerFactory.getLogger(ServerTestUtils.class);
+
+  /** The list of base mdc keys that should be on every write to access.json. */
+  private static final List<String> DEFAULT_MDC_KEYS =
+      Arrays.asList(
+          BfdMDC.BENE_ID,
+          BfdMDC.HAPI_RESPONSE_TIMESTAMP_MILLI,
+          BfdMDC.HAPI_POST_PROCESS_TIMESTAMP_MILLI,
+          BfdMDC.HAPI_PRE_HANDLE_TIMESTAMP_MILLI,
+          BfdMDC.HAPI_PRE_PROCESS_TIMESTAMP_MILLI,
+          BfdMDC.HAPI_PROCESSING_COMPLETED_TIMESTAMP_MILLI,
+          BfdMDC.HAPI_PROCESSING_COMPLETED_NORM_TIMESTAMP_MILLI,
+          BfdMDC.HTTP_ACCESS_REQUEST_CLIENTSSL_DN,
+          BfdMDC.HTTP_ACCESS_REQUEST_HEADER_ACCEPT,
+          BfdMDC.HTTP_ACCESS_REQUEST_HEADER_ACCEPT_ENCODING,
+          BfdMDC.HTTP_ACCESS_REQUEST_HEADER_CONN_ENCODING,
+          BfdMDC.HTTP_ACCESS_REQUEST_HEADER_HOST_ENCODING,
+          BfdMDC.HTTP_ACCESS_REQUEST_HEADER_USER_AGENT,
+          BfdMDC.HTTP_ACCESS_REQUEST_HTTP_METHOD,
+          BfdMDC.HTTP_ACCESS_REQUEST_OPERATION,
+          BfdMDC.HTTP_ACCESS_REQUEST_QUERY_STR,
+          BfdMDC.HTTP_ACCESS_REQUEST_TYPE,
+          BfdMDC.HTTP_ACCESS_REQUEST_URI,
+          BfdMDC.HTTP_ACCESS_REQUEST_URL,
+          BfdMDC.HTTP_ACCESS_REQUEST_HEADER_CONTENT_TYPE,
+          BfdMDC.HTTP_ACCESS_RESPONSE_DURATION_MILLISECONDS,
+          BfdMDC.HTTP_ACCESS_RESPONSE_HEADER_ENCODING,
+          BfdMDC.HTTP_ACCESS_RESPONSE_HEADER_CONTENT_TYPE,
+          BfdMDC.HTTP_ACCESS_RESPONSE_HEADER_DATE,
+          BfdMDC.HTTP_ACCESS_RESPONSE_HEADER_LAST_MODIFIED,
+          BfdMDC.HTTP_ACCESS_RESPONSE_HEADER_POWERED_BY,
+          BfdMDC.HTTP_ACCESS_RESPONSE_HEADER_REQUEST_ID,
+          BfdMDC.HTTP_ACCESS_RESPONSE_OUTPUT_SIZE_IN_BYTES,
+          BfdMDC.HTTP_ACCESS_RESPONSE_STATUS,
+          BfdMDC.HTTP_ACCESS_RESPONSE_CONTENT_LENGTH,
+          BfdMDC.RESOURCES_RETURNED);
 
   /** The singleton {@link ServerTestUtils} instance to use everywhere. */
   private static ServerTestUtils SINGLETON;
@@ -787,9 +823,9 @@ public final class ServerTestUtils {
   }
 
   /**
-   * Assert mdc keys are written to the access.json log when calling the given REST query string.
-   * Will check a set of common mdc keys that should be on every call, and optionally takes a list
-   * of additional keys to check for specific to the request made.
+   * Assert mdc keys (not values) are written to the access.json log when calling the given REST
+   * query string. Will check a set of common mdc keys that should be on every call, and optionally
+   * takes a list of additional keys to check for specific to the request made.
    *
    * @param requestAuth the request auth for the restAssured call
    * @param requestString the request string for the restAssured call
@@ -797,17 +833,17 @@ public final class ServerTestUtils {
    *     mdc keys to check for in the access.json
    * @throws IOException if there is an issue with the IO around the access.json file
    */
-  public static void assertAccessJsonHasMdcKeys(
+  public static void assertDefaultAndAdditionalMdcKeys(
       RequestSpecification requestAuth, String requestString, List<String> additionalMdcKeysToCheck)
       throws IOException {
-    assertAccessJsonHasMdcKeys(
+    assertDefaultAndAdditionalMdcKeys(
         requestAuth, requestString, additionalMdcKeysToCheck, new HashMap<>());
   }
 
   /**
-   * Assert mdc keys are written to the access.json log when calling the given REST query string.
-   * Will check a set of common mdc keys that should be on every call, and optionally takes a list
-   * of additional keys to check for specific to the request made.
+   * Assert mdc keys (not values) are written to the access.json log when calling the given REST
+   * query string. Will check a set of common mdc keys that should be on every call, and optionally
+   * takes a list of additional keys to check for specific to the request made.
    *
    * @param requestAuth the request auth for the restAssured call
    * @param requestString the request string for the restAssured call
@@ -816,61 +852,65 @@ public final class ServerTestUtils {
    * @param headers the headers needed for the restAssured request
    * @throws IOException if there is an issue with the IO around the access.json file
    */
-  public static void assertAccessJsonHasMdcKeys(
+  public static void assertDefaultAndAdditionalMdcKeys(
       RequestSpecification requestAuth,
       String requestString,
       List<String> additionalMdcKeysToCheck,
       Map<String, String> headers)
       throws IOException {
+    assertMdcEntries(
+        requestAuth,
+        requestString,
+        Stream.concat(DEFAULT_MDC_KEYS.stream(), additionalMdcKeysToCheck.stream())
+            .distinct()
+            .collect(Collectors.toMap(key -> key, key -> Optional.empty())),
+        headers);
+  }
 
+  /**
+   * Assert that MDC entries provided exist in the access.jon log, and optionally check the values
+   * of the entries if the value provided for a given MDC key is not an empty {@link Optional}
+   * value.
+   *
+   * @param requestAuth the request auth for the restAssured call
+   * @param requestString the request string for the restAssured call
+   * @param expectedMdcKeysToValues a {@link Map} of MDC keys to values that are asserted upon. Keys
+   *     are always checked for existence, whereas values are only checked if a non-empty value is
+   *     provided
+   * @throws IOException if there is an issue with the IO around the access.json file
+   */
+  public static void assertMdcEntries(
+      RequestSpecification requestAuth,
+      String requestString,
+      Map<String, Optional<String>> expectedMdcKeysToValues)
+      throws IOException {
+    assertMdcEntries(requestAuth, requestString, expectedMdcKeysToValues, new HashMap<>());
+  }
+
+  /**
+   * Assert that MDC entries provided exist in the access.jon log, and optionally check the values
+   * of the entries if the value provided for a given MDC key is not an empty {@link Optional}
+   * value.
+   *
+   * @param requestAuth the request auth for the restAssured call
+   * @param requestString the request string for the restAssured call
+   * @param expectedMdcKeysToValues a {@link Map} of MDC keys to values that are asserted upon. Keys
+   *     are always checked for existence, whereas values are only checked if a non-empty value is
+   *     provided
+   * @param headers the headers needed for the restAssured request
+   * @throws IOException if there is an issue with the IO around the access.json file
+   */
+  public static void assertMdcEntries(
+      RequestSpecification requestAuth,
+      String requestString,
+      Map<String, Optional<String>> expectedMdcKeysToValues,
+      Map<String, String> headers)
+      throws IOException {
     Path accessLogJson =
         ServerTestUtils.getWarProjectDirectory()
             .resolve("target")
             .resolve("server-work")
             .resolve("access.json");
-
-    // A list of base mdc keys that should be on every write to access.json
-    List<String> baseKeysToCheck =
-        Arrays.asList(
-            BfdMDC.BENE_ID,
-            BfdMDC.HAPI_RESPONSE_TIMESTAMP_MILLI,
-            BfdMDC.HAPI_POST_PROCESS_TIMESTAMP_MILLI,
-            BfdMDC.HAPI_PRE_HANDLE_TIMESTAMP_MILLI,
-            BfdMDC.HAPI_PRE_PROCESS_TIMESTAMP_MILLI,
-            BfdMDC.HAPI_PROCESSING_COMPLETED_TIMESTAMP_MILLI,
-            BfdMDC.HAPI_PROCESSING_COMPLETED_NORM_TIMESTAMP_MILLI,
-            BfdMDC.HTTP_ACCESS_REQUEST_CLIENTSSL_DN,
-            BfdMDC.HTTP_ACCESS_REQUEST_HEADER_ACCEPT,
-            BfdMDC.HTTP_ACCESS_REQUEST_HEADER_ACCEPT_ENCODING,
-            BfdMDC.HTTP_ACCESS_REQUEST_HEADER_CONN_ENCODING,
-            BfdMDC.HTTP_ACCESS_REQUEST_HEADER_HOST_ENCODING,
-            BfdMDC.HTTP_ACCESS_REQUEST_HEADER_USER_AGENT,
-            BfdMDC.HTTP_ACCESS_REQUEST_HTTP_METHOD,
-            BfdMDC.HTTP_ACCESS_REQUEST_OPERATION,
-            BfdMDC.HTTP_ACCESS_REQUEST_QUERY_STR,
-            BfdMDC.HTTP_ACCESS_REQUEST_TYPE,
-            BfdMDC.HTTP_ACCESS_REQUEST_URI,
-            BfdMDC.HTTP_ACCESS_REQUEST_URL,
-            BfdMDC.HTTP_ACCESS_REQUEST_HEADER_CONTENT_TYPE,
-            BfdMDC.HTTP_ACCESS_RESPONSE_DURATION_MILLISECONDS,
-            BfdMDC.HTTP_ACCESS_RESPONSE_HEADER_ENCODING,
-            BfdMDC.HTTP_ACCESS_RESPONSE_HEADER_CONTENT_TYPE,
-            BfdMDC.HTTP_ACCESS_RESPONSE_HEADER_DATE,
-            BfdMDC.HTTP_ACCESS_RESPONSE_HEADER_LAST_MODIFIED,
-            BfdMDC.HTTP_ACCESS_RESPONSE_HEADER_POWERED_BY,
-            BfdMDC.HTTP_ACCESS_RESPONSE_HEADER_REQUEST_ID,
-            BfdMDC.HTTP_ACCESS_RESPONSE_OUTPUT_SIZE_IN_BYTES,
-            BfdMDC.HTTP_ACCESS_RESPONSE_STATUS,
-            BfdMDC.HTTP_ACCESS_RESPONSE_CONTENT_LENGTH,
-            BfdMDC.RESOURCES_RETURNED);
-
-    // Copy array so its mutable for the below add
-    List<String> mdcAccessKeysToCheck = new ArrayList<>(baseKeysToCheck);
-
-    // If there are any other additional mdc keys specific to this call, add them to the list to
-    // check
-    mdcAccessKeysToCheck.addAll(additionalMdcKeysToCheck);
-
     // Empty the access json to avoid pollution from other tests
     try (BufferedWriter writer = Files.newBufferedWriter(accessLogJson)) {
       Files.writeString(accessLogJson, "");
@@ -906,7 +946,7 @@ public final class ServerTestUtils {
 
     // Compile a list of mdc keys that are missing from the expected list
     List<String> missingMdcKeys = new ArrayList<>();
-    for (String mdcKey : mdcAccessKeysToCheck) {
+    for (String mdcKey : expectedMdcKeysToValues.keySet()) {
       if (!mdcKeyValueMap.containsKey(mdcKey)) {
         LOGGER.info("Missing header: " + mdcKey);
         missingMdcKeys.add(mdcKey);
@@ -918,16 +958,41 @@ public final class ServerTestUtils {
      * testing them on all endpoints */
     List<String> extraMdcKeys = new ArrayList<>();
     for (String mdcKey : mdcKeyValueMap.keySet()) {
-      if (!mdcAccessKeysToCheck.contains(mdcKey)
+      if (!expectedMdcKeysToValues.containsKey(mdcKey)
+          && !DEFAULT_MDC_KEYS.contains(mdcKey)
           && !mdcKey.startsWith("jpa")
           && !mdcKey.startsWith("database")) {
         LOGGER.info("Extra header: " + mdcKey);
         extraMdcKeys.add(mdcKey);
       }
     }
+
+    // Reduce the expected MDC entries to a subset of entries with values we'd like to check; that
+    // is, any entry with a value that isn't an empty Optional
+    Map<String, String> mdcEntriesWithExpectedVals =
+        expectedMdcKeysToValues.entrySet().stream()
+            .filter(es -> es.getValue().isPresent())
+            .map(es -> Map.entry(es.getKey(), es.getValue().get()))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+    // Reduce the actual values map to one with keys matching that of the expected, checked map
+    // above. This is necessary as we only want to check the value of a particular entry if a value
+    // was provided
+    Map<String, String> actualMdcEntriesToCheck =
+        mdcKeyValueMap.entrySet().stream()
+            .filter(es -> mdcEntriesWithExpectedVals.containsKey(es.getKey()))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
     // Check we have no missing mdc keys in a way that makes a useful assertion error if not
     assertEquals(missingMdcKeys, new ArrayList<>(), "Missing expected MDC keys in access.json");
     assertEquals(
         extraMdcKeys, new ArrayList<>(), "Found unexpected additional MDC keys in access.json");
+
+    // Check the MDC entries with an expected value against the real value assertMdcEntries from
+    // access.json
+    assertEquals(
+        mdcEntriesWithExpectedVals,
+        actualMdcEntriesToCheck,
+        "Found MDC entries with unexpected values in access.json");
   }
 }

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/ServerTestUtils.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/ServerTestUtils.java
@@ -861,6 +861,9 @@ public final class ServerTestUtils {
     assertMdcEntries(
         requestAuth,
         requestString,
+        // Generate a Map that is the combination of the default keys and any additional keys to
+        // check where each key has a corresponding empty value indicating that only the key's
+        // existence should be verified; basically, this method doesn't check any MDC values
         Stream.concat(DEFAULT_MDC_KEYS.stream(), additionalMdcKeysToCheck.stream())
             .distinct()
             .collect(Collectors.toMap(key -> key, key -> Optional.empty())),

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/PatientE2E.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/PatientE2E.java
@@ -217,7 +217,7 @@ public class PatientE2E extends PatientE2EBase {
     List<String> additionalExpectedMdcKeys = new ArrayList<>(MDC_EXPECTED_BASE_KEYS);
     additionalExpectedMdcKeys.add(BfdMDC.HTTP_ACCESS_RESPONSE_DURATION_PER_KB);
 
-    ServerTestUtils.assertAccessJsonHasMdcKeys(
+    ServerTestUtils.assertDefaultAndAdditionalMdcKeys(
         requestAuth, requestString, additionalExpectedMdcKeys, headers);
   }
 

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/pac/ClaimE2E.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/pac/ClaimE2E.java
@@ -159,6 +159,52 @@ public class ClaimE2E extends ServerRequiredTest {
   }
 
   /**
+   * Tests to see if nonsensitive MBI identifiers (hash and ID) are logged to the MDC when a FISS
+   * {@link Claim} with an associated {@link Mbi} is looked up by a specific ID.
+   */
+  @Test
+  void testClaimReadLogsMbiIdentifiersForFissClaimWithMbiRecord() throws IOException {
+    String requestString = claimEndpoint + "f-123456";
+
+    Mbi testingMbi = rdaTestUtils.lookupTestMbiRecord(rdaTestUtils.getEntityManager());
+    ServerTestUtils.assertMdcEntries(
+        requestAuth,
+        requestString,
+        Map.of(
+            BfdMDC.MBI_HASH,
+            Optional.of(testingMbi.getHash()),
+            BfdMDC.MBI_ID,
+            Optional.of(testingMbi.getMbiId().toString()),
+            // This isn't a default key, but we need to include it without checking its value to
+            // satisfy the assertion for extra, unexpected MDC keys
+            BfdMDC.HTTP_ACCESS_RESPONSE_HEADER_CONTENT_LOCATION,
+            Optional.empty()));
+  }
+
+  /**
+   * Tests to see if nonsensitive MBI identifiers (hash and ID) are logged to the MDC when an MCS
+   * {@link Claim} with an associated {@link Mbi} is looked up by a specific ID.
+   */
+  @Test
+  void testClaimReadLogsMbiIdentifiersForMcsClaimWithMbiRecord() throws IOException {
+    String requestString = claimEndpoint + "m-654321";
+
+    Mbi testingMbi = rdaTestUtils.lookupTestMbiRecord(rdaTestUtils.getEntityManager());
+    ServerTestUtils.assertMdcEntries(
+        requestAuth,
+        requestString,
+        Map.of(
+            BfdMDC.MBI_HASH,
+            Optional.of(testingMbi.getHash()),
+            BfdMDC.MBI_ID,
+            Optional.of(testingMbi.getMbiId().toString()),
+            // This isn't a default key, but we need to include it without checking its value to
+            // satisfy the assertion for extra, unexpected MDC keys
+            BfdMDC.HTTP_ACCESS_RESPONSE_HEADER_CONTENT_LOCATION,
+            Optional.empty()));
+  }
+
+  /**
    * Tests to see if the correct response is given when a search is done for {@link Claim}s using
    * given mbi and service-date range. In this test case the query finds the matched claims because
    * their to dates are within the date range even though their from dates are not.

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/pac/ClaimE2E.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/pac/ClaimE2E.java
@@ -4,12 +4,18 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 
+import gov.cms.bfd.model.rda.Mbi;
+import gov.cms.bfd.server.sharedutils.BfdMDC;
 import gov.cms.bfd.server.war.ServerRequiredTest;
+import gov.cms.bfd.server.war.ServerTestUtils;
 import gov.cms.bfd.server.war.commons.CommonHeaders;
 import gov.cms.bfd.server.war.utils.AssertUtils;
 import gov.cms.bfd.server.war.utils.RDATestUtils;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import org.hl7.fhir.r4.model.Claim;
 import org.junit.jupiter.api.AfterAll;
@@ -265,6 +271,29 @@ public class ClaimE2E extends ServerRequiredTest {
         .statusCode(200)
         .when()
         .get(requestString);
+  }
+
+  /**
+   * Verify that Claim logs nonsensitive MBI identifiers (hash and ID) to the MDC log when receiving
+   * a valid Claim request.
+   */
+  @Test
+  public void testClaimFindByPatientLogsMbiIdentifiers() throws IOException {
+    String requestString = claimEndpoint + "?mbi=" + RDATestUtils.MBI_HASH;
+
+    Mbi testingMbi = rdaTestUtils.lookupTestMbiRecord(rdaTestUtils.getEntityManager());
+    ServerTestUtils.assertMdcEntries(
+        requestAuth,
+        requestString,
+        Map.of(
+            BfdMDC.MBI_HASH,
+            Optional.of(testingMbi.getHash()),
+            BfdMDC.MBI_ID,
+            Optional.of(testingMbi.getMbiId().toString()),
+            // This isn't a default key, but we need to include it without checking its value to
+            // satisfy the assertion for extra, unexpected MDC keys
+            BfdMDC.HTTP_ACCESS_RESPONSE_DURATION_PER_KB,
+            Optional.empty()));
   }
 
   /**

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/pac/ClaimResponseE2E.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/r4/providers/pac/ClaimResponseE2E.java
@@ -82,6 +82,52 @@ public class ClaimResponseE2E extends ServerRequiredTest {
   }
 
   /**
+   * Tests to see if nonsensitive MBI identifiers (hash and ID) are logged to the MDC when a FISS
+   * {@link ClaimResponse} with an associated {@link Mbi} is looked up by a specific ID.
+   */
+  @Test
+  void testClaimResponseReadLogsMbiIdentifiersForFissClaimWithMbiRecord() throws IOException {
+    String requestString = claimResponseEndpoint + "f-123456";
+
+    Mbi testingMbi = rdaTestUtils.lookupTestMbiRecord(rdaTestUtils.getEntityManager());
+    ServerTestUtils.assertMdcEntries(
+        requestAuth,
+        requestString,
+        Map.of(
+            BfdMDC.MBI_HASH,
+            Optional.of(testingMbi.getHash()),
+            BfdMDC.MBI_ID,
+            Optional.of(testingMbi.getMbiId().toString()),
+            // This isn't a default key, but we need to include it without checking its value to
+            // satisfy the assertion for extra, unexpected MDC keys
+            BfdMDC.HTTP_ACCESS_RESPONSE_HEADER_CONTENT_LOCATION,
+            Optional.empty()));
+  }
+
+  /**
+   * Tests to see if nonsensitive MBI identifiers (hash and ID) are logged to the MDC when an MCS
+   * {@link ClaimResponse} with an associated {@link Mbi} is looked up by a specific ID.
+   */
+  @Test
+  void testClaimResponseReadLogsMbiIdentifiersForMcsClaimWithMbiRecord() throws IOException {
+    String requestString = claimResponseEndpoint + "m-654321";
+
+    Mbi testingMbi = rdaTestUtils.lookupTestMbiRecord(rdaTestUtils.getEntityManager());
+    ServerTestUtils.assertMdcEntries(
+        requestAuth,
+        requestString,
+        Map.of(
+            BfdMDC.MBI_HASH,
+            Optional.of(testingMbi.getHash()),
+            BfdMDC.MBI_ID,
+            Optional.of(testingMbi.getMbiId().toString()),
+            // This isn't a default key, but we need to include it without checking its value to
+            // satisfy the assertion for extra, unexpected MDC keys
+            BfdMDC.HTTP_ACCESS_RESPONSE_HEADER_CONTENT_LOCATION,
+            Optional.empty()));
+  }
+
+  /**
    * Tests to see if the correct response is given when a search is done for {@link ClaimResponse}s
    * using given mbi and service-date range. In this test case the query finds the matched claims
    * because their to dates are within the date range even though their from dates are not.

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/PatientE2E.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/stu3/providers/PatientE2E.java
@@ -705,7 +705,7 @@ public class PatientE2E extends PatientE2EBase {
     additionalExpectedMdcKeys.add(BfdMDC.HTTP_ACCESS_RESPONSE_DURATION_PER_KB);
     additionalExpectedMdcKeys.add(BfdMDC.HTTP_ACCESS_REQUEST_HEADER_IDENTIFIERS);
 
-    ServerTestUtils.assertAccessJsonHasMdcKeys(
+    ServerTestUtils.assertDefaultAndAdditionalMdcKeys(
         requestAuth, requestString, additionalExpectedMdcKeys, headers);
   }
 

--- a/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/utils/RDATestUtils.java
+++ b/apps/bfd-server/bfd-server-war/src/test/java/gov/cms/bfd/server/war/utils/RDATestUtils.java
@@ -690,7 +690,7 @@ public class RDATestUtils {
    * @param em our {@link EntityManager}
    * @return the {@link Mbi}
    */
-  private Mbi lookupTestMbiRecord(EntityManager em) {
+  public Mbi lookupTestMbiRecord(EntityManager em) {
     final CriteriaBuilder builder = em.getCriteriaBuilder();
     final CriteriaQuery<Mbi> criteria = builder.createQuery(Mbi.class);
     final Root<Mbi> root = criteria.from(Mbi.class);

--- a/ops/terraform/services/server/insights/api-requests/glue.tf
+++ b/ops/terraform/services/server/insights/api-requests/glue.tf
@@ -1373,6 +1373,17 @@ module "glue-table-api-requests" {
       "type"    = "string",
       "comment" = ""
     },
+    {
+      "name"    = "mdc_mbi_id",
+      "type"    = "string",
+      "comment" = ""
+    },
+
+    {
+      "name"    = "mdc_mbi_hash",
+      "type"    = "string",
+      "comment" = ""
+    }
   ]
 }
 


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
BFD-3688

### What Does This PR Do?

<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

This PR introduces additional logging to the `Claim` and `ClaimResponse` endpoints that logs the `mbi_id` and `mbi_hash` of the MBI associated with the FISS or MCS claim to the MDC. Since the MDC log informs BFD Insights, these fields are now available to query within Athena as `mdc_mbi_hash` and `mdc_mbi_id`. Correspondingly, the Glue Table and Parquet schemas have been updated to include these new columns.

Additionally, E2E tests were added verifying that these identifiers are logged to the `access.json` MDC log for any valid request against `Claim` or `ClaimResponse`.

**Note that the Glue Crawlers in `prod-sbx` and `prod` must be run after this is merged before `mdc_mbi_hash` and `mdc_mbi_id` can be queried upon. I will do this upon merge, out-of-band.**

### What Should Reviewers Watch For?

<!--
Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:

<!-- Add some items here -->

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:

- ~~Adds any new software dependencies~~
- ~~Modifies any security controls~~
- ~~Adds new transmission or storage of data~~
- ~~Any other changes that could possibly affect security?~~

- [x] I have considered the above security implications as it relates to this PR. (If one or more of the above apply, it cannot be merged without the ISSO or team security engineer's (`@sb-benohe`) approval.)

### Validation

Have you fully verified and tested these changes? Is the acceptance criteria met? Please provide reproducible testing instructions, code snippets, or screenshots as applicable.

- Running all automated tests **including the new E2E tests**, _verifying that_ they pass
- Deploying all changes to `test` and running the Regression Suite against the Server in `test`, _verifying that_:
  - `mbi_id` and `mbi_hash` appear in valid `Claim` and `ClaimResponse` access.json logs 
  - `mbi_id` and `mbi_hash` are queryable in BFD Insights data using Athena