### PR TITLE
BFD-3737: Add missing launch-template-data.sh

### DIFF
--- a/ops/terraform/services/server/modules/bfd_server_asg/scripts/launch-template-data.sh
+++ b/ops/terraform/services/server/modules/bfd_server_asg/scripts/launch-template-data.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+#######################################
+# Fetch the remote launch template version
+# Returned json object includes a "latest_version" as
+# - a string when the launch template exists
+# - "null" when the launch template does not yet exist
+# Arguments:
+#   $1 maps to desired environment, used in templated "bfd-${1}-fhir", e.g. "bfd-2558-test-fhir"
+#######################################
+set -eu
+BFD_ENV="$1"
+
+aws ec2 describe-launch-templates --launch-template-names "bfd-${BFD_ENV}-fhir" 2>/dev/null | yq --output-format=json '. | {"latest_version": .LaunchTemplates[0].LatestVersionNumber | tostring // null}'


### PR DESCRIPTION
**JIRA Ticket:**
BFD-3737

### What Does This PR Do?
This adds a missing helper script that was erroneously absent in the BFD-2558.

### What Should Reviewers Watch For?
<!--
Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
n/a

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:  

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security? 

* [x] I have considered the above security implications as it relates to this PR. (If one or more of the above apply, it cannot be merged without the ISSO or team security engineer's (`@sb-benohe`) approval.) 


### Validation

Have you fully verified and tested these changes? Is the acceptance criteria met? Please provide reproducible testing instructions, code snippets, or screenshots as applicable.

This was used to run successful out-of-band on deployments to `test`, `prod-sbx`, and `prod`.