### PR TITLE
BFD-3740: Update awscli to v2 in CBC Container

### DIFF
--- a/ops/jenkins/bfd-cbc-build/Dockerfile
+++ b/ops/jenkins/bfd-cbc-build/Dockerfile
@@ -10,11 +10,17 @@ RUN yum update -y --security && \
     yum -y groupinstall "Development Tools" && \
     yum install -y \
     ansible \
-    awscli \
     gcc \
     git \
     jq \
+    unzip \
     openssl-devel
+
+# Install awscliv2
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf awscliv2.zip ./aws
 
 FROM base as prereqs
 


### PR DESCRIPTION
**JIRA Ticket:**
BFD-3740


### What Does This PR Do?
Updates awscli to version 2 to match what engineers are using in their local development environments.

### What Should Reviewers Watch For?
<!--
Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items here -->

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:  

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security? 

* [x] I have considered the above security implications as it relates to this PR. (If one or more of the above apply, it cannot be merged without the ISSO or team security engineer's (`@sb-benohe`) approval.) 


### Validation

Have you fully verified and tested these changes? Is the acceptance criteria met? Please provide reproducible testing instructions, code snippets, or screenshots as applicable.

- builds locally without issue
- remote build was successful, resulting cbc build image used as part of the 2.164.0 deployment today, 2024-11-06
    
