### PR TITLE
BFD-3788: Fix ephemeral bfd-server-slo-alarm apply

### DIFF
--- a/ops/terraform/services/server/modules/bfd_server_slo_alarms/data-sources.tf
+++ b/ops/terraform/services/server/modules/bfd_server_slo_alarms/data-sources.tf
@@ -2,17 +2,17 @@ data "aws_region" "current" {}
 
 data "aws_sns_topic" "high_alert_sns" {
   count = local.env_sns.high_alert != null ? 1 : 0
-  name  = local.env_sns.high_alert
+  name  = (local.env_sns.high_alert != null ? local.env_sns.high_alert : "EMPTY")
 }
 
 data "aws_sns_topic" "alert_sns" {
   count = local.env_sns.alert != null ? 1 : 0
-  name  = local.env_sns.alert
+  name  = (local.env_sns.alert != null ? local.env_sns.alert : "EMPTY")
 }
 
 data "aws_sns_topic" "warning_sns" {
   count = local.env_sns.warning != null ? 1 : 0
-  name  = local.env_sns.warning
+  name  = (local.env_sns.warning != null ? local.env_sns.warning : "EMPTY")
 }
 
 data "external" "client_ssls_by_partner" {

--- a/ops/terraform/services/server/modules/bfd_server_slo_alarms/data-sources.tf
+++ b/ops/terraform/services/server/modules/bfd_server_slo_alarms/data-sources.tf
@@ -1,18 +1,18 @@
 data "aws_region" "current" {}
 
 data "aws_sns_topic" "high_alert_sns" {
-  count = local.env_sns.high_alert != null ? 1 : 0
-  name  = (local.env_sns.high_alert != null ? local.env_sns.high_alert : "EMPTY")
+  count = local.env_sns.high_alert != "null" ? 1 : 0
+  name  = local.env_sns.high_alert
 }
 
 data "aws_sns_topic" "alert_sns" {
-  count = local.env_sns.alert != null ? 1 : 0
-  name  = (local.env_sns.alert != null ? local.env_sns.alert : "EMPTY")
+  count = local.env_sns.alert != "null" ? 1 : 0
+  name  = local.env_sns.alert
 }
 
 data "aws_sns_topic" "warning_sns" {
-  count = local.env_sns.warning != null ? 1 : 0
-  name  = (local.env_sns.warning != null ? local.env_sns.warning : "EMPTY")
+  count = local.env_sns.warning != "null" ? 1 : 0
+  name  = local.env_sns.warning
 }
 
 data "external" "client_ssls_by_partner" {

--- a/ops/terraform/services/server/modules/bfd_server_slo_alarms/main.tf
+++ b/ops/terraform/services/server/modules/bfd_server_slo_alarms/main.tf
@@ -32,10 +32,11 @@ locals {
   }
   # In the event this module is being applied in a non-established environment (i.e. an ephemeral
   # environment) this lookup will ensure that an empty configuration will be returned
+  # by allowing successful evaluation of this module from the parent
   env_sns = lookup(local.topic_names_by_env, local.env, {
-    high_alert = null
-    alert      = null
-    warning    = null
+    high_alert = "null"
+    alert      = "null"
+    warning    = "null"
   })
   # Use Terraform's "splat" operator to automatically return either an empty list, if no
   # SNS topic was retrieved (data.aws_sns_topic.sns.length == 0) or a list with 1 element that


### PR DESCRIPTION
**JIRA Ticket:**
BFD-3788

### What Does This PR Do?
Enable evaluation for module "bfd_server_slo_alarms" despite zero count for ephemerals

### What Should Reviewers Watch For?

Are any unintended consequences introduced?

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:  

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security? 

* [x] I have considered the above security implications as it relates to this PR. (If one or more of the above apply, it cannot be merged without the ISSO or team security engineer's (`@sb-benohe`) approval.) 

### Validation

Employing these changes locally for BFD-3766 allowed bad-server deployment to succeed.
    
