### PR TITLE
BFD-3685: Separate CCW and RDA Pipeline Log Groups

### DIFF
--- a/ops/ansible/playbooks-ccs/templates/cwagent-data-pipeline.json.j2
+++ b/ops/ansible/playbooks-ccs/templates/cwagent-data-pipeline.json.j2
@@ -24,7 +24,7 @@
           {
             "file_path": "{{ ref_dir }}/bluebutton-data-pipeline.log",
             "log_group_name": "/bfd/{{ env_name_std }}/bfd-pipeline/messages.txt",
-            "log_stream_name": "{instance_id}",
+            "log_stream_name": "{instance_id}-{{ pipeline_instance_type }}-messages.txt",
             "timestamp_format": "%Y-%m-%d %H:%M:%S,%f",
             "multi_line_start_pattern": "^[\\d\\d\\d\\d-\\d\\d-\\d\\d ]"
           }

--- a/ops/ansible/playbooks-ccs/templates/cwagent-data-pipeline.json.j2
+++ b/ops/ansible/playbooks-ccs/templates/cwagent-data-pipeline.json.j2
@@ -23,8 +23,8 @@
           },
           {
             "file_path": "{{ ref_dir }}/bluebutton-data-pipeline.log",
-            "log_group_name": "/bfd/{{ env_name_std }}/bfd-pipeline/messages.txt",
-            "log_stream_name": "{instance_id}-{{ pipeline_instance_type }}-messages.txt",
+            "log_group_name": "/bfd/{{ env_name_std }}/bfd-pipeline-{{ pipeline_instance_type }}/messages.txt",
+            "log_stream_name": "{instance_id}",
             "timestamp_format": "%Y-%m-%d %H:%M:%S,%f",
             "multi_line_start_pattern": "^[\\d\\d\\d\\d-\\d\\d-\\d\\d ]"
           }

--- a/ops/terraform/services/pipeline/main.tf
+++ b/ops/terraform/services/pipeline/main.tf
@@ -81,7 +81,8 @@ locals {
   }
 
   log_groups = {
-    messages = "/bfd/${local.env}/bfd-pipeline/messages.txt"
+    rda_messages = "/bfd/${local.env}/bfd-pipeline-rda/messages.txt"
+    ccw_messages = "/bfd/${local.env}/bfd-pipeline-ccw/messages.txt"
   }
 
   alarm_actions = local.is_prod ? [data.aws_sns_topic.alarm[0].arn] : []


### PR DESCRIPTION
**JIRA Ticket:**
BFD-3685

### What Does This PR Do?

This PR separates the CloudWatch log groups for the CCW and RDA pipelines. The relevant alarms and other affected resources have been updated accordingly. The changes have been applied to an ephemeral environment, and it has been tested to confirm that the logs are now separated as intended

### What Should Reviewers Watch For?
<!--
Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items here -->

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:  

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security? 

* [x] I have considered the above security implications as it relates to this PR. (If one or more of the above apply, it cannot be merged without the ISSO or team security engineer's (`@sb-benohe`) approval.) 

### Validation

**Have you fully verified and tested these changes? Is the acceptance criteria met? Please provide reproducible testing instructions, code snippets, or screenshots as applicable.**

 The changes have been applied to an ephemeral environment and tested.
    
