### PR TITLE
BFD-3922: bfd-parent jib definition uses standardized base container images

### DIFF
--- a/apps/pom.xml
+++ b/apps/pom.xml
@@ -205,8 +205,12 @@
         <!-- The jib maven plugin produces optimized docker images from maven projects. -->
         <!-- https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin#quickstart -->
         <jib.version>3.4.4</jib.version>
-        <!-- The base image (FROM) used to build images with jib. -->
-        <jib.from>amazoncorretto:21.0.1-alpine</jib.from>
+        <!-- The base image (FROM) used to build images with jib. Defaults to pulling from the
+        Docker daemon; override with -Djib.from=<image> -->
+        <!-- May not work properly with Podman due to
+        https://github.com/GoogleContainerTools/jib/issues/4134; use suggested override above in
+        that case -->
+        <jib.from>docker://bfd-mgmt-base-jdk:${project.version}</jib.from>
         <!--
           The goal to use with the jib plugin.   Override on command line to change behavior:
           dockerBuild: build on local docker only
@@ -1349,6 +1353,8 @@
                 <jib.skip>false</jib.skip>
                 <jib.goal>build</jib.goal>
                 <jib.namespace>${env.ECR_REPOSITORY_NAMESPACE}/</jib.namespace>
+                <!-- Ensure that the base image is pulled from ECR on release -->
+                <jib.from>${jib.namespace}bfd-mgmt-base-jdk:${project.version}</jib.from>
                 <maven.build.cache.enabled>false</maven.build.cache.enabled>
                 <!-- Source jars are large and we don't need to publish them. -->
                 <maven.source.skip>true</maven.source.skip>


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
BFD-3922

### What Does This PR Do?
<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

This PR updates the base Image definition (`jib.from`) for Jib-built BFD application Images to base them off the new `bfd-mgmt-base-jdk` Image introduced in BFD-3919. This PR also changes the default `jib.from` to build from _local_ `bfd-mgmt-base-jdk` Images as developers will typically be building local images based upon `-SNAPSHOT` versions.

NOTES:

- There is [a known compatibility issue between Jib and Podman](https://github.com/GoogleContainerTools/jib/issues/4134) that currently causes local `dockerBuild`s to fail when the `jib.from` is pulling from the Podman daemon.
- It seems that Maven does not expand environment variables during the `dockerBuild` goal (i.e. specifying a `jib.from` in the `pom.xml` like `${env.ECR_REPO}/...` does not work), so at this time I suspect we will need to workaround these issues by manually specifying `jib.from` when running `mvn` locally, e.g.:

  ```bash
  mvn compile com.google.cloud.tools:jib-maven-plugin:3.4.4:dockerBuild -pl :bfd-server-image -Djib.skip=false -Djib.from="$(aws ecr describe-repositories | jq -r '.repositories[] | select(.repositoryName == "bfd-mgmt-base-jdk") | .repositoryUri'):2.182.0"
  ```

### What Should Reviewers Watch For?
<!--
Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items here -->

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:  

- ~~Adds any new software dependencies~~
- ~~Modifies any security controls~~
- ~~Adds new transmission or storage of data~~
- ~~Any other changes that could possibly affect security?~~

- [x] I have considered the above security implications as it relates to this PR. (If one or more of the above apply, it cannot be merged without the ISSO or team security engineer's (`@sb-benohe`) approval.)
- [x] I have created tests to sufficiently ensure the reliability of my code, if applicable. If this is a modification to an existing piece of code, I have audited the associated tests to ensure everything works as expected.

### Validation

**Have you fully verified and tested these changes? Is the acceptance criteria met? Please provide reproducible testing instructions, code snippets, or screenshots as applicable.**

- Running a `Build Release` based on this PR's branch, _verifying that_ (see [run 201](https://github.com/CMSgov/beneficiary-fhir-data/actions/runs/13725873780)):
  - The Workflow run succeeds
  - The [Workflow log](https://productionresultssa8.blob.core.windows.net/actions-results/29ecf873-7472-45c4-ac4f-542f8a803b39/workflow-job-run-4d5f6d1f-6982-5d55-d3d6-ee0d9e93c09e/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-03-07T18%3A01%3A17Z&sig=0YOhZcJJ%2Fh8zxd85DR8Lzrddf%2F4XM5bmrYXIq3QB7gI%3D&ske=2025-03-08T03%3A38%3A45Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-03-07T15%3A38%3A45Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-01-05&sp=r&spr=https&sr=b&st=2025-03-07T17%3A51%3A12Z&sv=2025-01-05) indicates that the `bfd-mgmt-base-jdk` image was used for Jib-generated Images:

    ```text
    2025-03-07T17:25:58.0474519Z [INFO] [WARNING] Base image '***/bfd-mgmt-base-jdk:2.183.0-3922-testing-1' does not use a specific image digest - build may not be reproducible
    ```

  - Inspecting the `bfd-db-migrator` Image with `dive` indicates that it was based off of the `bfd-mgmt-base-jdk` image
