### PR TITLE
BFD-4012: Do not send slack messages when file transfer is successful

### DIFF
--- a/ops/terraform/services/eft/modules/bfd_eft_outbound_o11y/lambda_src/outbound_slack_notifier/outbound_slack_notifier.py
+++ b/ops/terraform/services/eft/modules/bfd_eft_outbound_o11y/lambda_src/outbound_slack_notifier/outbound_slack_notifier.py
@@ -108,7 +108,9 @@ def handler(event: dict[Any, Any], context: LambdaContext):  # pylint: disable=u
 
             logger.append_keys(notification_type=status_notification.type.value)
          
-            if (status_notification.type == NotificationType.TRANSFER_SUCCESS):
+            if (status_notification.type in [
+                        NotificationType.TRANSFER_SUCCESS,
+                        NotificationType.FILE_DISCOVERED ]):
                continue 
 
             _slack_status_notif(status_notification=status_notification)

--- a/ops/terraform/services/eft/modules/bfd_eft_outbound_o11y/lambda_src/outbound_slack_notifier/outbound_slack_notifier.py
+++ b/ops/terraform/services/eft/modules/bfd_eft_outbound_o11y/lambda_src/outbound_slack_notifier/outbound_slack_notifier.py
@@ -107,11 +107,12 @@ def handler(event: dict[Any, Any], context: LambdaContext):  # pylint: disable=u
             status_notification = StatusNotification(**raw_notification)
 
             logger.append_keys(notification_type=status_notification.type.value)
-         
-            if (status_notification.type in [
-                        NotificationType.TRANSFER_SUCCESS,
-                        NotificationType.FILE_DISCOVERED ]):
-               continue 
+
+            if status_notification.type in [
+                NotificationType.TRANSFER_SUCCESS,
+                NotificationType.FILE_DISCOVERED,
+            ]:
+                continue
 
             _slack_status_notif(status_notification=status_notification)
     except Exception:

--- a/ops/terraform/services/eft/modules/bfd_eft_outbound_o11y/lambda_src/outbound_slack_notifier/outbound_slack_notifier.py
+++ b/ops/terraform/services/eft/modules/bfd_eft_outbound_o11y/lambda_src/outbound_slack_notifier/outbound_slack_notifier.py
@@ -107,6 +107,9 @@ def handler(event: dict[Any, Any], context: LambdaContext):  # pylint: disable=u
             status_notification = StatusNotification(**raw_notification)
 
             logger.append_keys(notification_type=status_notification.type.value)
+         
+            if (status_notification.type == NotificationType.TRANSFER_SUCCESS):
+               continue 
 
             _slack_status_notif(status_notification=status_notification)
     except Exception:


### PR DESCRIPTION
**JIRA Ticket:**
BFD-4012

### What Does This PR Do?
Skip sending file transfer successful messages by BFD EFT Outbound Lambda, to slack.


### What Should Reviewers Watch For?
No file transfer successful messages by BFD EFT Outbound Lambda on the slack channel bfd-internal-alerts.

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:  
* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security? 
None

* [x] I have considered the above security implications as it relates to this PR. (If one or more of the above apply, it cannot be merged without the ISSO or team security engineer's (`@sb-benohe`) approval.) 
* [x] I have created tests to sufficiently ensure the reliability of my code, if applicable. If this is a modification to an existing piece of code, I have audited the associated tests to ensure everything works as expected.

### Validation
Publish a message of type TRANSFER_SUCCESS in the Outbound Notifications SNS topic.  This should not send slack TRANSFER_SUCCESS notification to slack channel bfd-internal-alerts.

    
