### PR TITLE
BFD-4023: Fix metric_name on the CloudWatch Metric Alarm, samhsa-mismatch-error

### DIFF
--- a/ops/terraform/services/server/modules/bfd_server_log_alarms/main.tf
+++ b/ops/terraform/services/server/modules/bfd_server_log_alarms/main.tf
@@ -113,8 +113,9 @@ resource "aws_cloudwatch_metric_alarm" "server-query-logging-listener-warning" {
 resource "aws_cloudwatch_metric_alarm" "samhsa-mismatch-error" {
   alarm_name          = "bfd-${local.env}-samhsa-mismatch-error"
   namespace           = "bfd-${local.env}/bfd-server"
-  metric_name         = "bfd-${local.env}/bfd-server/samhsa-mismatch/count/error"
+  metric_name         = "samhsa-mismatch/count/error"
   comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold = 1
   evaluation_periods  = 1
   period              = 60
   statistic           = "Sum"

--- a/ops/terraform/services/server/modules/bfd_server_log_alarms/main.tf
+++ b/ops/terraform/services/server/modules/bfd_server_log_alarms/main.tf
@@ -115,7 +115,7 @@ resource "aws_cloudwatch_metric_alarm" "samhsa-mismatch-error" {
   namespace           = "bfd-${local.env}/bfd-server"
   metric_name         = "samhsa-mismatch/count/error"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  threshold = 1
+  threshold           = 1
   evaluation_periods  = 1
   period              = 60
   statistic           = "Sum"

--- a/ops/terraform/services/server/modules/bfd_server_log_alarms/main.tf
+++ b/ops/terraform/services/server/modules/bfd_server_log_alarms/main.tf
@@ -126,10 +126,6 @@ resource "aws_cloudwatch_metric_alarm" "samhsa-mismatch-error" {
       "in APP-ENV: bfd-${local.env}"
   ])
 
-  dimensions = {
-    LogGroupName = "/bfd/${local.env}/bfd-server/messages.json"
-  }
-
   alarm_actions = local.notify_arn
 
   ok_actions = []


### PR DESCRIPTION
**JIRA Ticket:**
BFD-4023


### What Does This PR Do?
Addresses a bug where the metric_name for CloudWatch Metric Alarm samhsa-mismatch-error was incorrect

### What Should Reviewers Watch For?
Correct metric_name is set properly to "samhsa-mismatch/count/error"


### What Security Implications Does This PR Have?
None
Please indicate if this PR does any of the following:  

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security? 

* [x] I have considered the above security implications as it relates to this PR. (If one or more of the above apply, it cannot be merged without the ISSO or team security engineer's (`@sb-benohe`) approval.) 
* [x] I have created tests to sufficiently ensure the reliability of my code, if applicable. If this is a modification to an existing piece of code, I have audited the associated tests to ensure everything works as expected.

### Validation
Test alarm is triggered when encountering error message like "Samhsa: Claim ID mismatch between old SAMHSA filter":
1. Insert a log event into CloudWatch test log stream:
aws logs put-log-events --log-group-name "/bfd/test/bfd-server/messages.json" --log-stream-name "i-0f00beeed624e1f90" --log-events timestamp=$(date +%s%3N), message="{\"message\": \"Samhsa: Claim ID mismatch between old SAMHSA filter (hasSamhsaData) and new SAMHSA 2.0 (hasSamhsaDataV2)\"}"

2. Verify alarm samhsa-mismatch-error is triggered
    
