### PR TITLE
BFD-4024: Change log metric filter pattern

### DIFF
--- a/ops/terraform/services/server/modules/bfd_server_metrics/main.tf
+++ b/ops/terraform/services/server/modules/bfd_server_metrics/main.tf
@@ -434,7 +434,7 @@ resource "aws_cloudwatch_log_metric_filter" "query_logging_listener_count_warnin
 resource "aws_cloudwatch_log_metric_filter" "samhsa_mismatch_error_count" {
   name           = "bfd-${local.env}/bfd-server/samhsa-mismatch/count/error"
   log_group_name = local.log_groups.messages
-  pattern        = "{$.message = \"Samhsa: Claim ID mismatch between old SAMHSA filter (hasSamhsaData) and new SAMHSA 2.0 (hasSamhsaDataV2)\"}"
+  pattern        = "{ $.message = %Samhsa: Claim ID mismatch between old SAMHSA filter% }"
 
   metric_transformation {
     name      = "samhsa-mismatch/count/error"


### PR DESCRIPTION
**JIRA Ticket:**
BFD-4024


### What Does This PR Do?
Addresses an incorrect message filter pattern on bfd samhsa-mismatch CloudWatch Log filter.

### What Should Reviewers Watch For?
log message filter %Samhsa: Claim ID mismatch between old SAMHSA filter% is set

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:  
None

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security? 

* [x] I have considered the above security implications as it relates to this PR. (If one or more of the above apply, it cannot be merged without the ISSO or team security engineer's (`@sb-benohe`) approval.) 
* [x] I have created tests to sufficiently ensure the reliability of my code, if applicable. If this is a modification to an existing piece of code, I have audited the associated tests to ensure everything works as expected.

### Validation
Execute in Test the following command and verified alarm samhsa-mismatch-error is triggered:
aws logs put-log-events --log-group-name "/bfd/test/bfd-server/messages.json"  --log-events timestamp=$(date +%s%3N), message="{\"message\": \"Samhsa: Claim ID mismatch between old SAMHSA filter (hasSamhsaData) and new SAMHSA 2.0 (hasSamhsaDataV2) - Claim ID: 12345678 (Class: CarrierClaim) - Missing in: hasSamhsaData"}"

**Have you fully verified and tested these changes? Is the acceptance criteria met? Please provide reproducible testing instructions, code snippets, or screenshots as applicable.**
    
