### PR TITLE
BFD-3530: Route lambda errors to appropriate channels; allow disabling notifications for specified failed lambdas

### DIFF
--- a/ops/terraform/env/mgmt/data-sources.tf
+++ b/ops/terraform/env/mgmt/data-sources.tf
@@ -17,6 +17,10 @@ data "aws_kms_key" "cmk" {
   key_id = "alias/bfd-mgmt-cmk"
 }
 
+data "aws_kms_key" "test_cmk" {
+  key_id = "alias/bfd-test-cmk"
+}
+
 data "aws_kms_key" "config_cmk" {
   key_id = "alias/bfd-mgmt-config-cmk"
 }
@@ -109,4 +113,35 @@ data "aws_iam_policy_document" "snyk_container_scanning_trust_policy" {
       values   = [local.ssm_config["/bfd/common/snyk/organization_id"]]
     }
   }
+}
+
+data "aws_iam_policy_document" "lambda_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_sns_topic" "victor_ops" {
+  name = "bfd-prod-cloudwatch-alarms"
+}
+
+data "aws_sns_topic" "internal_alert_slack" {
+  #FIXME: replace when slack alert is in mgmt
+  name = "bfd-test-cloudwatch-alarms-slack-bfd-test"
+}
+
+data "aws_sns_topic" "bfd_alerts_slack" {
+  name = "bfd-test-cloudwatch-alarms-slack-bfd-alerts"
+}
+
+data "aws_sns_topic" "bfd_notices_slack" {
+  name = "bfd-test-cloudwatch-alarms-slack-bfd-notices"
+}
+
+data "aws_sns_topic" "bfd_warnings_slack" {
+    name = "bfd-test-cloudwatch-alarms-slack-bfd-warnings"
 }

--- a/ops/terraform/env/mgmt/lambda_failure_notification_router.py
+++ b/ops/terraform/env/mgmt/lambda_failure_notification_router.py
@@ -1,0 +1,151 @@
+import boto3
+from datetime import datetime, timedelta, timezone
+import json
+import os
+import logging
+
+sns_client = boto3.client("sns")
+cw_client = boto3.client("cloudwatch")
+lambda_client = boto3.client("lambda")
+ssm_client = boto3.client("ssm")
+cloudwatch_client = boto3.client("cloudwatch")
+
+DEFAULT_SNS_TOPIC_ARN = os.environ["DEFAULT_SNS_TOPIC_ARN"]
+VICTOR_OPS = os.environ["VICTOR_OPS"]
+BFD_INTERNAL_TOPIC_ARN = os.environ["BFD_INTERNAL"]
+BFD_ALERTS_TOPIC_ARN = os.environ["BFD_ALERTS"]
+BFD_WARNINGS_TOPIC_ARN = os.environ["BFD_WARNINGS"]
+BFD_NOTICES_TOPIC_ARN = os.environ["BFD_NOTICES"]
+
+DO_NOT_NOTIFY_FOR_PARAM = os.environ["DO_NOT_NOTIFY_FOR_PARAM"] 
+SEND_ALERT_TO_PARAM = os.environ["SEND_ALERT_TO_PARAM"] 
+
+TOPIC_TO_ROUTE_TO = {
+    "DEFAULT_SNS_TOPIC": DEFAULT_SNS_TOPIC_ARN,
+    "VICTOR_OPS": VICTOR_OPS,
+    "BFD_INTERNAL": BFD_INTERNAL_TOPIC_ARN,
+    "BFD_ALERTS": BFD_ALERTS_TOPIC_ARN,
+    "BFD_WARNINGS": BFD_WARNINGS_TOPIC_ARN,
+    "BFD_NOTICES": BFD_NOTICES_TOPIC_ARN,
+}
+
+logging.basicConfig(level=logging.INFO, force=True)
+logger = logging.getLogger()
+
+def get_failed_lambdas(lookback_minutes=2):
+    lambda_client = boto3.client("lambda")
+    cloudwatch = boto3.client("cloudwatch")
+
+    # Time window
+    end_time = datetime.now(timezone.utc)
+    start_time = end_time - timedelta(minutes=lookback_minutes)
+
+    # List all Lambda functions
+    function_names = []
+    paginator = lambda_client.get_paginator("list_functions")
+    for page in paginator.paginate():
+        for fn in page["Functions"]:
+            function_names.append(fn["FunctionName"])
+
+    if not function_names:
+        logger.info("No Lambda functions found.")
+        return []
+
+    # Prepare MetricDataQueries
+    queries = []
+    for idx, fn_name in enumerate(function_names):
+        queries.append({
+            "Id": f"errors_{idx}",
+            "MetricStat": {
+                "Metric": {
+                    "Namespace": "AWS/Lambda",
+                    "MetricName": "Errors",
+                    "Dimensions": [{"Name": "FunctionName", "Value": fn_name}],
+                },
+                "Period": 60,
+                "Stat": "Sum",
+            },
+            "Label": fn_name,
+            "ReturnData": True,
+        })
+
+    failed_functions = set()
+
+    for i in range(0, len(queries), 100):
+        batch = queries[i : i + 100]
+        response = cloudwatch.get_metric_data(
+            MetricDataQueries=batch,
+            StartTime=start_time,
+            EndTime=end_time,
+            ScanBy="TimestampDescending",
+        )
+        for result in response["MetricDataResults"]:
+            if any(value > 0 for value in result["Values"]):
+                failed_functions.add(result["Label"])
+
+    return failed_functions
+
+def get_do_not_notify_list():
+    try:
+        response = ssm_client.get_parameter(Name=DO_NOT_NOTIFY_FOR_PARAM)
+        logger.info(f"Do not notify list retrieved successfully: {str(response["Parameter"]["Value"])}")
+        value = response["Parameter"]["Value"]
+        return value.split(",") if value else []
+    except Exception as e:
+        logger.error(f"Error retrieving or parsing SSM parameter {DO_NOT_NOTIFY_FOR_PARAM}: {e}")
+        return []
+
+def get_send_alert_to():
+    try:
+        response = ssm_client.get_parameter(Name=SEND_ALERT_TO_PARAM)
+        logger.info(f"Send alert to list retrieved successfully: {str(response["Parameter"]["Value"])}")
+        value = response["Parameter"]["Value"]
+        return json.loads(value) if value else {}
+    except Exception as e:
+        logger.error(f"Error retrieving or parsing SSM parameter {SEND_ALERT_TO_PARAM}: {e}")
+        return []
+
+def handler(event, context):
+    try:
+        alarm_name = event["detail"]["alarmName"]
+
+        failed_lambda_functions = get_failed_lambdas(lookback_minutes=2)
+        logger.info("Failed Lambdas: " + str(failed_lambda_functions))
+
+        do_not_notify_for = get_do_not_notify_list()
+        send_alert_for = get_send_alert_to()
+
+        failed_lambda_functions_to_notify = failed_lambda_functions.difference(
+            set(do_not_notify_for)
+        )
+
+        logger.info("Failed Lambdas to notify: " + str(failed_lambda_functions_to_notify))
+
+        for lambda_function_name in failed_lambda_functions_to_notify:
+            # Determine SNS topic ARN to use
+            topic_arn = TOPIC_TO_ROUTE_TO.get(
+                send_alert_for.get(lambda_function_name, "DEFAULT_SNS_TOPIC")
+            )
+            logger.info(
+                f"Sending notification to {topic_arn} for function {lambda_function_name}"
+            )
+            message = json.dumps(
+                {
+                    "AlarmDescription": f"A Lambda failure occured for function {lambda_function_name}",
+                    "AlarmName": f"{alarm_name}",
+                    "NewStateReason": f"Lambda function '{lambda_function_name}' triggered alarm '{alarm_name}'.",
+                    "Trigger": {
+                        "MetricName": "Errors",
+                    },
+                }
+            )
+            sns_client.publish(
+                TopicArn=topic_arn,
+                Subject=f"Lambda Failure: {lambda_function_name}",
+                Message=message,
+            )
+            logger.info(f"Notification sent to {topic_arn} for function {lambda_function_name}")
+    except Exception as e:
+        logger.error(f"{context.function_name}-Error failed to send SNS notification: {e}")
+
+    return "Processed successfully"

--- a/ops/terraform/env/mgmt/lambda_failure_notification_router.tf
+++ b/ops/terraform/env/mgmt/lambda_failure_notification_router.tf
@@ -1,0 +1,172 @@
+locals {
+  notification_router_lambda_name = "lambda_failure_notification_router"
+  do_not_notify_for_param_name    = "/bfd/mgmt/common/nonsensitive/alarm/bfd-mgmt-lambda-error/do_not_notify_for"
+  send_alert_to_param             = "/bfd/mgmt/common/nonsensitive/alarm/bfd-mgmt-lambda-error/send_alert_to"
+}
+
+resource "aws_ssm_parameter" "do_not_notify_list_param" {
+  name  = local.do_not_notify_for_param_name
+  type  = "StringList"
+  value = local.notification_router_lambda_name
+
+  lifecycle {
+    ignore_changes = ["value"]
+  }
+}
+
+resource "aws_ssm_parameter" "send_alert_to_param" {
+  name  = local.send_alert_to_param
+  type  = "String"
+  value = "{}"
+
+  lifecycle {
+    ignore_changes = ["value"]
+  }
+}
+
+data "archive_file" "zip_notification_router_lambda" {
+  type        = "zip"
+  source_file = "./${local.notification_router_lambda_name}.py"
+  output_path = "./${local.notification_router_lambda_name}.zip"
+}
+
+resource "aws_iam_role" "notification_router_lambda_role" {
+  name               = "${local.notification_router_lambda_name}-role"
+  description        = "Role for the ${local.notification_router_lambda_name} Lambda"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+}
+
+resource "aws_iam_policy" "notification_router_lambda" {
+  name = "${local.notification_router_lambda_name}-policy"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Sid    = "AllowPublishingToSNS",
+      Effect = "Allow",
+      Action = ["sns:Publish"],
+      Resource = [data.aws_sns_topic.internal_alert_slack.arn,
+        data.aws_sns_topic.bfd_alerts_slack.arn,
+        data.aws_sns_topic.bfd_notices_slack.arn,
+        data.aws_sns_topic.bfd_warnings_slack.arn,
+      data.aws_sns_topic.victor_ops.arn]
+      },
+      {
+        Sid      = "AllowListingOfLambdaFunctions",
+        Effect   = "Allow",
+        Action   = ["lambda:ListFunctions"],
+        Resource = "*"
+
+      },
+      {
+        Sid      = "AllowToReadSSMParameters",
+        Effect   = "Allow",
+        Action   = ["ssm:GetParameter"],
+        Resource = "arn:aws:ssm:${local.region}:${local.account_id}:parameter/*"
+      },
+      {
+        Sid    = "AllowToPublishToEncryptedSNS",
+        Effect = "Allow",
+        Action = ["kms:GenerateDataKey",
+        "kms:Decrypt"],
+        Resource = data.aws_kms_key.test_cmk.arn
+      },
+      {
+        Sid    = "AllowListingTagsOnCloudWatchAlarms",
+        Effect = "Allow",
+        Action = ["cloudwatch:ListTagsForResource",
+        "cloudwatch:GetMetricData"],
+        Resource = "*"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "notification_router_lambda_basic_permission" {
+  role       = aws_iam_role.notification_router_lambda_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_policy_attachment" "nofitication_router_lambda_custom_permission" {
+  name       = "${local.notification_router_lambda_name}_custom_permission"
+  policy_arn = aws_iam_policy.notification_router_lambda.arn
+  roles      = [aws_iam_role.notification_router_lambda_role.name]
+}
+
+resource "aws_lambda_function" "notification_router" {
+  function_name    = local.notification_router_lambda_name
+  runtime          = "python3.12"
+  filename         = data.archive_file.zip_notification_router_lambda.output_path
+  source_code_hash = data.archive_file.zip_notification_router_lambda.output_base64sha256
+  role             = aws_iam_role.notification_router_lambda_role.arn
+  handler          = "${local.notification_router_lambda_name}.handler"
+
+  timeout = 30
+
+  environment {
+    variables = {
+      DEFAULT_SNS_TOPIC_ARN   = "${data.aws_sns_topic.internal_alert_slack.arn}"
+      BFD_INTERNAL            = "${data.aws_sns_topic.internal_alert_slack.arn}"
+      BFD_ALERTS              = "${data.aws_sns_topic.bfd_alerts_slack.arn}"
+      BFD_NOTICES             = "${data.aws_sns_topic.bfd_notices_slack.arn}"
+      BFD_WARNINGS            = "${data.aws_sns_topic.bfd_warnings_slack.arn}"
+      VICTOR_OPS              = "${data.aws_sns_topic.victor_ops.arn}"
+      DO_NOT_NOTIFY_FOR_PARAM = "${aws_ssm_parameter.do_not_notify_list_param.name}"
+      SEND_ALERT_TO_PARAM     = "${aws_ssm_parameter.send_alert_to_param.name}"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "notification_router" {
+  name           = "${local.notification_router_lambda_name}-metric-filter"
+  log_group_name = "/aws/lambda/${aws_lambda_function.notification_router.function_name}"
+  pattern        = "\"${aws_lambda_function.notification_router.function_name}-Error\""
+
+  metric_transformation {
+    namespace = "LambdaNotificationRouterMetricFilter"
+    name      = "Error"
+    value     = 1
+  }
+
+  depends_on = [aws_lambda_function.notification_router]
+}
+
+resource "aws_cloudwatch_metric_alarm" "notification_router" {
+  alarm_name          = local.notification_router_lambda_name
+  namespace           = "LambdaNotificationRouterMetricFilter"
+  comparison_operator = "GreaterThanThreshold"
+  statistic           = "Sum"
+  metric_name         = "Error"
+  threshold           = 0
+  period              = 60
+  evaluation_periods  = 1
+
+  alarm_actions = [data.aws_sns_topic.internal_alert_slack.arn]
+}
+
+resource "aws_cloudwatch_event_rule" "alarm_state_change" {
+  name = "lambda-failure-alarm-events"
+  event_pattern = jsonencode({
+    "source" : ["aws.cloudwatch"],
+    "detail-type" : ["CloudWatch Alarm State Change"],
+    "detail" : {
+      "alarmName" : [aws_cloudwatch_metric_alarm.lambda_errors.alarm_name],
+      "state" : {
+        "value" : ["ALARM"]
+      },
+    }
+  })
+}
+
+resource "aws_cloudwatch_event_target" "route_alarm_to_lambda" {
+  rule      = aws_cloudwatch_event_rule.alarm_state_change.name
+  target_id = "lambda-failure-notification-router"
+  arn       = aws_lambda_function.notification_router.arn
+}
+
+resource "aws_lambda_permission" "notification_router" {
+  function_name = aws_lambda_function.notification_router.function_name
+  statement_id  = "AllowCloudWatchFunctionInvocation"
+  action        = "lambda:InvokeFunction"
+  principal     = "events.amazonaws.com"
+  #source_arn    = "arn:aws:events:us-east-1:577373831711:rule/lambda-failure-alarm-events"
+  source_arn = aws_cloudwatch_event_rule.alarm_state_change.arn
+}

--- a/ops/terraform/env/mgmt/terraform.tf
+++ b/ops/terraform/env/mgmt/terraform.tf
@@ -41,5 +41,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.53.0"
     }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.4.0"
+    }
   }
 }


### PR DESCRIPTION
**JIRA Ticket:**
BFD-3530

### What Does This PR Do?
Modify current Lambda failure notification process so that when any of the BFD lambda errors/fails, route the error notification(s) to the slack/splunk channel configured for the lambda function; otherwise it sends the notification to a default slack channel.  The possible slack/splunk channels are: BFD_INTERNAL, BFD_ALERTS, BFD_WARNINGS, BFD_NOTICES, VICTOR_OPS.  Ops has also the ability of disabling notifications for a set of lambda functions.  The alert message includes the specific lambda function that fails; instead of the generic message we are currently receiving.


### What Should Reviewers Watch For?

* Is this likely to address the goals expressed in the user story? Yes
* Are any additional documentation updates needed? Runbook will be updated
* Are there any unhandled and/or untested edge cases you can think of? No
* Is user input properly sanitized & handled? N/A
* Does this make any backwards-incompatible changes that might break end user clients? No
* Can you find any bugs if you run the code locally and test it manually? No

### What Security Implications Does This PR Have?
None

Please indicate if this PR does any of the following:  

* Adds any new software dependencies - No
* Modifies any security controls - No
* Adds new transmission or storage of data - No
* Any other changes that could possibly affect security?  - No

* [ x] I have considered the above security implications as it relates to this PR. (If one or more of the above apply, it cannot be merged without the ISSO or team security engineer's (`@sb-benohe`) approval.) 
* [x ] I have created tests to sufficiently ensure the reliability of my code, if applicable. If this is a modification to an existing piece of code, I have audited the associated tests to ensure everything works as expected.

### Validation

**Have you fully verified and tested these changes? Is the acceptance criteria met? Please provide reproducible testing instructions, code snippets, or screenshots as applicable.**
 
1. Before starting validation, disable actions for bfd-mgmt-lambda-error
2. Execute:
`aws lambda invoke --function-name bfd3530-failurelambda --payload '{"Test": "Test1"}' --cli-binary-format raw-in-base64-out output.json`
- Verify you received a failure notification message for lambda function bfd3530-failurelambda, in the bfd-internal-alerts slack channel
3. Add Lambda function bfd3530-failurelambda to the list parameter "do_not_notify_for" (`/bfd/mgmt/common/nonsensitive/alarm/bfd-mgmt-lambda-error/do_not_notify_for`), execute:
`aws lambda invoke --function-name bfd3530-failurelambda --payload '{"Test": "Test1"}' --cli-binary-format raw-in-base64-out output.json`
- Verify no message is received in any of the bfd slack channels
4. Add to `/bfd/mgmt/common/nonsensitive/alarm/bfd-mgmt-lambda-error/send_alert_to`, values:
    `{ "bfd3530-failurelambda: "BFD_NOTICES" }`
  - Execute:
       `aws lambda invoke --function-name bfd3530-failurelambda --payload '{"Test": "Test1"}' --cli-binary-format raw-in-base64-out output.json`
   - Verify you received a notification in the BFD_NOTICES channel
5. Re-enable actions for bfd-mgmt-lamba-error cloudwatch alarm



