### PR TITLE
BFD-4115: Deploy all Greenfield Terraform to Legacy in all environments

### DIFF
--- a/ops/platform/01-config/main.tf
+++ b/ops/platform/01-config/main.tf
@@ -33,7 +33,7 @@ locals {
   root_yaml_file       = "${path.module}/values/platform.root.sopsw.yaml"
   valid_root_sops_yaml = data.external.root_sops_yaml.result.valid_sops
 
-  account_yaml_file       = var.greenfield ? "${path.module}/values/platform.${local.account_type}.sopsw.yaml" : local.root_yaml_file
+  account_yaml_file       = var.greenfield ? "${path.module}/values/platform.${local.account_type}.sopsw.yaml" : "${path.module}/values/platform.legacy.sopsw.yaml"
   valid_account_sops_yaml = data.external.account_sops_yaml.result.valid_sops
 
   decrypted_root_data    = yamldecode(data.sops_external.root.raw)

--- a/ops/platform/01-config/values/.gitignore
+++ b/ops/platform/01-config/values/.gitignore
@@ -4,3 +4,4 @@
 !platform.root.sopsw.yaml
 !platform.prod.sopsw.yaml
 !platform.non-prod.sopsw.yaml
+!platform.legacy.sopsw.yaml

--- a/ops/platform/01-config/values/platform.legacy.sopsw.yaml
+++ b/ops/platform/01-config/values/platform.legacy.sopsw.yaml
@@ -1,0 +1,22 @@
+/bfd/platform/network/nonsensitive/route53/zones_list_json: |-
+  [
+    "root"
+  ]
+/bfd/platform/network/sensitive/route53/zone/root/domain: ENC[AES256_GCM,data:NqF4jL/a219kP1zQEQnBHx/f,iv:V5uqNePEZ41XgRhYFz0yb/PmxHfQYoqvHY91vwFLTbw=,tag:fbFBHvB94Zaqm6ZeZ9UgBw==,type:str]
+/bfd/platform/network/sensitive/route53/zone/root/comment: ENC[AES256_GCM,data:FSuN0VvQjEPb9UAdveNqGp4GvKGanCN3cbDnzON7zazGtLT017+AjIPJcCvxJRqQ513vGGEqXqoPeYPsbESxl9KBQeo3FhOM7ir/63ph,iv:hYd3Ss6L4Cpct/9O2QKsEdVTmlm1WPp7aQdQbBD3OVA=,tag:uGuO3r0F8CgygmIEBLPVlw==,type:str]
+#ENC[AES256_GCM,data:Pn2iduLxKPoJBETNs7AgJ/9z19d9iaOLmANbOhnxguKnFA1EceLU8DSsfGBIAM+SyA9Vby1BeEg=,iv:kcUNqWYe8AcGT+0QOgXZvlRwbw6L4nIJgsjvE4X5av4=,tag:dRjHl9oHB+eHZSbsPL+zag==,type:comment]
+/bfd/platform/network/sensitive/route53/zone/root/internal_vpcs_list_json: ENC[AES256_GCM,data:ad/8C4ogfkGUAgVdUtZcHc8MvTzIDb+3Y+hmsqZC8bazkxeCz18+wnTOVGIvfiui2BSvY9P/+l/+g+d7vxO+tQaE0asezpG7znsWArVzAAAMWxhvLb4NAGNW0ha+qBvOw2pnMgPvUAxVbuII0qU=,iv:ycY/wYkhw0PK2fc92d6Gn4rngmOgM1K3smQ7zPnmwNU=,tag:yKXwCLs71Iped0A6O9iv9g==,type:str]
+#ENC[AES256_GCM,data:hql66QUWH5yjYx7VQppdaowdeGjLcw2n4OlvE066Klycp7FCuiWAH6+IgGceKP0QCJR1Yqe7I0eayPxORTsNFgUUDijZL+EgSg==,iv:qjVtyebpcAfWqLEJpmxs2W7xg1p+qtxsY5pv9HiRHzs=,tag:Sia3gjy3hp7fDdsonNw1pQ==,type:comment]
+/bfd/platform/network/sensitive/route53/zone/root/external_vpcs_list_json: ENC[AES256_GCM,data:d2TFCHLNAtmCItIVA547vMhDd0U=,iv:ghN2f2NfPhKsyI+SN6oirj93vCsXGrwWXWszFS3dPf4=,tag:lrkC+jvAHbnHJ87Dedqpvg==,type:str]
+sops:
+  kms:
+    - arn: arn:aws:kms:us-east-1:${ACCOUNT_ID}:alias/bfd-platform-cmk
+      created_at: "2025-05-30T12:43:15Z"
+      enc: AQICAHjxly34ZBDoNlpGiKxZCgGefcvFT75wuI0miwFqykz7tQEDfyvFDA1mpW/IHYbsqOwHAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMJderfAUNjBsjyiW4AgEQgDuuO17SSWzeWvJsKlbnRXpfZPXQFTML1SFcqWyZRqWjY6xv887rFzbL6OiWwNq1ShiiGeHhxeulc3NpYA==
+      aws_profile: ""
+    - arn: arn:aws:kms:us-east-1:${ACCOUNT_ID}:alias/bfd-mgmt-config-cmk
+      created_at: "2025-05-30T12:44:10Z"
+      enc: AQICAHje54t884PQ3I3HmEfbyeDxeth8IxFtXCHA9cZvNPo2hQEAqQFvKJRgKu6sydo96tP0AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMIvwlyUZwlWvmbdSEAgEQgDum0Q8hV3gFoDfB+7+d9cjS6Uz28+zZo9N83BH5G6zzAck/r2PY0rWv79XibPhCKinS2WPK7pYMLN/WVw==
+      aws_profile: ""
+  unencrypted_regex: /nonsensitive/
+  version: 3.10.2

--- a/ops/services/01-config/values/prod-sbx.sopsw.yaml
+++ b/ops/services/01-config/values/prod-sbx.sopsw.yaml
@@ -763,6 +763,10 @@
   -----END CERTIFICATE-----
 /bfd/${env}/server/nonsensitive/ecs/capacity/min: 3
 /bfd/${env}/server/nonsensitive/ecs/capacity/max: 12
+/bfd/${env}/server/nonsensitive/ecs/capacity_provider/fargate/base: 0
+/bfd/${env}/server/nonsensitive/ecs/capacity_provider/fargate/weight: 0
+/bfd/${env}/server/nonsensitive/ecs/capacity_provider/fargate_spot/base: 0
+/bfd/${env}/server/nonsensitive/ecs/capacity_provider/fargate_spot/weight: 100
 /bfd/${env}/server/nonsensitive/ecs/resources/cpu: 4096
 /bfd/${env}/server/nonsensitive/ecs/resources/memory: 8192
 /bfd/${env}/server-alarms/nonsensitive/error_alerter/rate: 5 minutes

--- a/ops/services/01-config/values/prod.sopsw.yaml
+++ b/ops/services/01-config/values/prod.sopsw.yaml
@@ -494,6 +494,10 @@
   -----END CERTIFICATE-----
 /bfd/${env}/server/nonsensitive/ecs/capacity/min: 3
 /bfd/${env}/server/nonsensitive/ecs/capacity/max: 12
+/bfd/${env}/server/nonsensitive/ecs/capacity_provider/fargate/base: 1
+/bfd/${env}/server/nonsensitive/ecs/capacity_provider/fargate/weight: 0
+/bfd/${env}/server/nonsensitive/ecs/capacity_provider/fargate_spot/base: 0
+/bfd/${env}/server/nonsensitive/ecs/capacity_provider/fargate_spot/weight: 100
 /bfd/${env}/server/nonsensitive/ecs/resources/cpu: 8192
 /bfd/${env}/server/nonsensitive/ecs/resources/memory: 16384
 /bfd/${env}/server-alarms/nonsensitive/error_alerter/rate: 5 minutes

--- a/ops/services/01-config/values/prod.sopsw.yaml
+++ b/ops/services/01-config/values/prod.sopsw.yaml
@@ -492,10 +492,10 @@
   clnTv2aEV8UuG1e6ceb43KdpMxJM/DVo03brksPEqKBe42vTa/5fVCSEy6M4CMdc
   NgIzEFpYbI1ODGAJ8fQv0TzOSHlUbEzG0e+/jw==
   -----END CERTIFICATE-----
-/bfd/${env}/server/nonsensitive/ecs/capacity/min: 6
-/bfd/${env}/server/nonsensitive/ecs/capacity/max: 24
-/bfd/${env}/server/nonsensitive/ecs/resources/cpu: 4096
-/bfd/${env}/server/nonsensitive/ecs/resources/memory: 8192
+/bfd/${env}/server/nonsensitive/ecs/capacity/min: 3
+/bfd/${env}/server/nonsensitive/ecs/capacity/max: 12
+/bfd/${env}/server/nonsensitive/ecs/resources/cpu: 8192
+/bfd/${env}/server/nonsensitive/ecs/resources/memory: 16384
 /bfd/${env}/server-alarms/nonsensitive/error_alerter/rate: 5 minutes
 /bfd/${env}/server-alarms/nonsensitive/error_alerter/log_lookback_seconds: 330
 /bfd/${env}/server-alarms/nonsensitive/error_alerter/slack_webhook_ssm: /bfd/platform/alerting/sensitive/slack/bfd-internal-alerts/webhook

--- a/ops/services/01-config/values/test.sopsw.yaml
+++ b/ops/services/01-config/values/test.sopsw.yaml
@@ -377,6 +377,10 @@
   -----END CERTIFICATE-----
 /bfd/${env}/server/nonsensitive/ecs/capacity/min: 1
 /bfd/${env}/server/nonsensitive/ecs/capacity/max: 3
+/bfd/${env}/server/nonsensitive/ecs/capacity_provider/fargate/base: 0
+/bfd/${env}/server/nonsensitive/ecs/capacity_provider/fargate/weight: 0
+/bfd/${env}/server/nonsensitive/ecs/capacity_provider/fargate_spot/base: 0
+/bfd/${env}/server/nonsensitive/ecs/capacity_provider/fargate_spot/weight: 100
 /bfd/${env}/server/nonsensitive/ecs/resources/cpu: 4096
 /bfd/${env}/server/nonsensitive/ecs/resources/memory: 8192
 /bfd/${env}/server-alarms/nonsensitive/error_alerter/rate: 5 minutes

--- a/ops/services/04-server/deploy.tf
+++ b/ops/services/04-server/deploy.tf
@@ -74,6 +74,10 @@ resource "null_resource" "codedeploy_server" {
         task_definition_arn   = aws_ecs_task_definition.server.arn
         container_name        = local.service
         container_port        = local.server_port
+        base_fargate          = local.server_cps_fargate_base
+        weight_fargate        = local.server_cps_fargate_weight
+        base_fargate_spot     = local.server_cps_fargate_spot_base
+        weight_fargate_spot   = local.server_cps_fargate_spot_weight
         validation_lambda_arn = one(aws_lambda_function.regression_wrapper[*].arn)
       })
     }

--- a/ops/services/04-server/regression-wrapper.tf
+++ b/ops/services/04-server/regression-wrapper.tf
@@ -19,7 +19,7 @@ data "aws_network_interfaces" "load_balancer" {
 }
 
 data "aws_network_interface" "load_balancer" {
-  id = data.aws_network_interfaces.load_balancer.ids[0]
+  id = sort(data.aws_network_interfaces.load_balancer.ids)[0]
 }
 
 data "aws_lambda_function" "run_locust" {

--- a/ops/services/04-server/service.tf
+++ b/ops/services/04-server/service.tf
@@ -11,13 +11,17 @@ locals {
   log_router_version            = coalesce(var.log_router_version_override, local.latest_bfd_release)
   server_version                = coalesce(var.server_version_override, local.latest_bfd_release)
 
-  server_truststore_path = "/data/${local.truststore_filename}"
-  server_keystore_path   = "/data/${local.keystore_filename}"
-  server_port            = nonsensitive(local.ssm_config["/bfd/${local.service}/service_port"])
-  server_min_capacity    = nonsensitive(local.ssm_config["/bfd/${local.service}/ecs/capacity/min"])
-  server_max_capacity    = nonsensitive(local.ssm_config["/bfd/${local.service}/ecs/capacity/max"])
-  server_cpu             = nonsensitive(local.ssm_config["/bfd/${local.service}/ecs/resources/cpu"])
-  server_memory          = nonsensitive(local.ssm_config["/bfd/${local.service}/ecs/resources/memory"])
+  server_truststore_path         = "/data/${local.truststore_filename}"
+  server_keystore_path           = "/data/${local.keystore_filename}"
+  server_port                    = nonsensitive(local.ssm_config["/bfd/${local.service}/service_port"])
+  server_min_capacity            = nonsensitive(local.ssm_config["/bfd/${local.service}/ecs/capacity/min"])
+  server_max_capacity            = nonsensitive(local.ssm_config["/bfd/${local.service}/ecs/capacity/max"])
+  server_cps_fargate_base        = tonumber(nonsensitive(local.ssm_config["/bfd/${local.service}/ecs/capacity_provider/fargate/base"]))
+  server_cps_fargate_weight      = tonumber(nonsensitive(local.ssm_config["/bfd/${local.service}/ecs/capacity_provider/fargate/weight"]))
+  server_cps_fargate_spot_base   = tonumber(nonsensitive(local.ssm_config["/bfd/${local.service}/ecs/capacity_provider/fargate_spot/base"]))
+  server_cps_fargate_spot_weight = tonumber(nonsensitive(local.ssm_config["/bfd/${local.service}/ecs/capacity_provider/fargate_spot/weight"]))
+  server_cpu                     = nonsensitive(local.ssm_config["/bfd/${local.service}/ecs/resources/cpu"])
+  server_memory                  = nonsensitive(local.ssm_config["/bfd/${local.service}/ecs/resources/memory"])
   # TODO: Remove "/ng/" prefix when config is switched to
   server_ssm_hierarchies = [
     "/ng/bfd/${local.env}/${local.service}/sensitive/",
@@ -290,6 +294,7 @@ resource "aws_ecs_task_definition" "server" {
             protocol      = "${local.server_protocol}"
           },
         ]
+        stopTimeout = 120 # Allow enough time for server to gracefully stop on spot termination.
         # Empty declarations reduce Terraform diff noise
         systemControls = []
         volumesFrom    = []
@@ -373,9 +378,15 @@ resource "aws_ecs_service" "server" {
   }
 
   capacity_provider_strategy {
-    base              = 1
+    base              = local.server_cps_fargate_base
+    capacity_provider = "FARGATE"
+    weight            = local.server_cps_fargate_weight
+  }
+
+  capacity_provider_strategy {
+    base              = local.server_cps_fargate_spot_base
     capacity_provider = "FARGATE_SPOT"
-    weight            = 100
+    weight            = local.server_cps_fargate_spot_weight
   }
 
   deployment_controller {

--- a/ops/services/04-server/templates/server-appspec.yaml.tftpl
+++ b/ops/services/04-server/templates/server-appspec.yaml.tftpl
@@ -13,6 +13,13 @@ revision:
               LoadBalancerInfo:
                 ContainerName: "${container_name}"
                 ContainerPort: ${container_port}
+              CapacityProviderStrategy:
+                - Base: ${base_fargate}
+                  CapacityProvider: FARGATE
+                  Weight: ${weight_fargate}
+                - Base: ${base_fargate_spot}
+                  CapacityProvider: FARGATE_SPOT
+                  Weight: ${weight_fargate_spot}
       %{~ if validation_lambda_arn != null ~}
       Hooks:
         - AfterAllowTestTraffic: "${validation_lambda_arn}"


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
BFD-4115

### What Does This PR Do?
<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

This PR is an assortment of changes that were necessary in order to `apply` our Greenfield Terraform to the Legacy account.

In no particular order, this PR:

- Enables placement of `server` Service Tasks into both of the `FARGATE` (on-demand, not subject to Spot Termination) and `FARGATE_SPOT` (spot, subject to Spot Termination) Capacity Providers based on SSM Parameter values. Both `base` and `weight` values can be configured via SSM. Only `prod` is configured with any Tasks placed in the `FARGATE` Capacity Provider: 1 Task will _always_ run in `FARGATE` in `prod` to ensure we are never running without _some_ capacity in `prod`
- Ensures that `tofu apply`s of `server` report "no changes" when there really are no changes. Before this fix, the private IP address used in the Regression Suite would be different `apply` to `apply`, causing erroneous differences in the plan
- Standardizes the RDS Monitoring Interval between the Cluster and Writer instance
- Increases the per-Task resources allocated to `server` Tasks in `prod` from 4 vCPUs/8 GB RAM to 8 vCPUs/16 GB RAM. This is necessary as the bloom filters built on startup of `prod` `server` Tasks require a _large_ amount of memory and CPU to build relative to other environments. Reducing the resource allocation any lower than the new values results in Tasks eventually becoming unhealthy, which leads to _more_ Tasks being started to replace the unhealthy Tasks which eventually leads to extreme load on the database due to the new Tasks trying to build their own bloom filters
- Fixes the new `trigger-glue-crawler` Lambda always timing-out and starting the Glue Crawler twice whenever a new partition value is added to the Glue Table in S3
- Adds a `legacy` "flavor" of Platform `sopsw` configuration YAML specifically for the Legacy account. These values aren't used, _yet_, but it is good to have them configured if necessary

### What Should Reviewers Watch For?
<!--
Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items here -->

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:  

- ~~Adds any new software dependencies~~
- ~~Modifies any security controls~~
- ~~Adds new transmission or storage of data~~
- ~~Any other changes that could possibly affect security?~~

- [x] I have considered the above security implications as it relates to this PR. (If one or more of the above apply, it cannot be merged without the ISSO or team security engineer's (`@sb-benohe`) approval.)
- [x] I have created tests to sufficiently ensure the reliability of my code, if applicable. If this is a modification to an existing piece of code, I have audited the associated tests to ensure everything works as expected.

### Validation

**Have you fully verified and tested these changes? Is the acceptance criteria met? Please provide reproducible testing instructions, code snippets, or screenshots as applicable.**

- `tofu apply`ing all Greenfield Terraform (`ops/services`, `ops/platform`) in all environments in Legacy, _verifying that_ it all works
- Deploying `prod` with the increased resources, _verifying that_:
  - Tasks do not become unhealthy
  - Running a 100 user simulated load looks good (~1000 req/s)
- Deploying a new revision of `prod` `server` with the Capacity Provider Strategy changes, _verifying that_ a single Task is placed in the `FARGATE` provider
- Running a Locust test with `store` set in the invoke payload such that a new `hash` partition is created, _verifying that_ the `trigger-glue-crawler` Lambda triggers the Glue Crawler once and exits