### PR TITLE
BFD-4124: Refactor BFD-Insights S3-Bucket and Athena Resources prior to greenfield migration

### DIFF
--- a/ops/services/02-insights/main.tf
+++ b/ops/services/02-insights/main.tf
@@ -17,6 +17,7 @@ module "terraservice" {
 
 locals {
   service = "insights"
+  partners = ["bcda", "bfd", "bb2", "ab2d"]
 
   region                   = module.terraservice.region
   account_id               = module.terraservice.account_id
@@ -46,3 +47,107 @@ module "bucket_insights_bfd" {
 
   ssm_param_name = "/bfd/${local.env}/${local.service}/nonsensitive/bucket"
 }
+
+resource "aws_s3_object" "env_prefixes" {
+  for_each = merge(
+    {
+      for partner in local.partners: "${partner}-streams" => {
+        key = "${partner}/streams/"
+      }
+    },
+    {
+      for partner in local.partners: "${parner}-results" => {
+        key = "${partner}/results/"
+      }
+    }
+  )
+
+  bucket = module.bucket_insights_bfd.bucket.name
+  key = each.value.key
+  content = ""
+  content_type = "application/octet-stream"
+}
+
+resource "aws_athena_workgroup" "this" {
+  for_each = toset([local.partners]) 
+  name = "${local.env}-${each.key}"
+
+  configuration {
+    enforce_workgroup_configuration = true
+    publish_cloudwatch_metrics_enabled = true
+
+    result_configuration {
+      output_location = "s3://${module.bucket_insights_bfd.bucket.name}/${each.key}/results/"
+  
+      encryption_configuration {
+        encryption_option = "SSE_KMS"
+        kms_key_arn = module.terraservice.aws_kms_key.env.arn
+      }
+    }
+  }
+
+  state = "ENABLED"
+}
+
+resource "aws_glue_catalog_database" "this" {
+  for_each = toset(local.partners)
+  name = "${local.env}-${each.key}"
+}
+
+resource "aws_glue_crawler" "this" {
+  for_each = toset(local.partners)
+  name = "bfd-${local.env}-${each.key}-crawler"
+  role = aws_iam_role.glue_role.arn
+  database_name = aws_glue_catalog_database.this["${local.env}-${each.key}"].name
+  #table_prefix 
+
+  s3_target {
+   path = "s3://${module.bucket_insights_bfd.bucket.name}/${each.key}/streams/" 
+  }
+
+  configuration = jsonencode({
+    Version = "1.0",
+    CrawlerOutput = {
+      Tables = {
+        AddOrUpdateBehavior = "MergeNewColumns"
+      },
+      Partitions = {
+        AddOrUpdateBehavior = "InheritFromTable"
+      }
+    }
+  })
+
+  schema_change_policy {
+    delete_behavior = "LOG"
+    update_behavior = "UPDATE_IN_DATABASE"
+  }
+
+  recrawl_policy {
+    recrawl_behavior = "CRAWL_EVERYTHING"
+  }
+
+  schedule = "cron(0/15 * * * ? *)"
+}
+
+resource "aws_iam_role" "this" {
+  name = "bfd-insights-glue-crawler-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect = "Allow",
+      Principal = {
+        Service = "glue.amazonaws.com"
+      },
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "this" {
+  role = aws_iam_role.this
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
+}
+
+
+


### PR DESCRIPTION
**JIRA Ticket:**
BFD-4124


### What Does This PR Do?
Refactor BFD-Insights Athena, S3-Bucket, Glue Database and Glue Tables to have an S3 bucket per-environment; each bucket with per-consumer prefix; an Athena workgroup per environment, per-consumer; a Glue Catalog DB per-environment, per-consumer; Glue Crawlers configured to crawl the different consumers stream for new tables.


### What Should Reviewers Watch For?
Common items include:
* Is this likely to address the goals expressed in the user story? Yes
* Are any additional documentation updates needed? Yes
* Are there any unhandled and/or untested edge cases you can think of? No
* Is user input properly sanitized & handled? N/A
* Does this make any backwards-incompatible changes that might break end user clients? No
* Can you find any bugs if you run the code locally and test it manually? No


If you're reviewing this PR, please check for these things in particular:

### What Security Implications Does This PR Have? None

Please indicate if this PR does any of the following:  

* Adds any new software dependencies - No
* Modifies any security controls - No
* Adds new transmission or storage of data - No
* Any other changes that could possibly affect security?  No

* [x ] I have considered the above security implications as it relates to this PR. (If one or more of the above apply, it cannot be merged without the ISSO or team security engineer's (`@sb-benohe`) approval.) 
* [ ] I have created tests to sufficiently ensure the reliability of my code, if applicable. If this is a modification to an existing piece of code, I have audited the associated tests to ensure everything works as expected.

### Validation

**Have you fully verified and tested these changes? Is the acceptance criteria met? Please provide reproducible testing instructions, code snippets, or screenshots as applicable.**
    
