### PR TITLE
BFD-4297: Avoid Analyses on Merge Group Triggers

### DIFF
--- a/.github/workflows/ci-java.yml
+++ b/.github/workflows/ci-java.yml
@@ -125,7 +125,7 @@ jobs:
         working-directory: ./apps
 
       - name: 'Generate, Upload Build Reports'
-        if: ${{ github.event_type != 'merge_group' }}
+        if: ${{ github.event_name != 'merge_group' }}
         env:
           BFD_BRANCH: ${{ inputs.branch }}
         run: |


### PR DESCRIPTION
**JIRA Ticket:**
BFD-4297


### What Does This PR Do?
This fixes an issue where sonar analyses are generated and uploaded on merge_group events that cost an additional 90 to 120s of runtime.

These merge_queue events are currently running tests as a matter of course, but they're also spending time running a sonar analysis and uploading those results to sonarqube–these results are detached from the rest of the project and treated as independent branches and are not useful to any quality assurance or continuous improvement process.

### What Should Reviewers Watch For?
<!--
Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items here -->

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:  

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security? 

* [x] I have considered the above security implications as it relates to this PR. (If one or more of the above apply, it cannot be merged without the ISSO or team security engineer's (`@sb-benohe`) approval.) 
* [x] I have created tests to sufficiently ensure the reliability of my code, if applicable. If this is a modification to an existing piece of code, I have audited the associated tests to ensure everything works as expected.

### Validation

**Have you fully verified and tested these changes? Is the acceptance criteria met? Please provide reproducible testing instructions, code snippets, or screenshots as applicable.**

Limited testing conducted–the only risk presented here is that it merge_group triggered CI continues to request and publish sonar analyses to sonarqube. `github.event_type` is non-existent under the `github` context in the GitHub API: https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#example-usage-of-the-github-context
