### PR TITLE
BFD-4686: IDR Pipeline incremental performance improvements

### DIFF
--- a/apps/bfd-pipeline-idr/loader.py
+++ b/apps/bfd-pipeline-idr/loader.py
@@ -4,7 +4,7 @@ from datetime import UTC, date, datetime
 
 import psycopg
 from psycopg.abc import Params, QueryNoTemplate
-from psycopg.errors import DeadlockDetected, LockNotAvailable
+from psycopg.errors import DeadlockDetected, LockNotAvailable, QueryCanceled
 
 from constants import DEFAULT_MIN_DATE
 from load_partition import LoadPartition, LoadType
@@ -96,12 +96,15 @@ class BatchLoader:
         self.meta_keys = (
             ["bfd_created_ts"] if self.immutable else ["bfd_created_ts", "bfd_updated_ts"]
         )
+        self.progress_start_timer = Timer("progress_start", model, partition)
         self.idr_query_timer = Timer("idr_query", model, partition)
         self.temp_table_timer = Timer("temp_table", model, partition)
         self.copy_timer = Timer("copy", model, partition)
-        self.insert_timer = Timer("insert", model, partition)
-        self.commit_timer = Timer("commit", model, partition)
+        self.upsert_timer = Timer("upsert", model, partition)
         self.last_updated_timer = Timer("last_updated", model, partition)
+        self.total_insert_timer = Timer("total_insert", model, partition)
+        self.update_progress_timer = Timer("update_progress", model, partition)
+        self.commit_timer = Timer("commit", model, partition)
         self.load_type = load_type
         self.enable_load_progress = should_track_load_progress(load_mode)
 
@@ -113,8 +116,10 @@ class BatchLoader:
         # (temp tables can't be created with an explicit schema set)
 
         with self.conn.cursor() as cur:
+            self.progress_start_timer.start()
             self._insert_batch_start(cur)
             self.conn.commit()
+            self.progress_start_timer.stop()
             data_loaded = False
             num_rows = 0
 
@@ -142,11 +147,13 @@ class BatchLoader:
 
                 if results:
                     # Upsert into the main table
-                    self.insert_timer.start()
+                    self.total_insert_timer.start()
                     self._merge(cur, timestamp)
-                    self.insert_timer.stop()
+                    self.total_insert_timer.stop()
 
+                    self.update_progress_timer.start()
                     self._calculate_load_progress(cur, results)
+                    self.update_progress_timer.stop()
 
                 self.commit_timer.start()
                 self.conn.commit()
@@ -279,11 +286,15 @@ class BatchLoader:
         on_conflict = (
             "DO NOTHING"
             if self.immutable or not update_set
-            else f"DO UPDATE SET {update_set}, bfd_updated_ts=%(timestamp)s"
+            else (
+                f"DO UPDATE SET {update_set}, bfd_updated_ts=%(timestamp)s "
+                "WHERE (t.*) IS DISTINCT FROM (EXCLUDED.*)"
+            )
         )
-        timestamp_placeholders = ",".join("%(timestamp)s" for _ in self.meta_keys)
+        timestamp_placeholders = ", ".join("%(timestamp)s" for _ in self.meta_keys)
 
         # Upsert into the main table
+        self.upsert_timer.start()
         if self.model.should_replace():
             # Delete before inserting since we've specified that the data should be
             # replaced rather than merged.
@@ -292,25 +303,29 @@ class BatchLoader:
             cur.execute(f"DELETE FROM {self.table}")  # type: ignore
         cur.execute(
             f"""
-            INSERT INTO {self.table}({self.cols_str}, {",".join(self.meta_keys)})
-            SELECT {self.cols_str},{timestamp_placeholders} FROM {self.temp_table}
-            ON CONFLICT ({",".join(unique_key)}) {on_conflict}
+            INSERT INTO {self.table} AS t ({self.cols_str}, {", ".join(self.meta_keys)})
+            SELECT {self.cols_str}, {timestamp_placeholders} FROM {self.temp_table}
+            ON CONFLICT ({", ".join(unique_key)}) {on_conflict}
             """,  # type: ignore
             {"timestamp": timestamp},
+            binary=True,
         )
         self.conn.commit()
+        self.upsert_timer.stop()
 
         if self.load_type == LoadType.INCREMENTAL and self.model.last_updated_date_table():
             key = self.model.last_updated_timestamp_col()
             last_updated_cols = self.model.last_updated_date_column()
             set_clause = ", ".join(f"{col} = %(timestamp)s" for col in last_updated_cols)
 
+            self.last_updated_timer.start()
             try:
-                self.last_updated_timer.start()
                 # We want to immediately terminate the transaction if there is already a lock on
                 # the table so that we avoid extraneous waits because if there is a lock this table
                 # is being updated concurrently and that existing update will have the same result
-                cur.execute("SET lock_timeout=1")
+                cur.execute("SAVEPOINT pre_last_updated")
+                cur.execute("SET LOCAL lock_timeout=1")
+                cur.execute("SET LOCAL statement_timeout=3000")
                 cur.execute(
                     f"""
                     WITH current_ts AS (
@@ -330,9 +345,12 @@ class BatchLoader:
                     {"timestamp": timestamp},
                 )
                 self.conn.commit()
-                self.last_updated_timer.stop()
-            except (DeadlockDetected, LockNotAvailable) as ex:
-                logger.warning("deadlock/lock timeout updating update timestamp, ignoring: %s", ex)
+            except (DeadlockDetected, LockNotAvailable, QueryCanceled) as ex:
+                logger.warning(
+                    "deadlock/lock/statement timeout updating update timestamp, ignoring: %s", ex
+                )
+                cur.execute("ROLLBACK TO SAVEPOINT pre_last_updated")
+            self.last_updated_timer.stop()
 
     def _copy_data(self, cur: psycopg.Cursor, results: Sequence[T]) -> None:
         # Use COPY to load the batch into Postgres.

--- a/apps/bfd-pipeline-idr/loader.py
+++ b/apps/bfd-pipeline-idr/loader.py
@@ -213,8 +213,10 @@ class BatchLoader:
         # For simplicity's sake, we'll create our temp tables using the existing schema and
         # just drop the columns we need to ignore.
         cur.execute(
-            f"CREATE TEMPORARY TABLE {self.temp_table} (LIKE {self.table}) ON COMMIT DROP"  # type: ignore
+            f"CREATE TEMPORARY TABLE IF NOT EXISTS {self.temp_table} (LIKE {self.table}) "
+            "ON COMMIT PRESERVE ROWS"  # type: ignore
         )
+        cur.execute(f"TRUNCATE TABLE {self.temp_table}") # type: ignore
         # Created/updated columns don't need to be loaded from the source.
         for col in self.meta_keys:
             cur.execute(f"ALTER TABLE {self.temp_table} DROP COLUMN {col}")  # type: ignore
@@ -303,14 +305,12 @@ class BatchLoader:
             last_updated_cols = self.model.last_updated_date_column()
             set_clause = ", ".join(f"{col} = %(timestamp)s" for col in last_updated_cols)
 
-            # We require multi-step transactions since we're dealing with temp tables, so there
-            # is a chance of a deadlock here.
-            # However, it's safe to ignore these because if the timestamp for this row is being
-            # updated concurrently then it's going to have the same end result anyway.
-            # If a deadlock occurs, the CTE returns no rows and this is a no-op.
             try:
                 self.last_updated_timer.start()
-                cur.execute("SET lock_timeout=1s")
+                # We want to immediately terminate the transaction if there is already a lock on
+                # the table so that we avoid extraneous waits because if there is a lock this table
+                # is being updated concurrently and that existing update will have the same result
+                cur.execute("SET lock_timeout=1")
                 cur.execute(
                     f"""
                     WITH current_ts AS (
@@ -332,12 +332,6 @@ class BatchLoader:
                 self.conn.commit()
                 self.last_updated_timer.stop()
             except DeadlockDetected as ex:
-                # We require multi-step transactions since we're dealing with temp tables, so there
-                # is a chance of a deadlock here.
-                # Locking rows helps reduce the chance of this when multiple nodes update this
-                # table, but it doesn't eliminate the possibility.
-                # However, it's safe to ignore this because if the timestamp for this row is being
-                # updated concurrently then it's going to have the same end result anyway
                 logger.warning("deadlock updating update timestamp, ignoring: %s", ex)
 
     def _copy_data(self, cur: psycopg.Cursor, results: Sequence[T]) -> None:

--- a/apps/bfd-pipeline-idr/loader.py
+++ b/apps/bfd-pipeline-idr/loader.py
@@ -100,6 +100,7 @@ class BatchLoader:
         self.copy_timer = Timer("copy", model, partition)
         self.insert_timer = Timer("insert", model, partition)
         self.commit_timer = Timer("commit", model, partition)
+        self.progress_update_timer = Timer("progress_update", model, partition)
         self.load_type = load_type
         self.enable_load_progress = should_track_load_progress(load_mode)
 
@@ -305,6 +306,8 @@ class BatchLoader:
             # updated concurrently then it's going to have the same end result anyway.
             # If a deadlock occurs, the CTE returns no rows and this is a no-op.
 
+            self.progress_update_timer.start()
+            cur.execute("SET lock_timeout=1s")
             cur.execute(
                 f"""
                 WITH current_ts AS (
@@ -319,10 +322,11 @@ class BatchLoader:
                 UPDATE {self.model.last_updated_date_table()} u
                 SET {set_clause}
                 FROM current_ts t
-                WHERE u.{key} = t.{key};
+                WHERE u.{key} = t.{key}
                 """,  # type: ignore
                 {"timestamp": timestamp},
             )
+            self.progress_update_timer.stop()
 
     def _copy_data(self, cur: psycopg.Cursor, results: Sequence[T]) -> None:
         # Use COPY to load the batch into Postgres.

--- a/apps/bfd-pipeline-idr/loader.py
+++ b/apps/bfd-pipeline-idr/loader.py
@@ -4,7 +4,7 @@ from datetime import UTC, date, datetime
 
 import psycopg
 from psycopg.abc import Params, QueryNoTemplate
-from psycopg.errors import DeadlockDetected
+from psycopg.errors import DeadlockDetected, LockNotAvailable
 
 from constants import DEFAULT_MIN_DATE
 from load_partition import LoadPartition, LoadType
@@ -331,8 +331,8 @@ class BatchLoader:
                 )
                 self.conn.commit()
                 self.last_updated_timer.stop()
-            except DeadlockDetected as ex:
-                logger.warning("deadlock updating update timestamp, ignoring: %s", ex)
+            except (DeadlockDetected, LockNotAvailable) as ex:
+                logger.warning("deadlock/lock timeout updating update timestamp, ignoring: %s", ex)
 
     def _copy_data(self, cur: psycopg.Cursor, results: Sequence[T]) -> None:
         # Use COPY to load the batch into Postgres.

--- a/apps/bfd-pipeline-idr/loader.py
+++ b/apps/bfd-pipeline-idr/loader.py
@@ -262,6 +262,7 @@ class BatchLoader:
     ) -> None:
         if self.enable_load_progress:
             cur.execute(query, params)  # type: ignore
+            self.conn.commit()
 
     def _merge(self, cur: psycopg.Cursor, timestamp: datetime) -> None:
         unique_key = self.model.unique_key()
@@ -295,6 +296,7 @@ class BatchLoader:
             """,  # type: ignore
             {"timestamp": timestamp},
         )
+        self.conn.commit()
 
         if self.load_type == LoadType.INCREMENTAL and self.model.last_updated_date_table():
             key = self.model.last_updated_timestamp_col()
@@ -306,7 +308,6 @@ class BatchLoader:
             # However, it's safe to ignore these because if the timestamp for this row is being
             # updated concurrently then it's going to have the same end result anyway.
             # If a deadlock occurs, the CTE returns no rows and this is a no-op.
-
             try:
                 self.last_updated_timer.start()
                 cur.execute("SET lock_timeout=1s")
@@ -328,6 +329,7 @@ class BatchLoader:
                     """,  # type: ignore
                     {"timestamp": timestamp},
                 )
+                self.conn.commit()
                 self.last_updated_timer.stop()
             except DeadlockDetected as ex:
                 # We require multi-step transactions since we're dealing with temp tables, so there

--- a/apps/bfd-pipeline-idr/loader.py
+++ b/apps/bfd-pipeline-idr/loader.py
@@ -4,6 +4,7 @@ from datetime import UTC, date, datetime
 
 import psycopg
 from psycopg.abc import Params, QueryNoTemplate
+from psycopg.errors import DeadlockDetected
 
 from constants import DEFAULT_MIN_DATE
 from load_partition import LoadPartition, LoadType
@@ -100,7 +101,7 @@ class BatchLoader:
         self.copy_timer = Timer("copy", model, partition)
         self.insert_timer = Timer("insert", model, partition)
         self.commit_timer = Timer("commit", model, partition)
-        self.progress_update_timer = Timer("progress_update", model, partition)
+        self.last_updated_timer = Timer("last_updated", model, partition)
         self.load_type = load_type
         self.enable_load_progress = should_track_load_progress(load_mode)
 
@@ -306,27 +307,36 @@ class BatchLoader:
             # updated concurrently then it's going to have the same end result anyway.
             # If a deadlock occurs, the CTE returns no rows and this is a no-op.
 
-            self.progress_update_timer.start()
-            cur.execute("SET lock_timeout=1s")
-            cur.execute(
-                f"""
-                WITH current_ts AS (
-                    SELECT {key}
-                    FROM {self.model.last_updated_date_table()}
-                    WHERE {key} IN (
-                        SELECT {key} FROM {self.temp_table}
+            try:
+                self.last_updated_timer.start()
+                cur.execute("SET lock_timeout=1s")
+                cur.execute(
+                    f"""
+                    WITH current_ts AS (
+                        SELECT {key}
+                        FROM {self.model.last_updated_date_table()}
+                        WHERE {key} IN (
+                            SELECT {key} FROM {self.temp_table}
+                        )
+                        ORDER BY {key}
+                        FOR UPDATE SKIP LOCKED
                     )
-                    ORDER BY {key}
-                    FOR UPDATE SKIP LOCKED
+                    UPDATE {self.model.last_updated_date_table()} u
+                    SET {set_clause}
+                    FROM current_ts t
+                    WHERE u.{key} = t.{key};
+                    """,  # type: ignore
+                    {"timestamp": timestamp},
                 )
-                UPDATE {self.model.last_updated_date_table()} u
-                SET {set_clause}
-                FROM current_ts t
-                WHERE u.{key} = t.{key}
-                """,  # type: ignore
-                {"timestamp": timestamp},
-            )
-            self.progress_update_timer.stop()
+                self.last_updated_timer.stop()
+            except DeadlockDetected as ex:
+                # We require multi-step transactions since we're dealing with temp tables, so there
+                # is a chance of a deadlock here.
+                # Locking rows helps reduce the chance of this when multiple nodes update this
+                # table, but it doesn't eliminate the possibility.
+                # However, it's safe to ignore this because if the timestamp for this row is being
+                # updated concurrently then it's going to have the same end result anyway
+                logger.warning("deadlock updating update timestamp, ignoring: %s", ex)
 
     def _copy_data(self, cur: psycopg.Cursor, results: Sequence[T]) -> None:
         # Use COPY to load the batch into Postgres.

--- a/apps/bfd-pipeline-idr/loader.py
+++ b/apps/bfd-pipeline-idr/loader.py
@@ -216,10 +216,10 @@ class BatchLoader:
             f"CREATE TEMPORARY TABLE IF NOT EXISTS {self.temp_table} (LIKE {self.table}) "
             "ON COMMIT PRESERVE ROWS"  # type: ignore
         )
-        cur.execute(f"TRUNCATE TABLE {self.temp_table}") # type: ignore
+        cur.execute(f"TRUNCATE TABLE {self.temp_table}")  # type: ignore
         # Created/updated columns don't need to be loaded from the source.
         for col in self.meta_keys:
-            cur.execute(f"ALTER TABLE {self.temp_table} DROP COLUMN {col}")  # type: ignore
+            cur.execute(f"ALTER TABLE {self.temp_table} DROP COLUMN IF EXISTS {col}")  # type: ignore
 
     def _calculate_load_progress(self, cur: psycopg.Cursor, results: Sequence[T]) -> None:
         last = results[len(results) - 1].model_dump()

--- a/apps/bfd-pipeline-idr/test_pipeline.py
+++ b/apps/bfd-pipeline-idr/test_pipeline.py
@@ -45,7 +45,7 @@ def _run_migrator(postgres: PostgresContainer) -> None:
             f"-Dflyway.user={postgres.username} "
             f"-Dflyway.password={postgres.password} "
             "-Duser.timezone=UTC",
-            cwd="../bfd-db-migrator-ng",
+            cwd=Path(__file__).parent.joinpath("../bfd-db-migrator-ng"),
             shell=True,
             capture_output=True,
             check=True,
@@ -59,12 +59,12 @@ def _run_migrator(postgres: PostgresContainer) -> None:
 def setup_db() -> Generator[PostgresContainer]:
     with PostgresContainer("postgres:16", driver="") as postgres:
         with psycopg.connect(postgres.get_connection_url()) as conn:
-            with Path("./mock-idr.sql").open() as f:
+            with Path(__file__).parent.joinpath("./mock-idr.sql").open() as f:
                 conn.execute(f.read())  # type: ignore
             conn.commit()
 
             _run_migrator(postgres)
-            load_from_csv(PostgresExecutor(conn), "./test_samples1")  # type: ignore
+            load_from_csv(PostgresExecutor(conn), Path(__file__).parent.joinpath("./test_samples1"))  # type: ignore
 
             info = conn.info
             # Info level logs obscure the error output when running tests

--- a/apps/bfd-pipeline-idr/test_pipeline.py
+++ b/apps/bfd-pipeline-idr/test_pipeline.py
@@ -491,16 +491,38 @@ def test_pipeline() -> None:
     # This is REALLY dumb. Typically we would use a parameterized test plus a fixture to setup the
     # database and run the same test with both load types, but GitHub Actions Runners seem to have
     # some issue with testcontainers where only a single test case succeeds and all others fail to
-    # connect. This forces sequential execution of each test case and guarantees each Postgres
-    # container is cleaned-up prior to the next case running, avoiding the issue in CI
+    # connect. This forces sequential execution of each test case and ensures only a single
+    # container is ever started, avoiding the issue in CI
     # TODO: Don't do this, find a way to make parameterized tests work in CI
-    for load_type in [LoadType.INCREMENTAL, LoadType.INITIAL]:
-        with (
-            PostgresContainer("postgres:16", driver="") as postgres,
-            # No idea why pyright is upset about "row_factory", but we need to tell it to ignore the
-            # argument type here.
-            psycopg.connect(conninfo=postgres.get_connection_url(), row_factory=dict_row) as conn,  # pyright: ignore[reportArgumentType]
-        ):
+    with (
+        PostgresContainer("postgres:16", driver="") as postgres,
+        # No idea why pyright is upset about "row_factory", but we need to tell it to ignore the
+        # argument type here.
+        psycopg.connect(conninfo=postgres.get_connection_url(), row_factory=dict_row) as conn,  # pyright: ignore[reportArgumentType]
+    ):
+        for load_type in [LoadType.INCREMENTAL, LoadType.INITIAL]:
+            # Truncate all tables first. See above for justification
+            conn.execute(
+                """
+                DO $$ DECLARE
+                    r RECORD;
+                BEGIN
+                    FOR r IN (SELECT tablename FROM pg_tables WHERE schemaname = 'idr') LOOP
+                        EXECUTE 'DROP TABLE idr.' || quote_ident(r.tablename) || ' CASCADE';
+                    END LOOP;
+
+                    FOR r IN (
+                        SELECT tablename FROM pg_tables WHERE schemaname = 'cms_vdm_view_mdcr_prd'
+                    ) LOOP
+                        EXECUTE 'DROP TABLE cms_vdm_view_mdcr_prd.'
+                            || quote_ident(r.tablename)
+                            || ' CASCADE';
+                    END LOOP;
+                END $$;
+                """
+            )
+            conn.commit()
+
             with Path(__file__).parent.joinpath("./mock-idr.sql").open() as f:
                 conn.execute(f.read())  # type: ignore
             conn.commit()

--- a/apps/bfd-pipeline-idr/test_pipeline.py
+++ b/apps/bfd-pipeline-idr/test_pipeline.py
@@ -55,7 +55,7 @@ def _run_migrator(postgres: PostgresContainer) -> None:
         raise
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def setup_db() -> Generator[PostgresContainer]:
     with PostgresContainer("postgres:16", driver="") as postgres:
         with psycopg.connect(postgres.get_connection_url()) as conn:
@@ -81,8 +81,12 @@ def setup_db() -> Generator[PostgresContainer]:
         yield postgres
 
 
-def test_pipeline(setup_db: PostgresContainer) -> None:
-    load_type = LoadType.INCREMENTAL
+@pytest.mark.parametrize(
+    argnames="load_type",
+    argvalues=[LoadType.INCREMENTAL, LoadType.INITIAL],
+    ids=["test_pipeline--incremental", "test_pipeline--initial"],
+)
+def test_pipeline(setup_db: PostgresContainer, load_type: LoadType) -> None:
     conn = cast(
         psycopg.Connection[DictRow],
         psycopg.connect(setup_db.get_connection_url(), row_factory=dict_row),  # type: ignore

--- a/apps/bfd-pipeline-idr/test_pipeline.py
+++ b/apps/bfd-pipeline-idr/test_pipeline.py
@@ -1,7 +1,6 @@
 import os
 import shutil
 import subprocess
-from collections.abc import Generator
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import cast

--- a/apps/bfd-pipeline-idr/test_pipeline.py
+++ b/apps/bfd-pipeline-idr/test_pipeline.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 
 import psycopg
 import pytest
-from psycopg import sql
+from psycopg import Connection, sql
 from psycopg.rows import DictRow, dict_row
 from testcontainers.core.config import testcontainers_config  # type: ignore
 
@@ -55,45 +55,42 @@ def _run_migrator(postgres: PostgresContainer) -> None:
         raise
 
 
-@pytest.fixture
-def setup_db() -> Generator[PostgresContainer]:
-    with PostgresContainer("postgres:16", driver="") as postgres:
-        with psycopg.connect(postgres.get_connection_url()) as conn:
-            with Path(__file__).parent.joinpath("./mock-idr.sql").open() as f:
-                conn.execute(f.read())  # type: ignore
-            conn.commit()
-
-            _run_migrator(postgres)
-            load_from_csv(PostgresExecutor(conn), Path(__file__).parent.joinpath("./test_samples1"))  # type: ignore
-
-            info = conn.info
-            # Info level logs obscure the error output when running tests
-            # so we want to override this unless the calling process has set this explicitly
-            os.environ.setdefault("IDR_LOG_LEVEL", "warning")
-            os.environ["BFD_DB_ENDPOINT"] = info.host
-            os.environ["BFD_DB_PORT"] = str(info.port)
-            os.environ["BFD_DB_NAME"] = info.dbname
-            os.environ["BFD_DB_USERNAME"] = info.user
-            os.environ["BFD_DB_PASSWORD"] = info.password
-            os.environ["IDR_BATCH_SIZE"] = "100000"
-            os.environ["IDR_FORCE_LOAD_PROGRESS"] = "1"
-            os.environ["BFD_TEST_DATE"] = "2023-04-02"
-        yield postgres
-
-
 @pytest.mark.parametrize(
     argnames="load_type",
     argvalues=[LoadType.INCREMENTAL, LoadType.INITIAL],
     ids=["test_pipeline--incremental", "test_pipeline--initial"],
 )
-def test_pipeline(setup_db: PostgresContainer, load_type: LoadType) -> None:
-    conn = cast(
-        psycopg.Connection[DictRow],
-        psycopg.connect(setup_db.get_connection_url(), row_factory=dict_row),  # type: ignore
-    )
+def test_pipeline(load_type: LoadType) -> None:
+    with (
+        PostgresContainer("postgres:16", driver="") as postgres,
+        # No idea why pyright is upset about "row_factory", but we need to tell it to ignore the
+        # argument type here.
+        psycopg.connect(conninfo=postgres.get_connection_url(), row_factory=dict_row) as conn,  # pyright: ignore[reportArgumentType]
+    ):
+        with Path(__file__).parent.joinpath("./mock-idr.sql").open() as f:
+            conn.execute(f.read())  # type: ignore
+        conn.commit()
 
-    conn.commit()
+        _run_migrator(postgres)
+        load_from_csv(PostgresExecutor(conn), Path(__file__).parent.joinpath("./test_samples1"))  # type: ignore
 
+        info = conn.info
+        # Info level logs obscure the error output when running tests
+        # so we want to override this unless the calling process has set this explicitly
+        os.environ.setdefault("IDR_LOG_LEVEL", "warning")
+        os.environ["BFD_DB_ENDPOINT"] = info.host
+        os.environ["BFD_DB_PORT"] = str(info.port)
+        os.environ["BFD_DB_NAME"] = info.dbname
+        os.environ["BFD_DB_USERNAME"] = info.user
+        os.environ["BFD_DB_PASSWORD"] = info.password
+        os.environ["IDR_BATCH_SIZE"] = "100000"
+        os.environ["IDR_FORCE_LOAD_PROGRESS"] = "1"
+        os.environ["BFD_TEST_DATE"] = "2023-04-02"
+
+        _do_test_pipeline(cast(Connection[DictRow], conn), load_type)
+
+
+def _do_test_pipeline(conn: Connection[DictRow], load_type: LoadType) -> None:
     run(Source.POSTGRES, LoadMode.SYNTHETIC, load_type)
 
     cur = conn.execute("select * from idr.beneficiary order by bene_sk")

--- a/apps/bfd-pipeline-idr/test_pipeline.py
+++ b/apps/bfd-pipeline-idr/test_pipeline.py
@@ -7,7 +7,6 @@ from typing import cast
 from uuid import uuid4
 
 import psycopg
-import pytest
 from psycopg import Connection, sql
 from psycopg.rows import DictRow, dict_row
 from testcontainers.core.config import testcontainers_config  # type: ignore
@@ -52,41 +51,6 @@ def _run_migrator(postgres: PostgresContainer) -> None:
     except subprocess.CalledProcessError as ex:
         print(ex.output)
         raise
-
-
-@pytest.mark.parametrize(
-    argnames="load_type",
-    argvalues=[LoadType.INCREMENTAL, LoadType.INITIAL],
-    ids=["test_pipeline--incremental", "test_pipeline--initial"],
-)
-def test_pipeline(load_type: LoadType) -> None:
-    with (
-        PostgresContainer("postgres:16", driver="") as postgres,
-        # No idea why pyright is upset about "row_factory", but we need to tell it to ignore the
-        # argument type here.
-        psycopg.connect(conninfo=postgres.get_connection_url(), row_factory=dict_row) as conn,  # pyright: ignore[reportArgumentType]
-    ):
-        with Path(__file__).parent.joinpath("./mock-idr.sql").open() as f:
-            conn.execute(f.read())  # type: ignore
-        conn.commit()
-
-        _run_migrator(postgres)
-        load_from_csv(PostgresExecutor(conn), Path(__file__).parent.joinpath("./test_samples1"))  # type: ignore
-
-        info = conn.info
-        # Info level logs obscure the error output when running tests
-        # so we want to override this unless the calling process has set this explicitly
-        os.environ.setdefault("IDR_LOG_LEVEL", "warning")
-        os.environ["BFD_DB_ENDPOINT"] = info.host
-        os.environ["BFD_DB_PORT"] = str(info.port)
-        os.environ["BFD_DB_NAME"] = info.dbname
-        os.environ["BFD_DB_USERNAME"] = info.user
-        os.environ["BFD_DB_PASSWORD"] = info.password
-        os.environ["IDR_BATCH_SIZE"] = "100000"
-        os.environ["IDR_FORCE_LOAD_PROGRESS"] = "1"
-        os.environ["BFD_TEST_DATE"] = "2023-04-02"
-
-        _do_test_pipeline(cast(Connection[DictRow], conn), load_type)
 
 
 def _do_test_pipeline(conn: Connection[DictRow], load_type: LoadType) -> None:
@@ -521,3 +485,40 @@ def _do_test_pipeline(conn: Connection[DictRow], load_type: LoadType) -> None:
 def advance_time(timestamp: datetime) -> None:
     new_time = timestamp + timedelta(minutes=1)
     os.environ["BFD_TEST_DATE"] = new_time.isoformat()
+
+
+def test_pipeline() -> None:
+    # This is REALLY dumb. Typically we would use a parameterized test plus a fixture to setup the
+    # database and run the same test with both load types, but GitHub Actions Runners seem to have
+    # some issue with testcontainers where only a single test case succeeds and all others fail to
+    # connect. This forces sequential execution of each test case and guarantees each Postgres
+    # container is cleaned-up prior to the next case running, avoiding the issue in CI
+    # TODO: Don't do this, find a way to make parameterized tests work in CI
+    for load_type in [LoadType.INCREMENTAL, LoadType.INITIAL]:
+        with (
+            PostgresContainer("postgres:16", driver="") as postgres,
+            # No idea why pyright is upset about "row_factory", but we need to tell it to ignore the
+            # argument type here.
+            psycopg.connect(conninfo=postgres.get_connection_url(), row_factory=dict_row) as conn,  # pyright: ignore[reportArgumentType]
+        ):
+            with Path(__file__).parent.joinpath("./mock-idr.sql").open() as f:
+                conn.execute(f.read())  # type: ignore
+            conn.commit()
+
+            _run_migrator(postgres)
+            load_from_csv(PostgresExecutor(conn), Path(__file__).parent.joinpath("./test_samples1"))  # type: ignore
+
+            info = conn.info
+            # Info level logs obscure the error output when running tests
+            # so we want to override this unless the calling process has set this explicitly
+            os.environ.setdefault("IDR_LOG_LEVEL", "warning")
+            os.environ["BFD_DB_ENDPOINT"] = info.host
+            os.environ["BFD_DB_PORT"] = str(info.port)
+            os.environ["BFD_DB_NAME"] = info.dbname
+            os.environ["BFD_DB_USERNAME"] = info.user
+            os.environ["BFD_DB_PASSWORD"] = info.password
+            os.environ["IDR_BATCH_SIZE"] = "100000"
+            os.environ["IDR_FORCE_LOAD_PROGRESS"] = "1"
+            os.environ["BFD_TEST_DATE"] = "2023-04-02"
+
+            _do_test_pipeline(cast(Connection[DictRow], conn), load_type)

--- a/ops/services/02-database/db-node-parameters/aurora-postgresql16.yaml
+++ b/ops/services/02-database/db-node-parameters/aurora-postgresql16.yaml
@@ -32,3 +32,6 @@
 - apply_method: "pending-reboot"
   name: "shared_preload_libraries"
   value: "pg_stat_statements,auto_explain"
+- apply_method: "immediate"
+  name: "enable_seqscan"
+  value: "0"

--- a/ops/services/02-database/db-node-parameters/aurora-postgresql16.yaml
+++ b/ops/services/02-database/db-node-parameters/aurora-postgresql16.yaml
@@ -32,6 +32,3 @@
 - apply_method: "pending-reboot"
   name: "shared_preload_libraries"
   value: "pg_stat_statements,auto_explain"
-- apply_method: "immediate"
-  name: "enable_seqscan"
-  value: "0"

--- a/ops/services/04-idr-pipeline/lambda_src/run-idr-pipeline/app/main.py
+++ b/ops/services/04-idr-pipeline/lambda_src/run-idr-pipeline/app/main.py
@@ -95,7 +95,9 @@ class IdrContainerOverrides:
     @classmethod
     def from_invoke(cls, invoke_model: InvokeModel) -> IdrContainerOverrides:
         env_kvs = (
-            [EnvKeyValue(name=k, value=v) for k, v in invoke_model.env] if invoke_model.env else []
+            [EnvKeyValue(name=k, value=v) for k, v in invoke_model.env.items()]
+            if invoke_model.env
+            else []
         )
         command_seq = invoke_model.command.split() if invoke_model.command else None
 


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
BFD-4686


### What Does This PR Do?
<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

This PR makes minor, tangential improvements to the performance of the IDR Pipeline. Most importantly, the "`last_updated`" phase of batch loading has been modified to have a strict timeout of 3 seconds which should dramatically decrease the time it takes to load some tables with high contention. Additionally, more minor optimizations have been introduced like adding commits between distinct merge operations, a `WHERE` clause that should improve performance when `INSERT`ing rows that are not distinct, and unconditionally using binary mode when `INSERT`ing.


> [!NOTE]
> This PR does not solve the overall poor performance of upserts. Further effort is required there.
> See below for a summary of the investigative effort that resulted in this set of changes

#### Investigation

All of the following items were ineffective or had no meaningful or significant impact to upsert performance:

- Upgrading to latest Aurora Postgres 17.9
- Setting `work_mem` upto `256 MB`
- Setting `fillfactor` to `70`, `75`, `80`, etc.
- `VACUUM (ANALYZE)` on all tables
- Multiple upsert strategies:
  - `MERGE`
  - `INSERT ... UNNEST ... ON CONFLICT`
  - Separate `INSERT ... WHERE NOT EXISTS` and `UPDATE`
- Adding `WHERE (t.*) IS DISTINCT FROM (excluded.*)` to `INSERT ... ON CONFLICT`
- Multiple batch sizes (10000, 500000)
- Copying indexes from the permanent table into the temporary table that is `COPY`'d into
- `INSERT ... UNNEST...` with less than half the columns
- `CLUSTER`/`VACUUM FULL`/`pg_repack`
  - **cannot complete because RDS disk does not expand fast enough**

#### Observations

- `EXPLAIN (ANALYZE, ...)` explain does not indicate bottleneck
  - Example:

    ```
    Insert on idr.claim_item_professional_ss  (cost=0.00..2200.00 rows=0 width=0) (actual time=48489.063..48489.064 rows=0 loops=1)
      Conflict Resolution: UPDATE
      Conflict Arbiter Indexes: claim_item_professional_ss_pkey
      Tuples Inserted: 822
      Conflicting Tuples: 99178
      Buffers: shared hit=1746484 read=97713 written=35
      I/O Timings: shared read=46178.682 write=0.336
      ->  Seq Scan on public.claim_item_professional_ss_temp  (cost=0.00..2200.00 rows=100000 width=562) (actual time=0.008..57.242 rows=100000 loops=1)
            Output: <all_temp_cols>
            Buffers: shared hit=1200
    Settings: max_parallel_workers = '16', maintenance_io_concurrency = '1', effective_cache_size = '176237552kB', work_mem = '32MB', random_page_cost = '1.1'
    Query Identifier: 358277129191546854
    Planning Time: 0.092 ms
    Execution Time: 48489.211 ms
    ```

- We saw `EXPLAIN`s for `INSERT`s that were fast with no `I/O Timings ... read` reported. These usually occurred by running the same `INSERT` twice (presumably due to the cache being filled, indicating I/O being the bottleneck), e.g.:

  ```sql
  BEGIN;
  INSERT ... FROM ... ON CONFLICT ...; -- <-- slow
  ROLLBACK;
  BEGIN;
  INSERT ... FROM ... ON CONFLICT ...; -- <-- fast
  ROLLBACK;
  ```

  - Example:

    ```
    Insert on idr.claim_item_professional_ss  (cost=0.00..2200.00 rows=0 width=0) (actual time=1486.214..1486.215 rows=0 loops=1)
      Conflict Resolution: UPDATE
      Conflict Arbiter Indexes: claim_item_professional_ss_pkey
      Tuples Inserted: 822
      Conflicting Tuples: 99178
      Buffers: shared hit=1622627 written=1792
      I/O Timings: shared write=1.812
      ->  Seq Scan on public.claim_item_professional_ss_temp  (cost=0.00..2200.00 rows=100000 width=562) (actual time=0.008..34.130 rows=100000 loops=1)
            Output: <all_temp_cols>
            Buffers: shared hit=1200
    Settings: max_parallel_workers = '16', maintenance_io_concurrency = '1', effective_cache_size = '176237552kB', work_mem = '32MB', random_page_cost = '1.1'
    Query Identifier: 358277129191546854
    Planning Time: 0.076 ms
    Execution Time: 1486.368 ms
    ```

- Significant variance between the "same" (different data, same shape) `INSERT`. Some take 1 second, others take >60 for the same batch size

### What Should Reviewers Watch For?
<!--
Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items here -->

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:  

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security? 

* [x] I have considered the above security implications as it relates to this PR. (If one or more of the above apply, it cannot be merged without the ISSO or team security engineer's (`@sb-benohe`) approval.) 
* [x] I have created tests to sufficiently ensure the reliability of my code, if applicable. If this is a modification to an existing piece of code, I have audited the associated tests to ensure everything works as expected.

### Validation

**Have you fully verified and tested these changes? Is the acceptance criteria met? Please provide reproducible testing instructions, code snippets, or screenshots as applicable.**
    
- Running these changes in the `4686-prod` environment, _verifying that_:
   - the pipeline works
   - the performance is not worsened and is better* in _very_ specific cases
      - *more specifically, some beneficiary-related tables were taking upwards of 4500+ **seconds** to complete the `last_updated` phase of `_merge` which is unacceptable—a `statement_timeout` ensures that this cannot happen
      - the various other "improvements" are completely ineffective at worst, and have no real measurable impact on the poor upsert performance of the IDR Pipeline