### PR TITLE
BFD-4698: Reenable v3 Data Dictionary

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -288,44 +288,50 @@ jobs:
 
       # TODO: Re-enable the below once BFD v3 DD generation is fixed
 
-      # - name: Install node
-      #   uses: actions/setup-node@v6
-      #   with:
-      #     node-version: "22"
+     # TODO: Download and include FHIR packages for faster execution due to caching:
+     # - name: Cache FHIR Packages
+     #   uses: actions/cache@v4
+     #   with:
+     #    path: .fhir/packages
+     #    key: ${{ runner.os }}-fhir-packages
 
-      # - name: Install Sushi
-      #   run: |
-      #     npm install -g fsh-sushi
-      #     echo "Installed global packages"
+      - name: Install node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6.4.0
+        with:
+          node-version: "24"
 
-      # - name: Install fhirpath
-      #   working-directory: apps/bfd-model-idr
-      #   run: |
-      #     npm install fhirpath
+      - name: Install Sushi
+        run: |
+          npm install -g fsh-sushi
+          echo "Installed global packages"
 
-      # - name: Install uv
-      #   uses: astral-sh/setup-uv@v7
-      #   with:
-      #     version: "0.8.10"
+      - name: Install fhirpath
+        working-directory: apps/bfd-model-idr
+        run: |
+          npm install fhirpath
 
-      # - name: Install UV dependencies
-      #   run: uv sync
-      #   working-directory: apps/bfd-model-idr
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "0.11.9"
 
-      # - name: Download FHIR Validator CLI
-      #   working-directory: apps/bfd-model-idr
-      #   run: |
-      #     curl -L https://github.com/hapifhir/org.hl7.fhir.core/releases/download/6.7.10/validator_cli.jar \
-      #       -o validator_cli.jar
+      - name: Install UV dependencies
+        run: uv sync
+        working-directory: apps/bfd-model-idr
 
-      # - name: Compile all synthetic FHIR resources
-      #   run: ./compile-all-resources.sh
-      #   working-directory: apps/bfd-model-idr
+      - name: Download FHIR Validator CLI
+        working-directory: apps/bfd-model-idr
+        run: |
+          curl -L https://github.com/hapifhir/org.hl7.fhir.core/releases/download/6.9.7/validator_cli.jar -o validator_cli.jar
 
-      # - name: Generate v3 Data Dictionary
-      #   working-directory: apps/bfd-model-idr
-      #   run: |
-      #     uv run gen_dd.py
+      - name: Compile all synthetic FHIR resources
+        run: ./compile-all-resources.sh
+        working-directory: apps/bfd-model-idr
+
+      - name: Generate v3 Data Dictionary
+        working-directory: apps/bfd-model-idr
+        run: |
+          uv run gen_dd.py
 
       - name: Prepare artifacts
         env:
@@ -353,16 +359,16 @@ jobs:
           done
 
           # TODO: Re-enable this once BFD v3 DD generation is fixed
-          # echo "Preparing data dictionary artifacts..."
+           echo "Preparing data dictionary artifacts..."
 
           # # 2) Handle v3 artifacts
-          # for artifact_path in apps/bfd-model-idr/out/bfd_data_dictionary.*
-          # do
-          #   filename="$(basename -- "$artifact_path")"
-          #   artifact_ext="${filename#*.}"
+           for artifact_path in apps/bfd-model-idr/out/bfd_data_dictionary.*
+           do
+             filename="$(basename -- "$artifact_path")"
+             artifact_ext="${filename#*.}"
 
-          #   cp "$artifact_path" "assets/v3-data-dictionary-${BFD_RELEASE}.${artifact_ext}"
-          # done
+             cp "$artifact_path" "assets/v3-data-dictionary-${BFD_RELEASE}.${artifact_ext}"
+           done
 
           echo "Final staged artifacts:"
           ls -l assets

--- a/apps/bfd-model-idr/claims_generator.py
+++ b/apps/bfd-model-idr/claims_generator.py
@@ -700,7 +700,9 @@ def generate(
 
     if sushi:
         print("Running sushi build")
-        _, stderr = run_command(["sushi", "build"], cwd="./sushi")
+        sushi_command = ["sushi", "build"]
+        sushi_command.append("-n") # Don't hit the external service tx.fhir.org.
+        _, stderr = run_command(sushi_command, cwd="./sushi")
         if stderr:
             print("SUSHI errors:")
             print(stderr)

--- a/apps/bfd-model-idr/compile_resources.py
+++ b/apps/bfd-model-idr/compile_resources.py
@@ -191,7 +191,7 @@ def main():
     # Generate Structure Definitions + CodeSystems
     if(args.sushi):
         print("Running sushi build")
-        stdout, stderr = run_command("sushi build", cwd=script_dir / "sushi")
+        stdout, stderr = run_command("sushi build -n", cwd=script_dir / "sushi")
         print("SUSHI output:")
         print(stdout)
         if stderr:

--- a/apps/bfd-model-idr/generator_util.py
+++ b/apps/bfd-model-idr/generator_util.py
@@ -311,8 +311,10 @@ class GeneratorUtil:
             print("Running sushi build")
             try:
                 sushi_dir = "./sushi"
+                sushi_command = ["sushi", "build"]
+                sushi_command.append("-n") # Don't hit the external service tx.fhir.org.
                 result = subprocess.run(
-                    ["sushi", "build"], check=True, cwd=sushi_dir, capture_output=True, text=True
+                    sushi_command, check=True, cwd=sushi_dir, capture_output=True, text=True
                 )
                 if result.returncode == 0:
                     print("Sushi build completed successfully")


### PR DESCRIPTION

**JIRA Ticket:**
BFD-4698


### What Does This PR Do?
It reenables the v3 Data Dictionary which was disabled in BFD-4511 and also prevents sushi from hitting the external service `tx.fhir.org`.


### What Should Reviewers Watch For?

If you're reviewing this PR, please check for these things in particular:
That the workflow actually generates the data dictionary without failure.

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:  

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security? 

* [x] I have considered the above security implications as it relates to this PR. (If one or more of the above apply, it cannot be merged without the ISSO or team security engineer's (`@sb-benohe`) approval.) 
* [ ] I have created tests to sufficiently ensure the reliability of my code, if applicable. If this is a modification to an existing piece of code, I have audited the associated tests to ensure everything works as expected.

### Validation

**Have you fully verified and tested these changes? Is the acceptance criteria met? Please provide reproducible testing instructions, code snippets, or screenshots as applicable.**
    
I'm waiting for @alex-dzeda  to return from vacation to go over this with him as he's the SME for this.