### PR TITLE
Add GitHub Actions workflow for InfraScan analysis

### DIFF
--- a/.github/workflows/analysis-tools.yml
+++ b/.github/workflows/analysis-tools.yml
@@ -1,0 +1,37 @@
+name: Analysis Tools
+
+on:
+  workflow_dispatch:
+    inputs:
+      tool:
+        description: Analysis tool to run
+        required: true
+        type: choice
+        options:
+          - infrascan
+
+jobs:
+  infrascan:
+    if: ${{ github.event.inputs.tool == 'infrascan' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create Reports Directory
+        run: mkdir -p infrascan-reports
+
+      - name: Run InfraScan
+        uses: soldevelo/infrascan@v1.0.9
+        with:
+          scanner: comprehensive
+          format: html
+          out: infrascan-reports/report.html
+
+      - name: Upload InfraScan Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: infrascan-report
+          path: infrascan-reports/report.html
+          retention-days: 14


### PR DESCRIPTION
This workflow adds a manually triggered GitHub Actions job to run InfraScan and generate infrastructure security and cost optimization reports, with results uploaded as a downloadable artifact.

### What Does This PR Do?

Adds a `workflow_dispatch`-triggered GitHub Actions workflow that:
- Runs InfraScan (`soldevelo/infrascan@v1.0.9`)
- Generates an HTML report in `infrascan-reports/`
- Uploads the report as a GitHub artifact (14 days retention)

Latest InfraScan results:

<img width="1305" height="1021" alt="obraz" src="https://github.com/user-attachments/assets/35c7be1c-7d56-44d8-a114-0803d17dc9a6" />


- Overall Grade: B (92.1%)
- Total Issues: 463 (3 High)
- Cost Optimization: ~$205/month potential savings
- IaC Security: 332 findings
- Container Security: 3 high severity image issues

Report:
https://infrascan.soldevelo.com/report/beneficiary-fhir-data-5d788313-452f-489e-b96a-dda5c0932671

### What Should Reviewers Watch For?
- Correct manual trigger configuration (`workflow_dispatch`)
- Proper InfraScan action setup and outputs
- Artifact upload reliability (`if: always()`)

### Security Implications
- Adds InfraScan GitHub Action dependency
- Introduces infrastructure/security scanning workflow
- No changes to application runtime security