### PR TITLE
Add retention_in_days to CloudWatch Log Groups

### DIFF
--- a/ops/platform/02-alerting/slack-alerter.tf
+++ b/ops/platform/02-alerting/slack-alerter.tf
@@ -103,6 +103,7 @@ data "archive_file" "slack_alerter_src" {
 
 resource "aws_cloudwatch_log_group" "slack_alerter" {
   name         = "/aws/lambda/${local.slack_lambda_full_name}"
+  retention_in_days = 14
   kms_key_id   = local.kms_key_arn
   skip_destroy = true
 }

--- a/ops/platform/02-alerting/sns-topics.tf
+++ b/ops/platform/02-alerting/sns-topics.tf
@@ -50,12 +50,14 @@ data "aws_iam_policy_document" "topic_template" {
 
 resource "aws_cloudwatch_log_group" "splunk_incident_success" {
   name         = "sns/${local.region}/${local.account_id}/${local.splunk_incident_topic}"
+  retention_in_days = 14
   kms_key_id   = local.kms_key_arn
   skip_destroy = true
 }
 
 resource "aws_cloudwatch_log_group" "splunk_incident_failure" {
   name         = "sns/${local.region}/${local.account_id}/${local.splunk_incident_topic}/Failure"
+  retention_in_days = 14
   kms_key_id   = local.kms_key_arn
   skip_destroy = true
 }
@@ -95,6 +97,7 @@ resource "aws_cloudwatch_log_group" "slack_success" {
   for_each = local.slack_channel_to_topic
 
   name         = "sns/${local.region}/${local.account_id}/${each.value}"
+  retention_in_days = 14
   kms_key_id   = local.kms_key_arn
   skip_destroy = true
 }
@@ -103,6 +106,7 @@ resource "aws_cloudwatch_log_group" "slack_failure" {
   for_each = local.slack_channel_to_topic
 
   name         = "sns/${local.region}/${local.account_id}/${each.value}/Failure"
+  retention_in_days = 14
   kms_key_id   = local.kms_key_arn
   skip_destroy = true
 }

--- a/ops/services/02-bene-prefs/lambda.tf
+++ b/ops/services/02-bene-prefs/lambda.tf
@@ -11,6 +11,7 @@ resource "aws_cloudwatch_log_group" "this" {
   count = local.conditional_count
 
   name       = "/aws/lambda/${local.name_prefix}"
+  retention_in_days = 14
   kms_key_id = local.env_key_arn
 }
 

--- a/ops/services/02-cluster/main.tf
+++ b/ops/services/02-cluster/main.tf
@@ -38,6 +38,7 @@ locals {
 
 resource "aws_cloudwatch_log_group" "this" {
   name         = "/aws/ecs/${local.full_name}"
+  retention_in_days = 14
   kms_key_id   = local.env_key_arn
   skip_destroy = true
 }

--- a/ops/services/02-eft/inbound.tf
+++ b/ops/services/02-eft/inbound.tf
@@ -176,6 +176,7 @@ resource "aws_vpc_security_group_ingress_rule" "vpc_endpoint_allow_sftp_traffic_
 
 resource "aws_cloudwatch_log_group" "sftp_server" {
   name         = "/bfd/${local.service}/${local.full_name}"
+  retention_in_days = 14
   kms_key_id   = local.env_key_arn
   skip_destroy = true
 }

--- a/ops/services/02-eft/outbound.tf
+++ b/ops/services/02-eft/outbound.tf
@@ -198,6 +198,7 @@ resource "aws_cloudwatch_log_group" "sftp_outbound_transfer" {
   count = length(local.eft_partners_with_outbound_enabled) > 0 ? 1 : 0
 
   name         = "/aws/lambda/${local.outbound_lambda_full_name}"
+  retention_in_days = 14
   kms_key_id   = local.env_key_arn
   skip_destroy = true
 }

--- a/ops/services/03-eft-o11y/notifier-lambda.tf
+++ b/ops/services/03-eft-o11y/notifier-lambda.tf
@@ -37,6 +37,7 @@ data "archive_file" "slack_notifier_src" {
 
 resource "aws_cloudwatch_log_group" "slack_notifier" {
   name         = "/aws/lambda/${local.slack_notifier_lambda_full_name}"
+  retention_in_days = 14
   kms_key_id   = local.env_key_arn
   skip_destroy = true
 }

--- a/ops/services/03-locust/run-locust.tf
+++ b/ops/services/03-locust/run-locust.tf
@@ -51,6 +51,7 @@ resource "aws_vpc_security_group_ingress_rule" "allow_run_locust" {
 
 resource "aws_cloudwatch_log_group" "run_locust" {
   name         = "/aws/lambda/${local.run_locust_lambda_full_name}"
+  retention_in_days = 14
   kms_key_id   = local.env_key_arn
   skip_destroy = true
 }

--- a/ops/services/03-migrator-ng/main.tf
+++ b/ops/services/03-migrator-ng/main.tf
@@ -58,6 +58,7 @@ locals {
 
 resource "aws_cloudwatch_log_group" "messages" {
   name         = "/aws/ecs/${data.aws_ecs_cluster.main.cluster_name}/${local.service}/${local.service}/messages"
+  retention_in_days = 14
   kms_key_id   = local.env_key_arn
   skip_destroy = true
 }

--- a/ops/services/03-migrator/main.tf
+++ b/ops/services/03-migrator/main.tf
@@ -56,6 +56,7 @@ locals {
 
 resource "aws_cloudwatch_log_group" "messages" {
   name         = "/aws/ecs/${data.aws_ecs_cluster.main.cluster_name}/${local.service}/${local.service}/messages"
+  retention_in_days = 14
   kms_key_id   = local.env_key_arn
   skip_destroy = true
 }

--- a/ops/services/04-ccw-pipeline/ccw-runner.tf
+++ b/ops/services/04-ccw-pipeline/ccw-runner.tf
@@ -37,6 +37,7 @@ resource "aws_vpc_security_group_ingress_rule" "allow_ccw_runner_rds_cluster" {
 
 resource "aws_cloudwatch_log_group" "ccw_runner" {
   name         = "/aws/lambda/${local.ccw_runner_lambda_full_name}"
+  retention_in_days = 14
   kms_key_id   = local.env_key_arn
   skip_destroy = true
 }

--- a/ops/services/04-ccw-pipeline/main.tf
+++ b/ops/services/04-ccw-pipeline/main.tf
@@ -62,6 +62,7 @@ locals {
 
 resource "aws_cloudwatch_log_group" "ccw_messages" {
   name         = "/aws/ecs/${data.aws_ecs_cluster.main.cluster_name}/${local.service}/${local.service}/messages"
+  retention_in_days = 14
   kms_key_id   = local.env_key_arn
   skip_destroy = true
 }

--- a/ops/services/04-idr-pipeline/main.tf
+++ b/ops/services/04-idr-pipeline/main.tf
@@ -71,6 +71,7 @@ locals {
 
 resource "aws_cloudwatch_log_group" "idr_messages" {
   name         = "/aws/ecs/${data.aws_ecs_cluster.main.cluster_name}/${local.service}/${local.service}/messages"
+  retention_in_days = 14
   kms_key_id   = local.env_key_arn
   skip_destroy = true
 }

--- a/ops/services/04-npi-pipeline/main.tf
+++ b/ops/services/04-npi-pipeline/main.tf
@@ -58,6 +58,7 @@ locals {
 
 resource "aws_cloudwatch_log_group" "messages" {
   name         = "/aws/ecs/${data.aws_ecs_cluster.main.cluster_name}/${local.service}/${local.service}/messages"
+  retention_in_days = 14
   kms_key_id   = local.env_key_arn
   skip_destroy = true
 }

--- a/ops/services/04-rda-pipeline/main.tf
+++ b/ops/services/04-rda-pipeline/main.tf
@@ -59,6 +59,7 @@ locals {
 
 resource "aws_cloudwatch_log_group" "rda_messages" {
   name         = "/aws/ecs/${data.aws_ecs_cluster.main.cluster_name}/${local.service}/${local.service}/messages"
+  retention_in_days = 14
   kms_key_id   = local.env_key_arn
   skip_destroy = true
 }

--- a/ops/services/04-server/regression-wrapper.tf
+++ b/ops/services/04-server/regression-wrapper.tf
@@ -44,6 +44,7 @@ resource "aws_cloudwatch_log_group" "regression_wrapper" {
   count = local.regression_wrapper_enabled ? 1 : 0
 
   name         = "/aws/lambda/${local.rw_lambda_full_name}"
+  retention_in_days = 14
   kms_key_id   = local.env_key_arn
   skip_destroy = true
 }

--- a/ops/services/04-server/service.tf
+++ b/ops/services/04-server/service.tf
@@ -79,36 +79,42 @@ data "aws_ecr_image" "server" {
 
 resource "aws_cloudwatch_log_group" "certstores_messages" {
   name         = "/aws/ecs/${data.aws_ecs_cluster.main.cluster_name}/${local.service}/certstores/messages"
+  retention_in_days = 14
   kms_key_id   = local.env_key_arn
   skip_destroy = true
 }
 
 resource "aws_cloudwatch_log_group" "log_router_messages" {
   name         = "/aws/ecs/${data.aws_ecs_cluster.main.cluster_name}/${local.service}/log_router/messages"
+  retention_in_days = 14
   kms_key_id   = local.env_key_arn
   skip_destroy = true
 }
 
 resource "aws_cloudwatch_log_group" "server_messages" {
   name         = "/aws/ecs/${data.aws_ecs_cluster.main.cluster_name}/${local.service}/${local.service}/messages"
+  retention_in_days = 14
   kms_key_id   = local.env_key_arn
   skip_destroy = true
 }
 
 resource "aws_cloudwatch_log_group" "server_access" {
   name         = "/aws/ecs/${data.aws_ecs_cluster.main.cluster_name}/${local.service}/${local.service}/access"
+  retention_in_days = 14
   kms_key_id   = local.env_key_arn
   skip_destroy = true
 }
 
 resource "aws_cloudwatch_log_group" "adot_messages" {
   name         = "/aws/ecs/${data.aws_ecs_cluster.main.cluster_name}/${local.service}/adot/messages"
+  retention_in_days = 14
   kms_key_id   = local.env_key_arn
   skip_destroy = true
 }
 
 resource "aws_cloudwatch_log_group" "adot_metrics" {
   name         = "/aws/ecs/${data.aws_ecs_cluster.main.cluster_name}/${local.service}/adot/metrics"
+  retention_in_days = 14
   kms_key_id   = local.env_key_arn
   skip_destroy = true
 }

--- a/ops/services/06-ccw-pipeline-alarms/manifests-verifier.tf
+++ b/ops/services/06-ccw-pipeline-alarms/manifests-verifier.tf
@@ -54,6 +54,7 @@ resource "aws_scheduler_schedule" "verifier" {
 
 resource "aws_cloudwatch_log_group" "verifier" {
   name         = "/aws/lambda/${local.verifier_lambda_full_name}"
+  retention_in_days = 14
   kms_key_id   = local.env_key_arn
   skip_destroy = true
 }

--- a/ops/services/06-server-alarms/error-alerter.tf
+++ b/ops/services/06-server-alarms/error-alerter.tf
@@ -47,6 +47,7 @@ resource "aws_scheduler_schedule" "alerter" {
 
 resource "aws_cloudwatch_log_group" "alerter" {
   name         = "/aws/lambda/${local.alerter_lambda_full_name}"
+  retention_in_days = 14
   kms_key_id   = local.env_key_arn
   skip_destroy = true
 }

--- a/ops/terraform-modules/general/logging-sns-topic/main.tf
+++ b/ops/terraform-modules/general/logging-sns-topic/main.tf
@@ -47,12 +47,14 @@ data "aws_iam_policy_document" "combined" {
 
 resource "aws_cloudwatch_log_group" "success" {
   name         = "sns/${local.region}/${local.account_id}/${var.topic_name}"
+  retention_in_days = 14
   kms_key_id   = var.kms_key_arn
   skip_destroy = true
 }
 
 resource "aws_cloudwatch_log_group" "failure" {
   name         = "sns/${local.region}/${local.account_id}/${var.topic_name}/Failure"
+  retention_in_days = 14
   kms_key_id   = var.kms_key_arn
   skip_destroy = true
 }

--- a/ops/terraform-modules/general/trigger-glue-crawler/main.tf
+++ b/ops/terraform-modules/general/trigger-glue-crawler/main.tf
@@ -21,6 +21,7 @@ data "archive_file" "this" {
 
 resource "aws_cloudwatch_log_group" "this" {
   name         = "/aws/lambda/${var.lambda_name}"
+  retention_in_days = 14
   kms_key_id   = var.kms_key_arn
   skip_destroy = true
 }


### PR DESCRIPTION
## What Does This PR Do?

This PR adds missing `retention_in_days` configuration to all existing `aws_cloudwatch_log_group` resources across Terraform modules and services.

Previously, CloudWatch Log Groups were created without retention policies, which resulted in logs being stored indefinitely and increasing unnecessary storage costs. This change standardizes log retention (defaulting to 14 days where no specific context applies), reducing cost and improving log lifecycle management.

All changes are strictly limited to Terraform CloudWatch Log Group resources and do not affect application logic or runtime behavior.

This change is based on findings from **InfraScan analysis** (see PR: https://github.com/CMSgov/beneficiary-fhir-data/pull/3196), which identified missing retention policies as a cost optimization issue.

---

## What Should Reviewers Watch For?

- Ensure every `aws_cloudwatch_log_group` now includes `retention_in_days`
- Confirm no changes were made outside Terraform log group resources
- Verify no modifications to GitHub Actions, CI/CD, or InfraScan workflow
- Validate minimal and consistent diff across modules

---

## What Security Implications Does This PR Have?

- No new dependencies added
- No changes to application runtime security
- Improves operational hygiene by enforcing log retention policies
- Reduces risk of uncontrolled log data accumulation

✔ I have considered the above security implications and ensured no additional risk is introduced.