### PR TITLE
BFD-4841: Improve IDR Pipeline error handling

### DIFF
--- a/apps/bfd-pipeline-idr/pyproject.toml
+++ b/apps/bfd-pipeline-idr/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "click>=8.3.3",
     "anyio",
     "loguru",
+    "tblib>=3.2.2",
 ]
 
 [dependency-groups]

--- a/apps/bfd-pipeline-idr/src/idr_pipeline/__init__.py
+++ b/apps/bfd-pipeline-idr/src/idr_pipeline/__init__.py
@@ -126,17 +126,13 @@ def run(source: Source, load_mode: LoadMode, load_type: LoadType) -> None:
 
     async def run_worker_and_stages() -> None:
         stop_worker = anyio.Event()
-        try:
-            async with anyio.create_task_group() as tg:
-                await tg.start(worker_manager.start, stop_worker)
-                # We don't submit staged_pipeline.start to the task group because we want to set the
-                # stop signal for the background worker once it's complete. If we don't do it this
-                # way the pipeline process will run forever
-                await staged_pipeline.start()
-                stop_worker.set()
-        except* Exception as ex_group:
-            for ex in ex_group.exceptions:
-                raise ex from ex.__cause__
+        async with anyio.create_task_group() as tg:
+            await tg.start(worker_manager.start, stop_worker)
+            # We don't submit staged_pipeline.start to the task group because we want to set the
+            # stop signal for the background worker once it's complete. If we don't do it this
+            # way the pipeline process will run forever
+            await staged_pipeline.start()
+            stop_worker.set()
 
     try:
         anyio.run(run_worker_and_stages)

--- a/apps/bfd-pipeline-idr/src/idr_pipeline/__init__.py
+++ b/apps/bfd-pipeline-idr/src/idr_pipeline/__init__.py
@@ -1,5 +1,6 @@
 import atexit
 import multiprocessing
+import sys
 from datetime import UTC, datetime
 
 import anyio
@@ -149,6 +150,7 @@ def run(source: Source, load_mode: LoadMode, load_type: LoadType) -> None:
                 failure_time=resolve_test_date(load_mode),
             )
         logger.opt(exception=True).error("Unrecoverable exception raised during pipeline load:")
+        sys.exit(1)
     finally:
         if idr_job_events:
             update_completion_times(

--- a/apps/bfd-pipeline-idr/src/idr_pipeline/__init__.py
+++ b/apps/bfd-pipeline-idr/src/idr_pipeline/__init__.py
@@ -126,13 +126,17 @@ def run(source: Source, load_mode: LoadMode, load_type: LoadType) -> None:
 
     async def run_worker_and_stages() -> None:
         stop_worker = anyio.Event()
-        async with anyio.create_task_group() as tg:
-            await tg.start(worker_manager.start, stop_worker)
-            # We don't submit staged_pipeline.start to the task group because we want to set the
-            # stop signal for the background worker once it's complete. If we don't do it this way
-            # the pipeline process will run forever
-            await staged_pipeline.start()
-            stop_worker.set()
+        try:
+            async with anyio.create_task_group() as tg:
+                await tg.start(worker_manager.start, stop_worker)
+                # We don't submit staged_pipeline.start to the task group because we want to set the
+                # stop signal for the background worker once it's complete. If we don't do it this
+                # way the pipeline process will run forever
+                await staged_pipeline.start()
+                stop_worker.set()
+        except* Exception as ex_group:
+            for ex in ex_group.exceptions:
+                raise ex from ex.__cause__
 
     try:
         anyio.run(run_worker_and_stages)
@@ -149,7 +153,6 @@ def run(source: Source, load_mode: LoadMode, load_type: LoadType) -> None:
                 failure_time=resolve_test_date(load_mode),
             )
         logger.opt(exception=True).error("Unrecoverable exception raised during pipeline load:")
-        raise
     finally:
         if idr_job_events:
             update_completion_times(

--- a/apps/bfd-pipeline-idr/src/idr_pipeline/__init__.py
+++ b/apps/bfd-pipeline-idr/src/idr_pipeline/__init__.py
@@ -129,8 +129,8 @@ def run(source: Source, load_mode: LoadMode, load_type: LoadType) -> None:
         async with anyio.create_task_group() as tg:
             await tg.start(worker_manager.start, stop_worker)
             # We don't submit staged_pipeline.start to the task group because we want to set the
-            # stop signal for the background worker once it's complete. If we don't do it this
-            # way the pipeline process will run forever
+            # stop signal for the background worker once it's complete. If we don't do it this way
+            # the pipeline process will run forever
             await staged_pipeline.start()
             stop_worker.set()
 

--- a/apps/bfd-pipeline-idr/src/idr_pipeline/batch_worker.py
+++ b/apps/bfd-pipeline-idr/src/idr_pipeline/batch_worker.py
@@ -553,7 +553,7 @@ class LoadingBatchWorkerManager:
         try:
             async with anyio.create_task_group() as tg:
                 tg.start_soon(watch_queue)
-        except* Exception:
+        except BaseException:
             cancel_signal.set()
             raise
 

--- a/apps/bfd-pipeline-idr/src/idr_pipeline/batch_worker.py
+++ b/apps/bfd-pipeline-idr/src/idr_pipeline/batch_worker.py
@@ -3,6 +3,7 @@ import os
 import random
 import signal
 import string
+import sys
 import threading
 import uuid
 from collections import Counter, OrderedDict
@@ -13,6 +14,7 @@ from itertools import batched
 from math import ceil
 from multiprocessing import Manager, Process
 from multiprocessing.managers import SyncManager
+from pathlib import Path
 from queue import Empty, Queue
 from threading import Event
 from types import FrameType
@@ -28,6 +30,11 @@ from psycopg import sql
 from psycopg.errors import DeadlockDetected, InFailedSqlTransaction
 from psycopg_pool.abc import ACT
 
+from .exception_utils import (
+    SerializedExceptionChain,
+    rebuild_exception_chain,
+    serialize_exception_chain,
+)  # type: ignore
 from .load_partition import LoadPartition
 from .model.base_model import DbType, IdrBaseModel
 from .model.load_progress import LoadProgress
@@ -183,7 +190,7 @@ class _LoadingBatchWorker(Process):
     def __init__(
         self,
         task_queue: Queue[_TaskSequence],
-        errors_queue: Queue[BaseException],
+        errors_queue: Queue[SerializedExceptionChain],
         started_signal: Event,
         cancel_signal: Event,
         root_logger: Logger,
@@ -200,24 +207,31 @@ class _LoadingBatchWorker(Process):
         self._running_tasks: set[_Task] = set()
 
     def run(self) -> None:
-        self._logger.reinstall()
+        sys.unraisablehook = lambda _: None
+        sys.excepthook = lambda _, __, ___: None
+        with Path(os.devnull).open("w") as devnull:
+            sys.stderr = devnull
 
-        def _watch_for_parent_cancel(stop_signal: Event) -> None:
-            stop_signal.wait()
-            os.kill(os.getpid(), signal.SIGUSR1)
+            self._logger.reinstall()
 
-        def sigusr1_handler(signum: int, frame: FrameType | None) -> Never:  # noqa: ARG001
-            raise ExternallyCanceled("Externally canceled, interrupting")
+            def _watch_for_parent_cancel(stop_signal: Event) -> None:
+                stop_signal.wait()
+                os.kill(os.getpid(), signal.SIGUSR1)
 
-        signal.signal(signal.SIGUSR1, sigusr1_handler)
-        threading.Thread(
-            target=lambda: _watch_for_parent_cancel(self._cancel_signal), daemon=True
-        ).start()
+            def sigusr1_handler(signum: int, frame: FrameType | None) -> Never:  # noqa: ARG001
+                raise ExternallyCanceled("Externally canceled, interrupting")
 
-        try:
-            anyio.run(self._worker_main)
-        except BaseException as ex:
-            self.errors_queue.put(ex)
+            signal.signal(signal.SIGUSR1, sigusr1_handler)
+            threading.Thread(
+                target=lambda: _watch_for_parent_cancel(self._cancel_signal), daemon=True
+            ).start()
+
+            try:
+                anyio.run(self._worker_main)
+            except ExternallyCanceled:
+                pass
+            except BaseException as ex:
+                self.errors_queue.put(serialize_exception_chain(ex))
 
     async def _worker_main(self) -> None:
         task_send, task_receive = anyio.create_memory_object_stream[_TaskSequence](
@@ -508,7 +522,7 @@ class LoadingBatchWorkerManager:
             return
 
         self._started_signal.clear()
-        errors_queue: Queue[BaseException] = self._manager.Queue()
+        errors_queue: Queue[SerializedExceptionChain] = self._manager.Queue()
         cancel_signal = self._manager.Event()
 
         self._worker = _LoadingBatchWorker(
@@ -532,17 +546,16 @@ class LoadingBatchWorkerManager:
         async def watch_queue() -> None:
             while not stop.is_set():
                 with contextlib.suppress(Empty):
-                    errors = errors_queue.get_nowait()
-                    raise errors
+                    raise rebuild_exception_chain(errors_queue.get_nowait())
 
                 await anyio.sleep(0.01)
 
-        async with anyio.create_task_group() as tg:
-            try:
+        try:
+            async with anyio.create_task_group() as tg:
                 tg.start_soon(watch_queue)
-            except BaseException:
-                cancel_signal.set()
-                raise
+        except* Exception:
+            cancel_signal.set()
+            raise
 
     def cleanup(self, timeout: float = 5.0) -> None:
         if self._worker is None:

--- a/apps/bfd-pipeline-idr/src/idr_pipeline/batch_worker.py
+++ b/apps/bfd-pipeline-idr/src/idr_pipeline/batch_worker.py
@@ -34,7 +34,7 @@ from .exception_utils import (
     SerializedExceptionChain,
     rebuild_exception_chain,
     serialize_exception_chain,
-)  # type: ignore
+)
 from .load_partition import LoadPartition
 from .model.base_model import DbType, IdrBaseModel
 from .model.load_progress import LoadProgress

--- a/apps/bfd-pipeline-idr/src/idr_pipeline/batch_worker.py
+++ b/apps/bfd-pipeline-idr/src/idr_pipeline/batch_worker.py
@@ -535,10 +535,12 @@ class LoadingBatchWorkerManager:
         )
         self._worker.start()
 
-        # Block until the worker signals it has started
-        self._started_signal.wait()
-
-        logger.info("LoadingBatchWorker signaled startup")
+        # Block until the worker signals it has started, or 10 seconds have passed
+        self._started_signal.wait(10)
+        if self._started_signal.is_set():
+            logger.info("LoadingBatchWorker signaled startup")
+        else:
+            logger.error("LoadingBatchWorker start signal never set. See exception for detail")
 
         if task_status:
             task_status.started()

--- a/apps/bfd-pipeline-idr/src/idr_pipeline/batch_worker.py
+++ b/apps/bfd-pipeline-idr/src/idr_pipeline/batch_worker.py
@@ -207,6 +207,9 @@ class _LoadingBatchWorker(Process):
         self._running_tasks: set[_Task] = set()
 
     def run(self) -> None:
+        # The next four lines suppress unhandled/unraised Exception output to prevent noise when
+        # the ExternallyCanceled signal is used to stop this worker. Without this, Python's default
+        # behavior prints the full trace and Exception context to stderr, cluttering the logs.
         sys.unraisablehook = lambda _: None
         sys.excepthook = lambda _, __, ___: None
         with Path(os.devnull).open("w") as devnull:

--- a/apps/bfd-pipeline-idr/src/idr_pipeline/exception_utils.py
+++ b/apps/bfd-pipeline-idr/src/idr_pipeline/exception_utils.py
@@ -1,0 +1,86 @@
+from dataclasses import dataclass
+from types import TracebackType
+from typing import Any, cast
+
+from tblib import Traceback  # type: ignore
+
+type SerializedExceptionChain = list[SerializedException | SerializedExceptionGroup]
+
+
+@dataclass(frozen=True, eq=True)
+class SerializedException:
+    ex: BaseException
+    tb_dict: dict[str, Any]
+
+
+@dataclass(frozen=True, eq=True)
+class SerializedExceptionGroup:
+    ex_group: BaseExceptionGroup[Exception] | ExceptionGroup[Exception]
+    tb_dict: dict[str, Any]
+    exceptions: list[SerializedException]
+
+
+def get_exception_tb_dict(ex: BaseException) -> dict[str, Any]:
+    return Traceback(ex.__traceback__).as_dict()  # type: ignore
+
+
+def get_traceback_from_dict(tb_dict: dict[str, Any]) -> TracebackType | None:
+    return cast(Traceback, Traceback.from_dict(tb_dict)).as_traceback()  # type: ignore
+
+
+def serialize_exception_chain(exc: BaseException) -> SerializedExceptionChain:
+    chain: list[SerializedException | SerializedExceptionGroup] = []
+    current: BaseException | None = exc
+
+    while current is not None:
+        if isinstance(current, BaseExceptionGroup | ExceptionGroup):
+            current = cast(BaseExceptionGroup[Exception], current)
+            serialized_inner: list[SerializedException] = [
+                SerializedException(ex=inner, tb_dict=get_exception_tb_dict(inner))
+                for inner in current.exceptions
+            ]
+            chain.append(
+                SerializedExceptionGroup(
+                    ex_group=current,
+                    tb_dict=get_exception_tb_dict(current),
+                    exceptions=serialized_inner,
+                )
+            )
+        else:
+            chain.append(SerializedException(ex=current, tb_dict=get_exception_tb_dict(current)))
+
+        current = current.__cause__
+
+    return chain
+
+
+def rebuild_exception_chain(chain: SerializedExceptionChain) -> BaseException:
+    if not chain:
+        raise ValueError("Chain must contain at least one exception")
+
+    # Materialise each entry into a (BaseException, tb_dict) pair so the
+    # linking loop below stays uniform.
+    resolved: list[tuple[BaseException, dict[str, Any]]] = []
+
+    for entry in chain:
+        if isinstance(entry, SerializedExceptionGroup):
+            # Restore tracebacks on every inner exception.
+            restored_inners: list[Exception] = []
+            for serialized_inner in entry.exceptions:
+                inner_exc = serialized_inner.ex
+                inner_exc.__traceback__ = get_traceback_from_dict(serialized_inner.tb_dict)
+                restored_inners.append(inner_exc)  # type: ignore[arg-type]
+
+            # Re-create the group with the restored inner exceptions so that
+            # the group's own .exceptions tuple reflects the restored state.
+            restored_group = entry.ex_group.derive(restored_inners)
+            resolved.append((restored_group, entry.tb_dict))
+        else:
+            resolved.append((entry.ex, entry.tb_dict))
+
+    # Re-link the chain (cause → effect) and restore top-level tracebacks.
+    for i, (exc, tb_dict) in enumerate(resolved):
+        exc.__traceback__ = get_traceback_from_dict(tb_dict)
+        exc.__cause__ = resolved[i + 1][0] if i < len(resolved) - 1 else None
+
+    return resolved[0][0]

--- a/apps/bfd-pipeline-idr/src/idr_pipeline/exception_utils.py
+++ b/apps/bfd-pipeline-idr/src/idr_pipeline/exception_utils.py
@@ -58,18 +58,15 @@ def rebuild_exception_chain(chain: SerializedExceptionChain) -> BaseException:
     if not chain:
         raise ValueError("Chain must contain at least one exception")
 
-    # Materialise each entry into a (BaseException, tb_dict) pair so the
-    # linking loop below stays uniform.
     resolved: list[tuple[BaseException, dict[str, Any]]] = []
-
     for entry in chain:
         if isinstance(entry, SerializedExceptionGroup):
             # Restore tracebacks on every inner exception.
-            restored_inners: list[Exception] = []
+            restored_inners: list[BaseException] = []
             for serialized_inner in entry.exceptions:
                 inner_exc = serialized_inner.ex
                 inner_exc.__traceback__ = get_traceback_from_dict(serialized_inner.tb_dict)
-                restored_inners.append(inner_exc)  # type: ignore[arg-type]
+                restored_inners.append(inner_exc)
 
             # Re-create the group with the restored inner exceptions so that
             # the group's own .exceptions tuple reflects the restored state.
@@ -78,7 +75,8 @@ def rebuild_exception_chain(chain: SerializedExceptionChain) -> BaseException:
         else:
             resolved.append((entry.ex, entry.tb_dict))
 
-    # Re-link the chain (cause → effect) and restore top-level tracebacks.
+    # Re-create the "exception chain" (of __cause__s) and restore top-level (non-inner Exception)
+    # tracebacks
     for i, (exc, tb_dict) in enumerate(resolved):
         exc.__traceback__ = get_traceback_from_dict(tb_dict)
         exc.__cause__ = resolved[i + 1][0] if i < len(resolved) - 1 else None

--- a/apps/bfd-pipeline-idr/src/idr_pipeline/loader.py
+++ b/apps/bfd-pipeline-idr/src/idr_pipeline/loader.py
@@ -216,21 +216,26 @@ class BatchLoader:
             ) -> None:
                 updated_rows.extend(await load_func())
 
-            async with anyio.create_task_group() as tg:
-                for idx, chunk in enumerate(
-                    itertools.batched(results, PER_BATCH_CONCURRENT_ROWS, strict=False)
-                ):
+            try:
+                async with anyio.create_task_group() as tg:
+                    for idx, chunk in enumerate(
+                        itertools.batched(results, PER_BATCH_CONCURRENT_ROWS, strict=False)
+                    ):
 
-                    async def _wrap_batch_chunk(
-                        idx: int = idx, chunk: Sequence[T] = chunk
-                    ) -> list[dict[str, DbType]]:
-                        return await self._load_batch_chunk(idx, chunk, timestamp)
+                        async def _wrap_batch_chunk(
+                            idx: int = idx, chunk: Sequence[T] = chunk
+                        ) -> list[dict[str, DbType]]:
+                            return await self._load_batch_chunk(idx, chunk, timestamp)
 
-                    tg.start_soon(
-                        _store_updated_keys,
-                        _wrap_batch_chunk,
-                        name=f"{self.table}-{self.partition.name}-{idx}",
-                    )
+                        tg.start_soon(
+                            _store_updated_keys,
+                            _wrap_batch_chunk,
+                            name=f"{self.table}-{self.partition.name}-{idx}",
+                        )
+            except* Exception as ex_group:
+                for ex in ex_group.exceptions:
+                    raise ex from None
+
             self.insert_batch_timer.stop()
             logger.info(
                 "{}-{}-{}: upserted {} new/changed row(s) out of {}",

--- a/apps/bfd-pipeline-idr/src/idr_pipeline/loader.py
+++ b/apps/bfd-pipeline-idr/src/idr_pipeline/loader.py
@@ -216,25 +216,21 @@ class BatchLoader:
             ) -> None:
                 updated_rows.extend(await load_func())
 
-            try:
-                async with anyio.create_task_group() as tg:
-                    for idx, chunk in enumerate(
-                        itertools.batched(results, PER_BATCH_CONCURRENT_ROWS, strict=False)
-                    ):
+            async with anyio.create_task_group() as tg:
+                for idx, chunk in enumerate(
+                    itertools.batched(results, PER_BATCH_CONCURRENT_ROWS, strict=False)
+                ):
 
-                        async def _wrap_batch_chunk(
-                            idx: int = idx, chunk: Sequence[T] = chunk
-                        ) -> list[dict[str, DbType]]:
-                            return await self._load_batch_chunk(idx, chunk, timestamp)
+                    async def _wrap_batch_chunk(
+                        idx: int = idx, chunk: Sequence[T] = chunk
+                    ) -> list[dict[str, DbType]]:
+                        return await self._load_batch_chunk(idx, chunk, timestamp)
 
-                        tg.start_soon(
-                            _store_updated_keys,
-                            _wrap_batch_chunk,
-                            name=f"{self.table}-{self.partition.name}-{idx}",
-                        )
-            except* Exception as ex_group:
-                for ex in ex_group.exceptions:
-                    raise ex from None
+                    tg.start_soon(
+                        _store_updated_keys,
+                        _wrap_batch_chunk,
+                        name=f"{self.table}-{self.partition.name}-{idx}",
+                    )
 
             self.insert_batch_timer.stop()
             logger.info(

--- a/apps/bfd-pipeline-idr/src/idr_pipeline/loader.py
+++ b/apps/bfd-pipeline-idr/src/idr_pipeline/loader.py
@@ -231,7 +231,6 @@ class BatchLoader:
                         _wrap_batch_chunk,
                         name=f"{self.table}-{self.partition.name}-{idx}",
                     )
-
             self.insert_batch_timer.stop()
             logger.info(
                 "{}-{}-{}: upserted {} new/changed row(s) out of {}",

--- a/apps/bfd-pipeline-idr/src/idr_pipeline/parallel_executor.py
+++ b/apps/bfd-pipeline-idr/src/idr_pipeline/parallel_executor.py
@@ -1,10 +1,12 @@
 import contextlib
 import os
 import signal
+import sys
 import threading
 from collections.abc import Callable, Generator
 from concurrent.futures import Future, ProcessPoolExecutor
 from multiprocessing import Manager
+from pathlib import Path
 from queue import Empty, Queue
 from threading import Event
 from types import FrameType
@@ -12,6 +14,12 @@ from typing import Never
 
 import anyio
 from loguru import logger
+
+from .exception_utils import (
+    SerializedExceptionChain,
+    rebuild_exception_chain,
+    serialize_exception_chain,
+)
 
 type StageTask[T] = Callable[[], T]
 type Stage[T] = Generator[StageTask[T]]
@@ -30,40 +38,47 @@ class ParallelStagesExecutor:
     def _wrap[T](
         task: StageTask[T],
         index: int,
-        errors_queue: Queue[BaseException],
+        errors_queue: Queue[SerializedExceptionChain],
         cancel_signal: Event,
     ) -> tuple[int, T | None]:
+        sys.unraisablehook = lambda _: None
+        sys.excepthook = lambda _, __, ___: None
+        with Path(os.devnull).open("w") as devnull:
+            sys.stderr = devnull
 
-        def _watch_for_parent_cancel(cancel_signal: Event) -> None:
-            cancel_signal.wait()
-            os.kill(os.getpid(), signal.SIGUSR1)
+            def _watch_for_parent_cancel(cancel_signal: Event) -> None:
+                cancel_signal.wait()
+                os.kill(os.getpid(), signal.SIGUSR1)
 
-        def sigusr1_handler(signum: int, frame: FrameType | None) -> Never:  # noqa: ARG001
-            raise ExternallyCanceled("Externally canceled, interrupting")
+            def sigusr1_handler(signum: int, frame: FrameType | None) -> Never:  # noqa: ARG001
+                raise ExternallyCanceled("Externally canceled, interrupting")
 
-        signal.signal(signal.SIGUSR1, sigusr1_handler)
-        threading.Thread(
-            target=lambda: _watch_for_parent_cancel(cancel_signal), daemon=True
-        ).start()
+            signal.signal(signal.SIGUSR1, sigusr1_handler)
+            threading.Thread(
+                target=lambda: _watch_for_parent_cancel(cancel_signal), daemon=True
+            ).start()
 
-        try:
-            return (index, task())
-        except BaseException as e:
-            errors_queue.put(e)
+            try:
+                return (index, task())
+            except ExternallyCanceled:
+                pass
+            except BaseException as ex:
+                errors_queue.put(serialize_exception_chain(ex))
+
             return (index, None)
 
     async def _run_stage[T](
         self,
         stage: Stage[T],
-        errors_queue: Queue[BaseException],
+        errors_queue: Queue[SerializedExceptionChain],
         pool: ProcessPoolExecutor,
         results: dict[int, T | None],
     ) -> None:
         done = anyio.Event()
 
         cancel_signal = self._manager.Event()
-        async with anyio.create_task_group() as tg:
-            try:
+        try:
+            async with anyio.create_task_group() as tg:
                 tg.start_soon(self._poll_errors, errors_queue, done)
 
                 async with anyio.create_task_group() as tg2:
@@ -77,16 +92,12 @@ class ParallelStagesExecutor:
                         tg2.start_soon(_task)
 
                 done.set()
-            except BaseException:
-                cancel_signal.set()
-                raise
-
-        # Final drain in case an error landed after tasks completed
-        if not errors_queue.empty():
-            raise errors_queue.get()
+        except BaseException:
+            cancel_signal.set()
+            raise
 
     async def execute[T](self, stages: list[Stage[T]]) -> list[list[T | None]]:
-        errors_queue: Queue[BaseException] = self._manager.Queue()
+        errors_queue: Queue[SerializedExceptionChain] = self._manager.Queue()
         all_results: list[list[T | None]] = []
 
         with ProcessPoolExecutor(
@@ -100,10 +111,13 @@ class ParallelStagesExecutor:
         return all_results
 
     @staticmethod
-    async def _poll_errors(errors_queue: Queue[BaseException], done: anyio.Event) -> None:
+    async def _poll_errors(
+        errors_queue: Queue[SerializedExceptionChain], done: anyio.Event
+    ) -> None:
         while not done.is_set():
             with contextlib.suppress(Empty):
-                raise errors_queue.get_nowait()
+                raise rebuild_exception_chain(errors_queue.get_nowait())
+
             await anyio.sleep(0.01)
 
     @staticmethod

--- a/apps/bfd-pipeline-idr/src/idr_pipeline/parallel_executor.py
+++ b/apps/bfd-pipeline-idr/src/idr_pipeline/parallel_executor.py
@@ -41,6 +41,9 @@ class ParallelStagesExecutor:
         errors_queue: Queue[SerializedExceptionChain],
         cancel_signal: Event,
     ) -> tuple[int, T | None]:
+        # The next four lines suppress unhandled/unraised Exception output to prevent noise when
+        # the ExternallyCanceled signal is used to stop this worker. Without this, Python's default
+        # behavior prints the full trace and Exception context to stderr, cluttering the logs.
         sys.unraisablehook = lambda _: None
         sys.excepthook = lambda _, __, ___: None
         with Path(os.devnull).open("w") as devnull:

--- a/apps/bfd-pipeline-idr/src/idr_pipeline/pipeline_utils.py
+++ b/apps/bfd-pipeline-idr/src/idr_pipeline/pipeline_utils.py
@@ -34,6 +34,10 @@ from .model.load_progress import LoadProgress
 from .settings import BENEFICIARY_PART_D_PRUNE_BATCH_LIMIT, BENEFICIARY_PRUNE_BATCH_LIMIT
 
 
+class ModelExtractError(Exception):
+    pass
+
+
 def get_progress(
     load_mode: LoadMode,
     source: Source,
@@ -124,8 +128,7 @@ def extract_and_load(
                 raise ex
             time.sleep(1)
         except Exception as ex:
-            logger.opt(exception=True).error("error loading {}", cls.table())
-            raise ex
+            raise ModelExtractError(f"error loading {cls.table()}-{partition.name}") from ex
 
 
 def prune_phase_1_ss_claims(

--- a/apps/bfd-pipeline-idr/uv.lock
+++ b/apps/bfd-pipeline-idr/uv.lock
@@ -273,6 +273,7 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "snowflake-connector-python" },
     { name = "snowflake-snowpark-python" },
+    { name = "tblib" },
     { name = "unidecode" },
     { name = "usaddress" },
 ]
@@ -297,6 +298,7 @@ requires-dist = [
     { name = "python-dateutil", specifier = ">=2.9.0" },
     { name = "snowflake-connector-python", specifier = ">=4.4.0" },
     { name = "snowflake-snowpark-python", specifier = ">=1.50.0" },
+    { name = "tblib", specifier = ">=3.2.2" },
     { name = "unidecode", specifier = ">=1.4.0" },
     { name = "usaddress", specifier = ">=0.5.16" },
 ]
@@ -791,6 +793,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "tblib"
+version = "3.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/8a/14c15ae154895cc131174f858c707790d416c444fc69f93918adfd8c4c0b/tblib-3.2.2.tar.gz", hash = "sha256:e9a652692d91bf4f743d4a15bc174c0b76afc750fe8c7b6d195cc1c1d6d2ccec", size = 35046, upload-time = "2025-11-12T12:21:16.572Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/be/5d2d47b1fb58943194fb59dcf222f7c4e35122ec0ffe8c36e18b5d728f0b/tblib-3.2.2-py3-none-any.whl", hash = "sha256:26bdccf339bcce6a88b2b5432c988b266ebbe63a4e593f6b578b1d2e723d2b76", size = 12893, upload-time = "2025-11-12T12:21:14.407Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
BFD-4841


### What Does This PR Do?
<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

This PR fixes a variety of issues with the way the IDR Pipeline manages _unhandled `Exception`s_ between background/subprocess workers (e.g. `LoadingBatchWorker` or any of the `ParallelStageExecutor` jobs). 

The most notable improvements are:

- _All_ `Exception`s retain their full context and stack trace regardless of which process they were `raise`d in allowing us to more easily see where an unhandled error occurred
   - This may seem strange as why _wouldn't_ an `Exception` not have all of its context? This occurred because `Exception` "tracebacks" (a.k.a stack traces) are not preserved when an `Exception` is "pickled" (serialized) across processes. We now do this serialization manually using `tblib`, so all context is preserved
- Extraneous noise caused when sibling processes are forcibly stopped by `raise`ing `Exception`s in a signal handler  has been suppressed making it much easier to see the _real_ `Exception` in the logs
- `Exception`s `raise`d  when extracting/loading a table/`BaseModel`-derived model are now wrapped by a custom `Exception` that is explicit about _which_ table failed to load

Altogether, the error handling is significantly improved and we should be able to determine the cause of issues much more easily.

### What Should Reviewers Watch For?
<!--
Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items here -->

- See above

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:  

* Adds any new software dependencies
   * Yes,  `tblib`. I will not merge until @sb-benohe approves.
* ~~Modifies any security controls~~
* ~~Adds new transmission or storage of data~~
* ~~Any other changes that could possibly affect security?~~

* [x] I have considered the above security implications as it relates to this PR. (If one or more of the above apply, it cannot be merged without the ISSO or team security engineer's (`@sb-benohe`) approval.) 
* [x] I have created tests to sufficiently ensure the reliability of my code, if applicable. If this is a modification to an existing piece of code, I have audited the associated tests to ensure everything works as expected.

### Validation

**Have you fully verified and tested these changes? Is the acceptance criteria met? Please provide reproducible testing instructions, code snippets, or screenshots as applicable.**
    
- `raise`ing various `Exception`s in multiple different parts of the IDR Pipeline that run in subprocesses, _validating that_:
   - The full stack trace and `Exception` context is logged upon exit
   - No extraneous noise from the subprocess stopping is logged
   - The IDR Pipeline exits completely and near-immediately, as expected