### PR TITLE
BFD-4843: Add v3 export to json

### DIFF
--- a/apps/bfd-model-idr/gen_dd.py
+++ b/apps/bfd-model-idr/gen_dd.py
@@ -202,6 +202,9 @@ export_columns = [
     "profiles",
 ]
 export_df = dd_df[export_columns]
+
+export_df.to_json("out/bfd_data_dictionary.json", orient="records", indent=2)
+
 tips_df = pd.read_csv(dd_support_folder + "/tips.csv")
 
 with pd.ExcelWriter("out/bfd_data_dictionary.xlsx", engine="xlsxwriter") as writer:


### PR DESCRIPTION
**JIRA Ticket:**
[BFD-4843](https://jira.cms.gov/browse/BFD-4843)


### What Does This PR Do?
Exports v3 data-dictionary as a json during release

### What Should Reviewers Watch For?

- JSON should be as accurate as CSV
- Is there a preference that empty values be generated as `""` or `null`? Currently, they're `""`, per: https://github.com/CMSgov/beneficiary-fhir-data/blob/5ced4823080e02e05749457b6f5213d566ce7ee3/apps/bfd-model-idr/gen_dd.py#L158-L162

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:  

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security? 

* [ ] I have considered the above security implications as it relates to this PR. (If one or more of the above apply, it cannot be merged without the ISSO or team security engineer's (`@sb-benohe`) approval.) 
* [ ] I have created tests to sufficiently ensure the reliability of my code, if applicable. If this is a modification to an existing piece of code, I have audited the associated tests to ensure everything works as expected.

### Validation

**Have you fully verified and tested these changes? Is the acceptance criteria met? Please provide reproducible testing instructions, code snippets, or screenshots as applicable.**
    
Run`uv run gen_dd.py`, review `bfd_data_dictionary.json`

```json
[
  {
    "Field Name":"Beneficiary First Name",
    "Description":"A first name for a Medicare beneficiary.",
    "FHIR Resource":"Patient",
    "Coverage \/ Claim Type":null,
    "fhirPath":"Patient.name.given[0]",
    "example":"Frankie",
    "notes":null,
    "sourceView":"V2_MDCR_BENE_HSTRY",
    "sourceColumn":"BENE_1ST_NAME",
    "bfdDerived":null,
    "sources":null,
    "referenceTable":null,
    "cclfMapping":[
      "CCLF8.BENE_1ST_NAME"
    ],
    "ccwMapping":[
      "BENE_GVN_NAME"
    ],
    "profiles":null
  },
...
]
```
