### PR TITLE
BFD-4850: Exclude synthetic data from prunes

### DIFF
--- a/apps/bfd-pipeline-idr/src/idr_pipeline/model/base_model.py
+++ b/apps/bfd-pipeline-idr/src/idr_pipeline/model/base_model.py
@@ -855,6 +855,7 @@ def stale_phase_1_claims_query(
                 SELECT clm.clm_uniq_id 
                 FROM {header_table} clm
                 WHERE clm.clm_type_cd BETWEEN {PHASE_1_SS_MIN} AND {PHASE_1_SS_MAX}
+                AND clm.clm_uniq_id > 0
                 AND clm.clm_src_id IN ('{FISS_CLM_SOURCE}', '{MCS_CLM_SOURCE}', '{VMS_CLM_SOURCE}')
                 AND clm.bfd_updated_ts < %s
                 ORDER BY clm.bfd_updated_ts, clm.clm_uniq_id


### PR DESCRIPTION
**JIRA Ticket:**
BFD-4850


### What Does This PR Do?
This PR excludes synthetic data (clm_src_id < 0) from the Phase 1 Shared System prune query. 

### What Should Reviewers Watch For?
A well formed SQL query.

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:  

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security? 

* [x] I have considered the above security implications as it relates to this PR. (If one or more of the above apply, it cannot be merged without the ISSO or team security engineer's (`@sb-benohe`) approval.) 
* [x] I have created tests to sufficiently ensure the reliability of my code, if applicable. If this is a modification to an existing piece of code, I have audited the associated tests to ensure everything works as expected.

### Validation
Tests pass. 